### PR TITLE
[MINOR] Add GCS Maven Central mirror for faster dependency downloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,6 +483,57 @@
     </dependencies>
   </dependencyManagement>
 
+  <!-- Use Google Cloud Storage mirror for faster Maven Central downloads -->
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>gcs-maven-central-mirror</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+    </repository>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Maven Repository Switchboard</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>gcs-maven-central-mirror</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Maven Plugin Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <build>
     <resources>
       <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -504,7 +504,7 @@
         <enabled>false</enabled>
       </snapshots>
       <id>central</id>
-      <name>Maven Repository Switchboard</name>
+      <name>Maven Central</name>
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
   </repositories>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Google Cloud Storage Maven Central mirror as the primary repository for faster dependency downloads during builds.

### Changes:
- Add `gcs-maven-central-mirror` repository pointing to `https://maven-central.storage-download.googleapis.com/maven2/`
- Keep standard Maven Central as fallback
- Apply to both `<repositories>` and `<pluginRepositories>`

## Why are the changes needed?

The GCS Maven Central mirror is geographically distributed and typically provides faster download speeds than the default Maven Central. This is the same pattern used by Apache Spark.

## Does this PR introduce any user-facing change?

No. This only affects build-time dependency resolution.

## How was this patch tested?

- `./build/mvn validate` passes