### PR TITLE
Add a Shim layer for PartitionedFileUtil of Spark 3.5

### DIFF
--- a/shims/spark35/src/main/scala/org/apache/gluten/execution/PartitionedFileUtilShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/execution/PartitionedFileUtilShim.scala
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.PartitionedFileUtil
+import org.apache.spark.sql.execution.datasources.{FileStatusWithMetadata, PartitionedFile}
+
+import org.apache.hadoop.fs.Path
+
+import java.lang.reflect.Method
+
+object PartitionedFileUtilShim {
+
+  private val clz: Class[_] = PartitionedFileUtil.getClass
+
+  private lazy val getPartitionedFileMethod: Method = {
+    try {
+      val m = clz.getDeclaredMethod(
+        "getPartitionedFile",
+        classOf[FileStatusWithMetadata],
+        classOf[InternalRow])
+      m.setAccessible(true)
+      m
+    } catch {
+      case _: NoSuchMethodException => null
+    }
+  }
+
+  private lazy val getPartitionedFileByPathMethod: Method = {
+    try {
+      val m = clz.getDeclaredMethod(
+        "getPartitionedFile",
+        classOf[FileStatusWithMetadata],
+        classOf[Path],
+        classOf[InternalRow])
+      m.setAccessible(true)
+      m
+    } catch {
+      case _: NoSuchMethodException => null
+    }
+  }
+
+  def getPartitionedFile(
+      file: FileStatusWithMetadata,
+      partitionValues: InternalRow): PartitionedFile = {
+    if (getPartitionedFileMethod != null) {
+      getPartitionedFileMethod
+        .invoke(null, file, partitionValues)
+        .asInstanceOf[PartitionedFile]
+    } else if (getPartitionedFileByPathMethod != null) {
+      getPartitionedFileByPathMethod
+        .invoke(null, file, file.getPath, partitionValues)
+        .asInstanceOf[PartitionedFile]
+    } else {
+      val params = clz.getDeclaredMethods
+        .find(_.getName == "getPartitionedFile")
+        .map(_.getGenericParameterTypes.mkString(", "))
+      throw new RuntimeException(
+        s"getPartitionedFile with $params is not correctly shimmed " +
+          "in PartitionedFileUtilShim")
+    }
+  }
+
+  private lazy val splitFilesMethod: Method = {
+    try {
+      val m = clz.getDeclaredMethod(
+        "splitFiles",
+        classOf[SparkSession],
+        classOf[FileStatusWithMetadata],
+        classOf[Boolean],
+        classOf[Long],
+        classOf[InternalRow])
+      m.setAccessible(true)
+      m
+    } catch {
+      case _: NoSuchMethodException => null
+    }
+  }
+
+  private lazy val splitFilesByPathMethod: Method = {
+    try {
+      val m = clz.getDeclaredMethod(
+        "splitFiles",
+        classOf[FileStatusWithMetadata],
+        classOf[Path],
+        classOf[Boolean],
+        classOf[Long],
+        classOf[InternalRow])
+      m.setAccessible(true)
+      m
+    } catch {
+      case _: NoSuchMethodException => null
+    }
+  }
+
+  def splitFiles(
+      sparkSession: SparkSession,
+      file: FileStatusWithMetadata,
+      isSplitable: Boolean,
+      maxSplitBytes: Long,
+      partitionValues: InternalRow): Seq[PartitionedFile] = {
+    if (splitFilesMethod != null) {
+      splitFilesMethod
+        .invoke(
+          null,
+          sparkSession,
+          file,
+          java.lang.Boolean.valueOf(isSplitable),
+          java.lang.Long.valueOf(maxSplitBytes),
+          partitionValues)
+        .asInstanceOf[Seq[PartitionedFile]]
+    } else if (splitFilesByPathMethod != null) {
+      splitFilesByPathMethod
+        .invoke(
+          null,
+          file,
+          file.getPath,
+          java.lang.Boolean.valueOf(isSplitable),
+          java.lang.Long.valueOf(maxSplitBytes),
+          partitionValues)
+        .asInstanceOf[Seq[PartitionedFile]]
+    } else {
+      val params = clz.getDeclaredMethods
+        .find(_.getName == "splitFiles")
+        .map(_.getGenericParameterTypes.mkString(", "))
+      throw new RuntimeException(
+        s"splitFiles with $params is not correctly shimmed " +
+          "in PartitionedFileUtilShim")
+    }
+  }
+
+}

--- a/shims/spark35/src/main/scala/org/apache/gluten/execution/PartitionedFileUtilShim.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/execution/PartitionedFileUtilShim.scala
@@ -28,6 +28,7 @@ import java.lang.reflect.Method
 object PartitionedFileUtilShim {
 
   private val clz: Class[_] = PartitionedFileUtil.getClass
+  private val module = clz.getField("MODULE$").get(null)
 
   private lazy val getPartitionedFileMethod: Method = {
     try {
@@ -61,11 +62,11 @@ object PartitionedFileUtilShim {
       partitionValues: InternalRow): PartitionedFile = {
     if (getPartitionedFileMethod != null) {
       getPartitionedFileMethod
-        .invoke(null, file, partitionValues)
+        .invoke(module, file, partitionValues)
         .asInstanceOf[PartitionedFile]
     } else if (getPartitionedFileByPathMethod != null) {
       getPartitionedFileByPathMethod
-        .invoke(null, file, file.getPath, partitionValues)
+        .invoke(module, file, file.getPath, partitionValues)
         .asInstanceOf[PartitionedFile]
     } else {
       val params = clz.getDeclaredMethods
@@ -118,7 +119,7 @@ object PartitionedFileUtilShim {
     if (splitFilesMethod != null) {
       splitFilesMethod
         .invoke(
-          null,
+          module,
           sparkSession,
           file,
           java.lang.Boolean.valueOf(isSplitable),
@@ -128,7 +129,7 @@ object PartitionedFileUtilShim {
     } else if (splitFilesByPathMethod != null) {
       splitFilesByPathMethod
         .invoke(
-          null,
+          module,
           file,
           file.getPath,
           java.lang.Boolean.valueOf(isSplitable),

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.sql.shims.spark35
 
+import org.apache.gluten.execution.PartitionedFileUtilShim
 import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 import org.apache.gluten.utils.ExceptionUtils
@@ -164,7 +165,7 @@ class Spark35Shims extends SparkShims {
   override def filesGroupedToBuckets(
       selectedPartitions: Array[PartitionDirectory]): Map[Int, Array[PartitionedFile]] = {
     selectedPartitions
-      .flatMap(p => p.files.map(f => PartitionedFileUtil.getPartitionedFile(f, p.values)))
+      .flatMap(p => p.files.map(f => PartitionedFileUtilShim.getPartitionedFile(f, p.values)))
       .groupBy {
         f =>
           BucketingUtils
@@ -430,7 +431,7 @@ class Spark35Shims extends SparkShims {
       maxSplitBytes: Long,
       partitionValues: InternalRow,
       metadata: Map[String, Any] = Map.empty): Seq[PartitionedFile] = {
-    PartitionedFileUtil.splitFiles(
+    PartitionedFileUtilShim.splitFiles(
       sparkSession,
       FileStatusWithMetadata(file, metadata),
       isSplitable,

--- a/shims/spark35/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
+++ b/shims/spark35/src/main/scala/org/apache/spark/sql/execution/AbstractFileSourceScanExec.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.execution
 
+import org.apache.gluten.execution.PartitionedFileUtilShim
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.{FileSourceOptions, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
@@ -181,7 +183,7 @@ abstract class AbstractFileSourceScanExec(
     logInfo(s"Planning with ${bucketSpec.numBuckets} buckets")
     val filesGroupedToBuckets =
       selectedPartitions
-        .flatMap(p => p.files.map(f => PartitionedFileUtil.getPartitionedFile(f, p.values)))
+        .flatMap(p => p.files.map(f => PartitionedFileUtilShim.getPartitionedFile(f, p.values)))
         .groupBy {
           f =>
             BucketingUtils
@@ -269,7 +271,7 @@ abstract class AbstractFileSourceScanExec(
                   relation.sparkSession,
                   relation.options,
                   file.getPath)
-                PartitionedFileUtil.splitFiles(
+                PartitionedFileUtilShim.splitFiles(
                   sparkSession = relation.sparkSession,
                   file = file,
                   isSplitable = isSplitable,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a Shim layer for PartitionedFileUtil in Spark 3.5 to make it compilable with Spark 3.5.5 or any in-house branches patched with related changes 

## How was this patch tested?
