### PR TITLE
[VL] Remove lib boost from DEPENDENCY_DIR instead of the default dir

### DIFF
--- a/ep/build-velox/src/setup-centos7.sh
+++ b/ep/build-velox/src/setup-centos7.sh
@@ -158,7 +158,7 @@ function install_lzo {
 function install_boost {
   # Remove old version.
   sudo rm -f /usr/local/lib/libboost_* /usr/lib64/libboost_* /opt/rh/devtoolset-11/root/usr/lib64/dyninst/libboost_*
-  sudo rm -rf /tmp/velox-deps/boost/ /usr/local/include/boost/ /usr/local/lib/cmake/Boost-1.72.0/
+  sudo rm -rf "${DEPENDENCY_DIR}"/boost/ /usr/local/include/boost/ /usr/local/lib/cmake/Boost-1.72.0/
   cd "${DEPENDENCY_DIR}"
   wget_and_untar https://github.com/boostorg/boost/releases/download/boost-1.84.0/boost-1.84.0.tar.gz boost
   cd boost


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed a typo for boost installation

## How was this patch tested?
