### PR TITLE
[CORE] Build: Use upstream Wartremover

### DIFF
--- a/backends-clickhouse/src-delta20/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/backends-clickhouse/src-delta20/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -489,7 +489,7 @@ class DeltaLog private (
 
 object DeltaLog extends DeltaLogging {
   // --- modified start
-  @SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+  @SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
   private class DeltaHadoopFsRelation(
       location: FileIndex,
       partitionSchema: StructType,

--- a/backends-clickhouse/src-delta20/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src-delta20/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
@@ -39,7 +39,7 @@ import java.{util => ju}
 
 import scala.collection.JavaConverters._
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class ClickHouseTableV2(
     override val spark: SparkSession,
     override val path: Path,
@@ -111,7 +111,7 @@ class ClickHouseTableV2(
   cacheThis()
 }
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class TempClickHouseTableV2(
     override val spark: SparkSession,
     override val catalogTable: Option[CatalogTable] = None)

--- a/backends-clickhouse/src-delta20/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
+++ b/backends-clickhouse/src-delta20/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
@@ -28,7 +28,7 @@ import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class AddMergeTreeParts(
     val database: String,
     val table: String,

--- a/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -633,7 +633,7 @@ class DeltaLog private(
 object DeltaLog extends DeltaLogging {
 
   // --- modified start
-  @SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+  @SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
   private class DeltaHadoopFsRelation(
       location: FileIndex,
       partitionSchema: StructType,

--- a/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
@@ -39,7 +39,7 @@ import java.{util => ju}
 
 import scala.collection.JavaConverters._
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class ClickHouseTableV2(
     override val spark: SparkSession,
     override val path: Path,
@@ -111,7 +111,7 @@ class ClickHouseTableV2(
   cacheThis()
 }
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class TempClickHouseTableV2(
     override val spark: SparkSession,
     override val catalogTable: Option[CatalogTable] = None)

--- a/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
+++ b/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
@@ -28,7 +28,7 @@ import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class AddMergeTreeParts(
     val database: String,
     val table: String,

--- a/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
+++ b/backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
 import org.apache.spark.sql.delta.{DeltaParquetFileFormat, MergeTreeFileFormat}
 import org.apache.spark.sql.delta.actions.Metadata
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class DeltaMergeTreeFileFormat(metadata: Metadata)
   extends DeltaParquetFileFormat(metadata)
   with MergeTreeFileFormat {

--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -692,7 +692,7 @@ class DeltaLog private(
 }
 
 object DeltaLog extends DeltaLogging {
-  @SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+  @SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
   private class DeltaHadoopFsRelation(
       location: FileIndex,
       partitionSchema: StructType,

--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/catalog/ClickHouseTableV2.scala
@@ -42,7 +42,7 @@ import java.{util => ju}
 
 import scala.collection.JavaConverters._
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class ClickHouseTableV2(
     override val spark: SparkSession,
     override val path: Path,
@@ -106,7 +106,7 @@ class ClickHouseTableV2(
   cacheThis()
 }
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class TempClickHouseTableV2(
     override val spark: SparkSession,
     override val catalogTable: Option[CatalogTable] = None)

--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/metadata/AddFileTags.scala
@@ -28,7 +28,7 @@ import java.util.{List => JList}
 
 import scala.collection.JavaConverters._
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class AddMergeTreeParts(
     val database: String,
     val table: String,

--- a/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
+++ b/backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/execution/datasources/v2/clickhouse/source/DeltaMergeTreeFileFormat.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.v2.clickhouse.source
 import org.apache.spark.sql.delta.{DeltaParquetFileFormat, MergeTreeFileFormat}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class DeltaMergeTreeFileFormat(
     protocol: Protocol,
     metadata: Metadata,

--- a/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/HashPartitioningWrapper.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/shuffle/HashPartitioningWrapper.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 
 // A wrapper for HashPartitioning to remain original hash expressions.
 // Only used by CH backend when shuffle hash expressions contains non-field expression.
-@SuppressWarnings(Array("io.github.zhztheplayer.scalawarts.InheritFromCaseClass"))
+@SuppressWarnings(Array("org.wartremover.contrib.warts.CaseClassInheritance"))
 class HashPartitioningWrapper(
     original: Seq[Expression],
     newExpr: Seq[Expression],

--- a/pom.xml
+++ b/pom.xml
@@ -1547,7 +1547,7 @@
               <dependency>
                 <groupId>org.wartremover</groupId>
                 <artifactId>wartremover-contrib_${scala.binary.version}</artifactId>
-                <version>2.3.3</version>
+                <version>2.3.4</version>
               </dependency>
             </dependencies>
             <recompileMode>${scala.recompile.mode}</recompileMode>

--- a/pom.xml
+++ b/pom.xml
@@ -195,14 +195,14 @@
                   <compilerPlugin>
                     <groupId>org.wartremover</groupId>
                     <artifactId>wartremover_${scala.binary.version}</artifactId>
-                    <version>3.0.6</version>
+                    <version>3.4.0</version>
                   </compilerPlugin>
                 </compilerPlugins>
                 <dependencies>
                   <dependency>
-                    <groupId>io.github.zhztheplayer.scalawarts</groupId>
-                    <artifactId>scalawarts_${scala.binary.version}</artifactId>
-                    <version>0.1.2</version>
+                    <groupId>org.wartremover</groupId>
+                    <artifactId>wartremover-contrib_${scala.binary.version}</artifactId>
+                    <version>2.3.4</version>
                   </dependency>
                 </dependencies>
                 <recompileMode>${scala.recompile.mode}</recompileMode>
@@ -246,7 +246,7 @@
                   <arg>-Wconf:cat=unchecked&amp;msg=outer reference:s</arg>
                   <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
                   <arg>-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s</arg>
-                  <arg>-P:wartremover:traverser:io.github.zhztheplayer.scalawarts.InheritFromCaseClass</arg>
+                  <arg>-P:wartremover:traverser:org.wartremover.contrib.warts.CaseClassInheritance</arg>
                 </args>
               </configuration>
               <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <caffeine.version>2.9.3</caffeine.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scala.version>2.12.17</scala.version>
+    <scala.version>2.12.18</scala.version>
     <scala-xml.version>2.1.0</scala-xml.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <spark.major.version>3</spark.major.version>
@@ -173,7 +173,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly.
         -->
-        <scala.version>2.12.17</scala.version>
+        <scala.version>2.12.18</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
       </properties>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -1540,14 +1540,14 @@
               <compilerPlugin>
                 <groupId>org.wartremover</groupId>
                 <artifactId>wartremover_${scala.binary.version}</artifactId>
-                <version>3.0.6</version>
+                <version>3.4.0</version>
               </compilerPlugin>
             </compilerPlugins>
             <dependencies>
               <dependency>
-                <groupId>io.github.zhztheplayer.scalawarts</groupId>
-                <artifactId>scalawarts_${scala.binary.version}</artifactId>
-                <version>0.1.2</version>
+                <groupId>org.wartremover</groupId>
+                <artifactId>wartremover-contrib_${scala.binary.version}</artifactId>
+                <version>2.3.3</version>
               </dependency>
             </dependencies>
             <recompileMode>${scala.recompile.mode}</recompileMode>
@@ -1557,7 +1557,7 @@
               <arg>-deprecation</arg>
               <arg>-feature</arg>
               <arg>-Wconf:cat=deprecation:wv,any:e</arg>
-              <arg>-P:wartremover:traverser:io.github.zhztheplayer.scalawarts.InheritFromCaseClass</arg>
+              <arg>-P:wartremover:traverser:org.wartremover.contrib.warts.CaseClassInheritance</arg>
             </args>
           </configuration>
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <caffeine.version>2.9.3</caffeine.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.17</scala.version>
     <scala-xml.version>2.1.0</scala-xml.version>
     <javax.servlet.version>3.1.0</javax.servlet.version>
     <spark.major.version>3</spark.major.version>
@@ -173,7 +173,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly.
         -->
-        <scala.version>2.12.15</scala.version>
+        <scala.version>2.12.17</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
       </properties>
     </profile>

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -17,7 +17,7 @@
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <scala.library.version>2.12.17</scala.library.version>
+    <scala.library.version>2.12.18</scala.library.version>
     <spark.version>3.4.4</spark.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spark.major.version>3</spark.major.version>
@@ -150,21 +150,21 @@
       </activation>
       <properties>
         <spark.version>3.2.2</spark.version>
-        <scala.library.version>2.12.15</scala.library.version>
+        <scala.library.version>2.12.18</scala.library.version>
       </properties>
     </profile>
     <profile>
       <id>spark-3.3</id>
       <properties>
         <spark.version>3.3.1</spark.version>
-        <scala.library.version>2.12.15</scala.library.version>
+        <scala.library.version>2.12.18</scala.library.version>
       </properties>
     </profile>
     <profile>
       <id>spark-3.4</id>
       <properties>
         <spark.version>3.4.4</spark.version>
-        <scala.library.version>2.12.17</scala.library.version>
+        <scala.library.version>2.12.18</scala.library.version>
       </properties>
     </profile>
     <profile>

--- a/tools/qualification-tool/pom.xml
+++ b/tools/qualification-tool/pom.xml
@@ -9,7 +9,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.12.17</scala.version>
+    <scala.version>2.12.18</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spec2.version>4.2.0</spec2.version>
     <spotless.version>2.27.2</spotless.version>

--- a/tools/qualification-tool/pom.xml
+++ b/tools/qualification-tool/pom.xml
@@ -9,7 +9,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <encoding>UTF-8</encoding>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.17</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <spec2.version>4.2.0</spec2.version>
     <spotless.version>2.27.2</spotless.version>


### PR DESCRIPTION
We currently rely on Wartremover for case-class inheritance check during Maven build.

Wartremover upstream repo has accepted some PRs of mine so we don't have to rely on my personal repository.

Upstream wart `org.wartremover.contrib.warts.CaseClassInheritance` will replace the previous use of `io.github.zhztheplayer.scalawarts.InheritFromCaseClass`.