### PR TITLE
[GLUTEN-8227][VL] fix: Update sort elimination rules for Hash Aggregate

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -161,7 +161,8 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
       aggregateAttributes: Seq[Attribute],
       initialInputBufferOffset: Int,
       resultExpressions: Seq[NamedExpression],
-      child: SparkPlan): HashAggregateExecBaseTransformer = {
+      child: SparkPlan,
+      offloadedSortExec: Boolean): HashAggregateExecBaseTransformer = {
     val replacedResultExpressions = CHHashAggregateExecTransformer.getCHAggregateResultExpressions(
       groupingExpressions,
       aggregateExpressions,

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -339,15 +339,29 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi {
       aggregateAttributes: Seq[Attribute],
       initialInputBufferOffset: Int,
       resultExpressions: Seq[NamedExpression],
-      child: SparkPlan): HashAggregateExecBaseTransformer =
-    RegularHashAggregateExecTransformer(
-      requiredChildDistributionExpressions,
-      groupingExpressions,
-      aggregateExpressions,
-      aggregateAttributes,
-      initialInputBufferOffset,
-      resultExpressions,
-      child)
+      child: SparkPlan,
+      offloadedSortExec: Boolean): HashAggregateExecBaseTransformer =
+    if (offloadedSortExec) {
+      HashFromSortAggregateExecTransformer(
+        requiredChildDistributionExpressions,
+        groupingExpressions,
+        aggregateExpressions,
+        aggregateAttributes,
+        initialInputBufferOffset,
+        resultExpressions,
+        child
+      )
+    } else {
+      RegularHashAggregateExecTransformer(
+        requiredChildDistributionExpressions,
+        groupingExpressions,
+        aggregateExpressions,
+        aggregateAttributes,
+        initialInputBufferOffset,
+        resultExpressions,
+        child
+      )
+    }
 
   /** Generate HashAggregateExecPullOutHelper */
   override def genHashAggregateExecPullOutHelper(

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashAggregateExecTransformer.scala
@@ -610,6 +610,43 @@ case class RegularHashAggregateExecTransformer(
     resultExpressions,
     child) {
 
+  override def isOffloadedSortExec: Boolean = false
+
+  override protected def allowFlush: Boolean = false
+
+  override def simpleString(maxFields: Int): String =
+    s"${super.simpleString(maxFields)}"
+
+  override def verboseString(maxFields: Int): String =
+    s"${super.verboseString(maxFields)}"
+
+  override protected def withNewChildInternal(newChild: SparkPlan): HashAggregateExecTransformer = {
+    copy(child = newChild)
+  }
+}
+
+// Hash aggregation that is offloaded from sort aggregation.
+// Is identical to RegularHashAggregateExecTransformer but with a
+// different value of isOffloadedSortExec.
+case class HashFromSortAggregateExecTransformer(
+    requiredChildDistributionExpressions: Option[Seq[Expression]],
+    groupingExpressions: Seq[NamedExpression],
+    aggregateExpressions: Seq[AggregateExpression],
+    aggregateAttributes: Seq[Attribute],
+    initialInputBufferOffset: Int,
+    resultExpressions: Seq[NamedExpression],
+    child: SparkPlan)
+  extends HashAggregateExecTransformer(
+    requiredChildDistributionExpressions,
+    groupingExpressions,
+    aggregateExpressions,
+    aggregateAttributes,
+    initialInputBufferOffset,
+    resultExpressions,
+    child) {
+
+  override def isOffloadedSortExec: Boolean = true
+
   override protected def allowFlush: Boolean = false
 
   override def simpleString(maxFields: Int): String =

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
@@ -1171,6 +1171,37 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
       }
     }
   }
+
+  test("test collect_list with ordering") {
+    withTempView("t1") {
+      Seq((2, "d"), (2, "e"), (2, "f"), (1, "b"), (1, "a"), (1, "c"), (3, "i"), (3, "h"), (3, "g"))
+        .toDF("id", "value")
+        .createOrReplaceTempView("t1")
+      runQueryAndCompare(
+        """
+          | SELECT 1 - id, collect_list(value) AS values_list
+          |        FROM (
+          |        select * from
+          |        (SELECT id, value
+          |          FROM t1
+          |          DISTRIBUTE BY rand())
+          |          DISTRIBUTE BY id sort by id,value
+          |        ) t
+          |        GROUP BY 1
+          |""".stripMargin,
+        false
+      ) {
+        df =>
+          {
+            assert(
+              getExecutedPlan(df).count(
+                plan => {
+                  plan.isInstanceOf[HashFromSortAggregateExecTransformer]
+                }) == 2)
+          }
+      }
+    }
+  }
 }
 
 class VeloxAggregateFunctionsDefaultSuite extends VeloxAggregateFunctionsSuite {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -79,7 +79,8 @@ trait SparkPlanExecApi {
       aggregateAttributes: Seq[Attribute],
       initialInputBufferOffset: Int,
       resultExpressions: Seq[NamedExpression],
-      child: SparkPlan): HashAggregateExecBaseTransformer
+      child: SparkPlan,
+      offloadedSortExec: Boolean): HashAggregateExecBaseTransformer
 
   /** Generate HashAggregateExecPullOutHelper */
   def genHashAggregateExecPullOutHelper(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
@@ -43,6 +43,8 @@ abstract class HashAggregateExecBaseTransformer(
   extends BaseAggregateExec
   with UnaryTransformSupport {
 
+  def isOffloadedSortExec: Boolean = false
+
   override lazy val allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++
       aggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
@@ -184,7 +186,7 @@ object HashAggregateExecBaseTransformer {
     case a: SortAggregateExec => a.initialInputBufferOffset
   }
 
-  def from(agg: BaseAggregateExec): HashAggregateExecBaseTransformer = {
+  def from(agg: BaseAggregateExec, offloadedSortExec: Boolean): HashAggregateExecBaseTransformer = {
     BackendsApiManager.getSparkPlanExecApiInstance
       .genHashAggregateExecTransformer(
         agg.requiredChildDistributionExpressions,
@@ -193,7 +195,8 @@ object HashAggregateExecBaseTransformer {
         agg.aggregateAttributes,
         getInitialInputBufferOffset(agg),
         agg.resultExpressions,
-        agg.child
+        agg.child,
+        offloadedSortExec
       )
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EliminateLocalSort.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EliminateLocalSort.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.{ProjectExec, SortExec, SparkPlan, UnaryEx
  */
 object EliminateLocalSort extends Rule[SparkPlan] {
   private def canEliminateLocalSort(p: SparkPlan): Boolean = p match {
-    case _: HashAggregateExecBaseTransformer => true
+    case h: HashAggregateExecBaseTransformer => h.isOffloadedSortExec
     case _: ShuffledHashJoinExecTransformerBase => true
     case _: WindowGroupLimitExecTransformer => true
     case s: SortExec if s.global == false => true

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -212,11 +212,14 @@ object OffloadOthers {
           val columnarChild = plan.child
           ProjectExecTransformer(plan.projectList, columnarChild)
         case plan: HashAggregateExec =>
-          HashAggregateExecBaseTransformer.from(plan)
+          logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
+          HashAggregateExecBaseTransformer.from(plan, false)
         case plan: SortAggregateExec =>
-          HashAggregateExecBaseTransformer.from(plan)
+          logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
+          HashAggregateExecBaseTransformer.from(plan, true)
         case plan: ObjectHashAggregateExec =>
-          HashAggregateExecBaseTransformer.from(plan)
+          logDebug(s"Columnar Processing for ${plan.getClass} is currently supported.")
+          HashAggregateExecBaseTransformer.from(plan, false)
         case plan: UnionExec =>
           ColumnarUnionExec.from(plan)
         case plan: ExpandExec =>


### PR DESCRIPTION
Update sort elimination rules for hash aggregate only when the base aggregate was a sort aggregate. Only if a sort aggregate is transformed into a hash aggregate, can we safely assume that the aggregation does not depend on input order.

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/incubator-gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
CI

## Was this patch authored or co-authored using generative AI tooling?
No


Related issue: #8227