### PR TITLE
[VL] Change to use Velox's wget_and_untar in setup-centos7.sh

### DIFF
--- a/ep/build-velox/src/setup-centos7.sh
+++ b/ep/build-velox/src/setup-centos7.sh
@@ -46,13 +46,6 @@ function yum_install {
   $SUDO yum install -y "$@"
 }
 
-function wget_and_untar {
-  local URL=$1
-  local DIR=$2
-  mkdir -p "${DIR}"
-  wget -q --max-redirect 3 -O - "${URL}" | tar -xz -C "${DIR}" --strip-components=1
-}
-
 function install_cmake {
   cd "${DEPENDENCY_DIR}"
   wget_and_untar https://cmake.org/files/v3.28/cmake-3.28.3.tar.gz cmake-3


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR makes the dependency installation look up the local download source tar tall first.

We can reduce some network issues for developers while they build their own CI or just daily dev.
## How was this patch tested?


tested locally

```
+ set -u
+ '[' -d /tmp/velox-deps ']'
+ run_and_time install_cmake
+ install_cmake
+ cd /tmp/velox-deps
+ wget_and_untar https://cmake.org/files/v3.28/ cmake-3.28.3.tar.gz cmake-3
+ local URL=https://cmake.org/files/v3.28/
+ local BIN=cmake-3.28.3.tar.gz
+ local DIR=cmake-3
+ mkdir -p cmake-3
+ [[ -f cmake-3.28.3.tar.gz ]]
+ tar -tzf cmake-3.28.3.tar.gz
+ echo 'Using cached cmake-3.28.3.tar.gz'
Using cached cmake-3.28.3.tar.gz
+ tar -xzf cmake-3.28.3.tar.gz -C cmake-3 --strip-components=1
+ return 0
```
