### PR TITLE
[GLUTEN-11406][VL] Update global off-heap memory to reuse the execution memory allocation code path

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/memory/arrow/alloc/ManagedAllocationListener.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/memory/arrow/alloc/ManagedAllocationListener.java
@@ -59,6 +59,7 @@ public class ManagedAllocationListener implements AllocationListener, AutoClosea
     }
     long toBeAcquired = requiredBlocks * BLOCK_SIZE;
     long granted = target.borrow(toBeAcquired);
+    assert (granted == toBeAcquired);
     sharedUsage.inc(granted);
   }
 
@@ -77,6 +78,7 @@ public class ManagedAllocationListener implements AllocationListener, AutoClosea
     }
     long toBeReleased = -requiredBlocks * BLOCK_SIZE;
     long freed = target.repay(toBeReleased);
+    assert (freed == toBeReleased);
     sharedUsage.inc(-freed);
   }
 

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargetVisitor.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargetVisitor.java
@@ -19,7 +19,7 @@ package org.apache.gluten.memory.memtarget;
 import org.apache.gluten.memory.memtarget.spark.RegularMemoryConsumer;
 import org.apache.gluten.memory.memtarget.spark.TreeMemoryConsumer;
 
-import org.apache.spark.memory.GlobalOffHeapMemoryTarget;
+import org.apache.spark.memory.GlobalOffHeapStorageMemoryTarget;
 
 public interface MemoryTargetVisitor<T> {
   T visit(OverAcquire overAcquire);
@@ -40,5 +40,5 @@ public interface MemoryTargetVisitor<T> {
 
   T visit(RetryOnOomMemoryTarget retryOnOomMemoryTarget);
 
-  T visit(GlobalOffHeapMemoryTarget globalOffHeapMemoryTarget);
+  T visit(GlobalOffHeapStorageMemoryTarget globalOffHeapStorageMemoryTarget);
 }

--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargets.java
@@ -20,10 +20,13 @@ import org.apache.gluten.config.GlutenCoreConfig;
 import org.apache.gluten.memory.MemoryUsageStatsBuilder;
 import org.apache.gluten.memory.memtarget.spark.TreeMemoryConsumers;
 
+import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.annotation.Experimental;
+import org.apache.spark.memory.MemoryManager;
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.memory.TaskMemoryManager;
+import org.apache.spark.memory.UnifiedMemoryManager;
 import org.apache.spark.task.TaskResources;
 import org.apache.spark.util.SparkResourceUtil;
 import org.slf4j.Logger;
@@ -31,12 +34,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
+import scala.Option;
+
 public final class MemoryTargets {
   private static final Logger LOGGER = LoggerFactory.getLogger(MemoryTargets.class);
-  private static final TaskMemoryManager GLOBAL_TMM =
-      new TaskMemoryManager(
-          SparkEnv.get().memoryManager(),
-          -439277); // Magic number to avoid possible collision with other Spark plugins.
+  private static TaskMemoryManager GLOBAL_TMM = null;
 
   private MemoryTargets() {
     // enclose factory ctor
@@ -63,9 +65,30 @@ public final class MemoryTargets {
     return memoryTarget;
   }
 
+  private static synchronized TaskMemoryManager getGlobalTaskMemoryManager() {
+    if (GLOBAL_TMM != null) {
+      return GLOBAL_TMM;
+    }
+    Option<MemoryManager> mm = SparkResourceUtil.getMemoryManagerOption();
+    if (mm.isEmpty()) {
+      return new TaskMemoryManager(
+          new UnifiedMemoryManager(
+              new SparkConf().set(GlutenCoreConfig.SPARK_OFFHEAP_ENABLED_KEY(), "false"),
+              Runtime.getRuntime().maxMemory(),
+              Runtime.getRuntime().maxMemory() / 2,
+              1),
+          0);
+    }
+    GLOBAL_TMM =
+        new TaskMemoryManager(
+            mm.get(),
+            -439277); // Magic task ID to avoid possible collision with other Spark plugins.
+    return GLOBAL_TMM;
+  }
+
   public static TreeMemoryTarget newGlobalConsumer(
       String name, Spiller spiller, Map<String, MemoryUsageStatsBuilder> virtualChildren) {
-    return newConsumer(GLOBAL_TMM, name, spiller, virtualChildren);
+    return newConsumer(getGlobalTaskMemoryManager(), name, spiller, virtualChildren);
   }
 
   public static TreeMemoryTarget newContextConsumer(

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
@@ -20,8 +20,6 @@ import org.apache.gluten.config.GlutenCoreConfig
 import org.apache.gluten.memory.MemoryUsageStatsBuilder
 import org.apache.gluten.memory.memtarget.{MemoryTarget, MemoryTargets, NoopMemoryTarget, Spillers}
 
-import com.google.common.annotations.VisibleForTesting
-
 import scala.collection.JavaConverters._
 
 /**
@@ -44,18 +42,15 @@ object GlobalOffHeapMemory {
         Map[String, MemoryUsageStatsBuilder]().asJava))
   }
 
-  @VisibleForTesting
   def acquire(numBytes: Long): Unit = {
     // OOM will be handled in MemoryTargets.throwOnOom(...).
     assert(target.borrow(numBytes) == numBytes)
   }
 
-  @VisibleForTesting
   def release(numBytes: Long): Unit = {
     assert(target.repay(numBytes) == numBytes)
   }
 
-  @VisibleForTesting
   def currentBytes(): Long = {
     target.usedBytes()
   }

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemory.scala
@@ -17,7 +17,12 @@
 package org.apache.spark.memory
 
 import org.apache.gluten.config.GlutenCoreConfig
-import org.apache.gluten.memory.memtarget.{MemoryTarget, MemoryTargets, NoopMemoryTarget}
+import org.apache.gluten.memory.MemoryUsageStatsBuilder
+import org.apache.gluten.memory.memtarget.{MemoryTarget, MemoryTargets, NoopMemoryTarget, Spillers}
+
+import com.google.common.annotations.VisibleForTesting
+
+import scala.collection.JavaConverters._
 
 /**
  * API #acuqire is for reserving some global off-heap memory from Spark memory manager. Once
@@ -29,21 +34,28 @@ import org.apache.gluten.memory.memtarget.{MemoryTarget, MemoryTargets, NoopMemo
  * BlockId to be extended by user, TestBlockId is chosen for the storage memory reservations.
  */
 object GlobalOffHeapMemory {
-  val target: MemoryTarget = if (GlutenCoreConfig.get.memoryUntracked) {
+  private val target: MemoryTarget = if (GlutenCoreConfig.get.memoryUntracked) {
     new NoopMemoryTarget()
   } else {
-    MemoryTargets.throwOnOom(MemoryTargets.global())
+    MemoryTargets.throwOnOom(
+      MemoryTargets.newGlobalConsumer(
+        GlobalOffHeapMemory.getClass.getSimpleName,
+        Spillers.NOOP,
+        Map[String, MemoryUsageStatsBuilder]().asJava))
   }
 
+  @VisibleForTesting
   def acquire(numBytes: Long): Unit = {
     // OOM will be handled in MemoryTargets.throwOnOom(...).
     assert(target.borrow(numBytes) == numBytes)
   }
 
+  @VisibleForTesting
   def release(numBytes: Long): Unit = {
     assert(target.repay(numBytes) == numBytes)
   }
 
+  @VisibleForTesting
   def currentBytes(): Long = {
     target.usedBytes()
   }

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
@@ -45,8 +45,7 @@ class GlobalOffHeapStorageMemoryTarget private[memory]
     else MemoryMode.OFF_HEAP
 
   override def borrow(size: Long): Long = {
-    SparkResourceUtil
-      .getMemoryManagerOption
+    SparkResourceUtil.getMemoryManagerOption
       .map {
         mm =>
           val succeeded =
@@ -83,8 +82,7 @@ class GlobalOffHeapStorageMemoryTarget private[memory]
   }
 
   override def repay(size: Long): Long = {
-    SparkResourceUtil
-      .getMemoryManagerOption
+    SparkResourceUtil.getMemoryManagerOption
       .map {
         mm =>
           mm.releaseStorageMemory(size, mode)

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
@@ -17,16 +17,14 @@
 package org.apache.spark.memory
 
 import org.apache.gluten.config.GlutenCoreConfig
-import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.memory.{MemoryUsageRecorder, SimpleMemoryUsageRecorder}
 import org.apache.gluten.memory.memtarget.{KnownNameAndStats, MemoryTarget, MemoryTargetUtil, MemoryTargetVisitor}
 import org.apache.gluten.proto.MemoryUsageStats
 
-import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.storage.BlockId
+import org.apache.spark.util.SparkResourceUtil
 
-import java.lang.reflect.Field
 import java.util.UUID
 
 /**
@@ -46,22 +44,9 @@ class GlobalOffHeapStorageMemoryTarget private[memory]
     if (GlutenCoreConfig.get.dynamicOffHeapSizingEnabled) MemoryMode.ON_HEAP
     else MemoryMode.OFF_HEAP
 
-  private val FIELD_MEMORY_MANAGER: Field = {
-    val f =
-      try {
-        classOf[TaskMemoryManager].getDeclaredField("memoryManager")
-      } catch {
-        case e: Exception =>
-          throw new GlutenException(
-            "Unable to find field TaskMemoryManager#memoryManager via reflection",
-            e)
-      }
-    f.setAccessible(true)
-    f
-  }
-
   override def borrow(size: Long): Long = {
-    memoryManagerOption()
+    SparkResourceUtil
+      .getMemoryManagerOption()
       .map {
         mm =>
           val succeeded =
@@ -98,7 +83,8 @@ class GlobalOffHeapStorageMemoryTarget private[memory]
   }
 
   override def repay(size: Long): Long = {
-    memoryManagerOption()
+    SparkResourceUtil
+      .getMemoryManagerOption()
       .map {
         mm =>
           mm.releaseStorageMemory(size, mode)
@@ -111,27 +97,6 @@ class GlobalOffHeapStorageMemoryTarget private[memory]
   override def usedBytes(): Long = recorder.current()
 
   override def accept[T](visitor: MemoryTargetVisitor[T]): T = visitor.visit(this)
-
-  private[memory] def memoryManagerOption(): Option[MemoryManager] = {
-    val env = SparkEnv.get
-    if (env != null) {
-      // SPARK-46947: https://github.com/apache/spark/pull/45052.
-      ensureMemoryStoreInitialized(env)
-      return Some(env.memoryManager)
-    }
-    val tc = TaskContext.get()
-    if (tc != null) {
-      // This may happen in test code that mocks the task context without booting up SparkEnv.
-      return Some(FIELD_MEMORY_MANAGER.get(tc.taskMemoryManager()).asInstanceOf[MemoryManager])
-    }
-    logWarning(
-      "Memory manager not found because the code is unlikely be run in a Spark application")
-    None
-  }
-
-  private def ensureMemoryStoreInitialized(env: SparkEnv): Unit = {
-    assert(env.blockManager.memoryStore != null)
-  }
 
   override def name(): String = targetName
 

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
@@ -35,7 +35,7 @@ import java.util.UUID
  *
  * Deprecated: [[GlobalOffHeapMemory]] now allocates Spark off-heap memory instead.
  */
-@Deprecated
+@deprecated
 class GlobalOffHeapStorageMemoryTarget private[memory]
   extends MemoryTarget
   with KnownNameAndStats

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
@@ -29,7 +29,14 @@ import org.apache.spark.storage.BlockId
 import java.lang.reflect.Field
 import java.util.UUID
 
-class GlobalOffHeapMemoryTarget private[memory]
+/**
+ * A global off-heap memory target that acquires memory from Spark storage memory pool of the
+ * current Spark executor.
+ *
+ * Deprecated: [[GlobalOffHeapMemory]] now allocates Spark off-heap memory instead.
+ */
+@Deprecated
+class GlobalOffHeapStorageMemoryTarget private[memory]
   extends MemoryTarget
   with KnownNameAndStats
   with Logging {

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapStorageMemoryTarget.scala
@@ -46,7 +46,7 @@ class GlobalOffHeapStorageMemoryTarget private[memory]
 
   override def borrow(size: Long): Long = {
     SparkResourceUtil
-      .getMemoryManagerOption()
+      .getMemoryManagerOption
       .map {
         mm =>
           val succeeded =
@@ -84,7 +84,7 @@ class GlobalOffHeapStorageMemoryTarget private[memory]
 
   override def repay(size: Long): Long = {
     SparkResourceUtil
-      .getMemoryManagerOption()
+      .getMemoryManagerOption
       .map {
         mm =>
           mm.releaseStorageMemory(size, mode)

--- a/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/SparkMemoryUtil.scala
@@ -139,7 +139,7 @@ object SparkMemoryUtil {
         retryOnOomMemoryTarget.target().accept(this)
       }
 
-      override def visit(globalOffHeapMemoryTarget: GlobalOffHeapMemoryTarget): String = {
+      override def visit(globalOffHeapMemoryTarget: GlobalOffHeapStorageMemoryTarget): String = {
         prettyPrintStats("Global off-heap target stats: ", globalOffHeapMemoryTarget)
       }
     })


### PR DESCRIPTION
For allocating global off-heap memory in Gluten, we have been using the storage-memory-based approach provided by utility `GlobalOffHeapMemory` (which is being renamed and deprecated in this PR). However, so far we noticed that the approach didn't bring us much benefit compared to directly allocating from off-heap execution memory via a process-wise dummy task memory manager. The PR refactors the code to rollback to the execution memory solution instead.

The main reason we do this is for more conveniently reusing the existing tree consumer code in Gluten, which helps memory allocations to account themselves to Spark with a specific name and category, which helps user and developer track these allocations, both in production and test.


Related issue: #11169

Related issue: #11406