### PR TITLE
[GLUTEN-7600][VL] Add monotonically_increasing_id function mapping

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -496,10 +496,15 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  // FIXME: Ignored: https://github.com/apache/incubator-gluten/issues/7600.
-  ignore("monotonically_increasintestg_id") {
+  test("monotonically_increasing_id") {
     runQueryAndCompare("""SELECT monotonically_increasing_id(), l_orderkey
                          | from lineitem limit 100""".stripMargin) {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    // Multiple calls must produce independent results (issue #7628).
+    runQueryAndCompare(
+      """SELECT monotonically_increasing_id(), monotonically_increasing_id()
+        | from lineitem limit 100""".stripMargin) {
       checkGlutenPlan[ProjectExecTransformer]
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
@@ -290,6 +290,7 @@ object ExpressionMappings {
     Sig[MakeDecimal](MAKE_DECIMAL),
     Sig[PromotePrecision](PROMOTE_PRECISION),
     Sig[SparkPartitionID](SPARK_PARTITION_ID),
+    Sig[MonotonicallyIncreasingID](MONOTONICALLY_INCREASING_ID),
     Sig[AtLeastNNonNulls](AT_LEAST_N_NON_NULLS),
     Sig[WidthBucket](WIDTH_BUCKET),
     Sig[ReplicateRows](REPLICATE_ROWS),


### PR DESCRIPTION
 ## Summary
  - Adds `Sig[MonotonicallyIncreasingID]` to `ExpressionMappings.SCALAR_SIGS` so the function is offloaded to Velox instead of falling back to vanilla Spark.
  - Sets Velox's `expression.dedup_non_deterministic` to `false` to match Spark semantics — Spark never deduplicates non-deterministic expressions, each call has independent state.
  - Un-ignores and fixes the test in `ScalarFunctionsValidateSuite`.

  ## Context
  PR #10097 previously attempted this but was closed because of a result mismatch (#7628): `SELECT monotonically_increasing_id(), monotonically_increasing_id()` returned
```
  ┌─────┬───────┬───────┐
  │ Row │ Col 1 │ Col 2 │
  ├─────┼───────┼───────┤
  │ 0   │ 0     │ 2     │
  ├─────┼───────┼───────┤
  │ 1   │ 1     │ 3     │
  └─────┴───────┴───────┘
```
 instead of Spark's expected 
```
  ┌─────┬───────┬───────┐
  │ Row │ Col 1 │ Col 2 │
  ├─────┼───────┼───────┤
  │ 0   │ 0     │ 0     │
  ├─────┼───────┼───────┤
  │ 1   │ 1     │ 1     │
  └─────┴───────┴───────┘
```
The root cause was Velox's expression compiler deduplicating the two structurally identical calls into one shared counter instance.

  Velox has since added the `expression.dedup_non_deterministic` config (facebookincubator/velox#15008) to control this behavior. This PR sets it to `false` for Gluten. This only affects non-deterministic expressions — deterministic expression deduplication is unchanged.

  **Question for reviewers:** Is setting `expression.dedup_non_deterministic = false` globally the right approach? An alternative would be conditionally disabling it only when stateful expressions like `monotonically_increasing_id` are detected in the plan, but we believe the global approach is correct since Spark semantics never deduplicate non-deterministic expressions.

  Closes #7628


Related issue: #7600