### PR TITLE
[GLUTEN-11677] Support get cpp stack using gdb from Spark UI

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenDriverEndpoint.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenDriverEndpoint.scala
@@ -137,15 +137,18 @@ class GlutenDriverEndpoint extends IsolatedRpcEndpoint with Logging {
         case t: Throwable => context.sendFailure(t)
       }
 
-    case GlutenQueryNativeStackRaw(requestId) =>
-      try {
-        val raw = GlutenDriverEndpoint
-          .getStackAsyncStatus(requestId)
-          .map { case (_, msg) => Option(msg).getOrElse("") }
-          .getOrElse("invalid requestId")
-        context.reply(raw)
-      } catch {
-        case t: Throwable => context.sendFailure(t)
+    case GlutenQueryNativeStackSync(executorId) =>
+      val data = GlutenDriverEndpoint.executorDataMap.get(executorId)
+      if (data == null) {
+        context.sendFailure(
+          new IllegalArgumentException(s"Executor $executorId not registered or unavailable"))
+      } else {
+        try {
+          val text = data.executorEndpointRef.askSync[String](GlutenDumpNativeStackSyncRequest)
+          context.reply(text)
+        } catch {
+          case t: Throwable => context.sendFailure(t)
+        }
       }
   }
 

--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
@@ -21,7 +21,8 @@ import org.apache.gluten.execution.{CHBroadcastBuildSideCache, CHNativeCacheMana
 import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.rpc.GlutenRpcMessages._
-import org.apache.spark.util.ThreadUtils
+import org.apache.spark.rpc.RpcCallContext
+import org.apache.spark.util.{ExecutorManager, ThreadUtils, Utils}
 
 import scala.util.{Failure, Success}
 
@@ -65,6 +66,173 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
         hashIds.forEach(
           resource_id => CHBroadcastBuildSideCache.invalidateBroadcastHashtable(resource_id))
       }
+
+    case GlutenDumpNativeStackAsyncRequest(requestId) =>
+      // Async collection: run in a separate thread and report result to driverEndpointRef
+      val runnable = new Runnable {
+        override def run(): Unit = {
+          def sendResult(msg: GlutenRpcMessage): Unit = {
+            var ref = driverEndpointRef
+            if (ref == null) {
+              try {
+                ref = rpcEnv.setupEndpointRefByURI(driverUrl)
+                driverEndpointRef = ref
+              } catch {
+                case t: Throwable =>
+                  logWarning("Resolve driverEndpointRef failed when reporting async result", t)
+              }
+            }
+            if (ref != null) {
+              try {
+                ref.send(msg)
+              } catch {
+                case t: Throwable => logWarning("Send async result to driver failed", t)
+              }
+            } else {
+              logError(
+                s"DriverEndpointRef unavailable; " +
+                  s"async stack result lost for requestId=$requestId")
+            }
+          }
+          try {
+            val pid = ExecutorManager.getProcessId()
+            def runCmd(cmd: String): Option[String] = {
+              try {
+                Some(Utils.executeAndGetOutput(Seq("bash", "-c", cmd)))
+              } catch { case _: Throwable => None }
+            }
+            def has(cmd: String): Boolean = {
+              try {
+                val out = Utils.executeAndGetOutput(
+                  Seq("bash", "-c", s"command -v $cmd >/dev/null 2>&1 && echo yes || echo no"))
+                out != null && out.trim == "yes"
+              } catch { case _: Throwable => false }
+            }
+            def tryInstallTools(): Unit = {
+              // Best-effort install for available package manager; may require root privileges.
+              val sudo = if (has("sudo")) "sudo " else ""
+              val cmdOpt = {
+                if (has("apt-get")) {
+                  val base = s"${sudo}apt-get update -y && ${sudo}apt-get install -y "
+                  Some(base + "gdb elfutils")
+                } else if (has("yum")) {
+                  Some(s"${sudo}yum install -y gdb elfutils")
+                } else if (has("dnf")) {
+                  Some(s"${sudo}dnf install -y gdb elfutils")
+                } else if (has("zypper")) {
+                  Some(s"${sudo}zypper -n install gdb elfutils")
+                } else {
+                  None
+                }
+              }
+              cmdOpt.foreach {
+                c =>
+                  try { Utils.executeCommand(Seq("bash", "-c", c)) }
+                  catch { case _: Throwable => () }
+              }
+            }
+            // Ensure gdb exists; best-effort install
+            if (!has("gdb")) { tryInstallTools() }
+            // Always use full-thread backtrace
+            val gdbCmdPrefix =
+              if (has("stdbuf")) "stdbuf -o0 -e0 gdb --batch-silent -q" else "gdb --batch-silent -q"
+            // Use gdb logging file to capture full output reliably, then segment and send
+            val tmpLog = java.nio.file.Files.createTempFile(s"gluten-bt-$requestId", ".log")
+            val logPath = tmpLog.toAbsolutePath.toString
+            val charset = java.nio.charset.StandardCharsets.UTF_8
+            val gdbWithLog = s"$gdbCmdPrefix -ex 'set pagination off' " +
+              s"-ex 'set print thread-events off' -ex 'set logging file $logPath' " +
+              s"-ex 'set logging overwrite on' -ex 'set logging on' " +
+              s"-ex 'thread apply all bt full' " +
+              s"-ex 'set logging off' -p $pid"
+            logInfo(
+              s"Starting async native stack collection: requestId=$requestId, pid=$pid, " +
+                s"cmd=$gdbWithLog")
+            val proc = new ProcessBuilder("bash", "-c", gdbWithLog).start()
+            // Incrementally tail the log file and stream to driver while gdb runs
+            val maxSegmentBytes = 64 * 1024
+            var pos: Long = 0L
+            var segments = 0
+            var totalBytes = 0L
+            def streamBytes(bytes: Array[Byte]): Unit = {
+              var offset = 0
+              while (offset < bytes.length) {
+                val end = Math.min(bytes.length, offset + maxSegmentBytes)
+                val segStr = new String(Arrays.copyOfRange(bytes, offset, end), charset)
+                sendResult(GlutenRpcMessages.GlutenNativeStackAsyncChunk(requestId, segStr))
+                segments += 1
+                offset = end
+              }
+            }
+            // Tail loop: read any appended bytes every ~100ms
+            while (proc.isAlive) {
+              try {
+                val raf = new RandomAccessFile(logPath, "r")
+                val len = raf.length()
+                if (len > pos) {
+                  val toRead = (len - pos).toInt
+                  val buf = new Array[Byte](toRead)
+                  raf.seek(pos)
+                  raf.readFully(buf)
+                  pos = len
+                  totalBytes += toRead
+                  streamBytes(buf)
+                }
+                raf.close()
+              } catch { case _: Throwable => () }
+              try Thread.sleep(100)
+              catch { case _: Throwable => () }
+            }
+            // After gdb exits, flush any remaining content
+            try {
+              val raf = new RandomAccessFile(logPath, "r")
+              val len = raf.length()
+              if (len > pos) {
+                val toRead = (len - pos).toInt
+                val buf = new Array[Byte](toRead)
+                raf.seek(pos)
+                raf.readFully(buf)
+                pos = len
+                totalBytes += toRead
+                streamBytes(buf)
+              }
+              raf.close()
+            } catch { case _: Throwable => () }
+            val exitCode = proc.waitFor()
+            logInfo(
+              s"gdb process exit code: $exitCode for requestId=$requestId; " +
+                s"streamedBytes=$totalBytes, segments=$segments")
+            // Cleanup temp file
+            try java.nio.file.Files.deleteIfExists(tmpLog)
+            catch { case _: Throwable => () }
+
+            if (exitCode != 0) {
+              sendResult(
+                GlutenRpcMessages.GlutenNativeStackAsyncResult(
+                  requestId,
+                  success = false,
+                  message =
+                    s"Check executor logs for native C++ stack. gdb exit code: " + exitCode))
+            } else {
+              sendResult(
+                GlutenRpcMessages.GlutenNativeStackAsyncResult(
+                  requestId,
+                  success = true,
+                  message = ""
+                ))
+            }
+          } catch {
+            case t: Throwable =>
+              sendResult(
+                GlutenRpcMessages.GlutenNativeStackAsyncResult(
+                  requestId,
+                  success = false,
+                  message = s"Async stack collection failed: ${t.getMessage}"))
+          }
+        }
+      }
+      // Use executor RPC env to run asynchronously
+      new Thread(runnable, s"gluten-stack-async-$requestId").start()
 
     case e =>
       logError(s"Received unexpected message. $e")

--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
@@ -24,6 +24,11 @@ import org.apache.spark.rpc.GlutenRpcMessages._
 import org.apache.spark.rpc.RpcCallContext
 import org.apache.spark.util.{ExecutorManager, ThreadUtils, Utils}
 
+import java.io.RandomAccessFile
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util
+
 import scala.util.{Failure, Success}
 
 /** Gluten executor endpoint. */
@@ -96,58 +101,15 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
           }
           try {
             val pid = ExecutorManager.getProcessId()
-            def runCmd(cmd: String): Option[String] = {
-              try {
-                Some(Utils.executeAndGetOutput(Seq("bash", "-c", cmd)))
-              } catch { case _: Throwable => None }
-            }
-            def has(cmd: String): Boolean = {
-              try {
-                val out = Utils.executeAndGetOutput(
-                  Seq("bash", "-c", s"command -v $cmd >/dev/null 2>&1 && echo yes || echo no"))
-                out != null && out.trim == "yes"
-              } catch { case _: Throwable => false }
-            }
-            def tryInstallTools(): Unit = {
-              // Best-effort install for available package manager; may require root privileges.
-              val sudo = if (has("sudo")) "sudo " else ""
-              val cmdOpt = {
-                if (has("apt-get")) {
-                  val base = s"${sudo}apt-get update -y && ${sudo}apt-get install -y "
-                  Some(base + "gdb elfutils")
-                } else if (has("yum")) {
-                  Some(s"${sudo}yum install -y gdb elfutils")
-                } else if (has("dnf")) {
-                  Some(s"${sudo}dnf install -y gdb elfutils")
-                } else if (has("zypper")) {
-                  Some(s"${sudo}zypper -n install gdb elfutils")
-                } else {
-                  None
-                }
-              }
-              cmdOpt.foreach {
-                c =>
-                  try { Utils.executeCommand(Seq("bash", "-c", c)) }
-                  catch { case _: Throwable => () }
-              }
-            }
-            // Ensure gdb exists; best-effort install
-            if (!has("gdb")) { tryInstallTools() }
-            // Always use full-thread backtrace
-            val gdbCmdPrefix =
-              if (has("stdbuf")) "stdbuf -o0 -e0 gdb --batch-silent -q" else "gdb --batch-silent -q"
-            // Use gdb logging file to capture full output reliably, then segment and send
-            val tmpLog = java.nio.file.Files.createTempFile(s"gluten-bt-$requestId", ".log")
+            ensureGdbInstalled()
+            val gdbCmdPrefix = gdbPrefix()
+            val tmpLog = Files.createTempFile(s"gluten-bt-$requestId", ".log")
             val logPath = tmpLog.toAbsolutePath.toString
             val charset = StandardCharsets.UTF_8
-            val gdbWithLog = s"$gdbCmdPrefix -ex 'set pagination off' " +
-              s"-ex 'set print thread-events off' -ex 'set logging file $logPath' " +
-              s"-ex 'set logging overwrite on' -ex 'set logging on' " +
-              s"-ex 'thread apply all bt full' " +
-              s"-ex 'set logging off' -p $pid"
+            val gdbWithLog = buildGdbWithLogging(gdbCmdPrefix, logPath, pid)
             logInfo(
-              s"Starting async native stack collection: requestId=$requestId, pid=$pid, " +
-                s"cmd=$gdbWithLog")
+              s"Starting async native stack collection: " +
+                s"requestId=$requestId, pid=$pid, cmd=$gdbWithLog")
             val proc = new ProcessBuilder("bash", "-c", gdbWithLog).start()
             // Incrementally tail the log file and stream to driver while gdb runs
             val maxSegmentBytes = 64 * 1024
@@ -203,7 +165,7 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
               s"gdb process exit code: $exitCode for requestId=$requestId; " +
                 s"streamedBytes=$totalBytes, segments=$segments")
             // Cleanup temp file
-            try java.nio.file.Files.deleteIfExists(tmpLog)
+            try Files.deleteIfExists(tmpLog)
             catch { case _: Throwable => () }
 
             if (exitCode != 0) {
@@ -267,6 +229,81 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
       }
     case e =>
       logError(s"Received unexpected message. $e")
+  }
+
+  override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
+    case GlutenDumpNativeStackSyncRequest =>
+      try {
+        val pid = ExecutorManager.getProcessId()
+        ensureGdbInstalled()
+        val gdbCmdPrefix = gdbPrefix()
+        val tmpLog = Files.createTempFile("gluten-bt-sync-", ".log")
+        val logPath = tmpLog.toAbsolutePath.toString
+        val charset = StandardCharsets.UTF_8
+        val gdbWithLog = buildGdbWithLogging(gdbCmdPrefix, logPath, pid)
+        logInfo(s"Starting sync native stack collection: pid=$pid, cmd=$gdbWithLog")
+        val proc = new ProcessBuilder("bash", "-c", gdbWithLog).start()
+        val exitCode = proc.waitFor()
+        val output =
+          try {
+            new String(Files.readAllBytes(tmpLog), charset)
+          } catch { case _: Throwable => "" }
+        try Files.deleteIfExists(tmpLog)
+        catch { case _: Throwable => () }
+        if (exitCode != 0 && (output == null || output.isEmpty)) {
+          context.reply(s"gdb exit code: $exitCode. Please check executor logs.")
+        } else {
+          context.reply(Option(output).getOrElse(""))
+        }
+      } catch {
+        case t: Throwable =>
+          logWarning("Sync native stack collection failed", t)
+          context.sendFailure(t)
+      }
+  }
+
+  private def has(cmd: String): Boolean = {
+    try {
+      val out = Utils.executeAndGetOutput(
+        Seq("bash", "-c", s"command -v $cmd >/dev/null 2>&1 && echo yes || echo no"))
+      out != null && out.trim == "yes"
+    } catch { case _: Throwable => false }
+  }
+
+  private def ensureGdbInstalled(): Unit = {
+    if (!has("gdb")) {
+      val sudo = if (has("sudo")) "sudo " else ""
+      val cmdOpt =
+        if (has("apt-get")) {
+          val base = s"${sudo}apt-get update -y && ${sudo}apt-get install -y "
+          Some(base + "gdb elfutils")
+        } else if (has("yum")) {
+          Some(s"${sudo}yum install -y gdb elfutils")
+        } else if (has("dnf")) {
+          Some(s"${sudo}dnf install -y gdb elfutils")
+        } else if (has("zypper")) {
+          Some(s"${sudo}zypper -n install gdb elfutils")
+        } else {
+          None
+        }
+      cmdOpt.foreach {
+        c =>
+          try { Utils.executeCommand(Seq("bash", "-c", c)) }
+          catch { case _: Throwable => () }
+      }
+    }
+  }
+
+  private def gdbPrefix(): String = {
+    if (has("stdbuf")) "stdbuf -o0 -e0 gdb --batch-silent -q" else "gdb --batch-silent -q"
+  }
+
+  private def buildGdbWithLogging(gdbCmdPrefix: String, logPath: String, pid: Long): String = {
+    s"$gdbCmdPrefix -ex 'set pagination off' " +
+      s"-ex 'set print thread-events off' -ex 'set logging file $logPath' " +
+      s"-ex 'set logging overwrite on' -ex 'set logging on' " +
+      s"-ex 'thread apply all bt full' " +
+      s"-ex 'set logging off' -p $pid"
   }
 }
 object GlutenExecutorEndpoint {

--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenExecutorEndpoint.scala
@@ -139,7 +139,7 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
             // Use gdb logging file to capture full output reliably, then segment and send
             val tmpLog = java.nio.file.Files.createTempFile(s"gluten-bt-$requestId", ".log")
             val logPath = tmpLog.toAbsolutePath.toString
-            val charset = java.nio.charset.StandardCharsets.UTF_8
+            val charset = StandardCharsets.UTF_8
             val gdbWithLog = s"$gdbCmdPrefix -ex 'set pagination off' " +
               s"-ex 'set print thread-events off' -ex 'set logging file $logPath' " +
               s"-ex 'set logging overwrite on' -ex 'set logging on' " +
@@ -208,14 +208,14 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
 
             if (exitCode != 0) {
               sendResult(
-                GlutenRpcMessages.GlutenNativeStackAsyncResult(
+                GlutenNativeStackAsyncResult(
                   requestId,
                   success = false,
                   message =
                     s"Check executor logs for native C++ stack. gdb exit code: " + exitCode))
             } else {
               sendResult(
-                GlutenRpcMessages.GlutenNativeStackAsyncResult(
+                GlutenNativeStackAsyncResult(
                   requestId,
                   success = true,
                   message = ""
@@ -224,7 +224,7 @@ class GlutenExecutorEndpoint(val executorId: String, val conf: SparkConf)
           } catch {
             case t: Throwable =>
               sendResult(
-                GlutenRpcMessages.GlutenNativeStackAsyncResult(
+                GlutenNativeStackAsyncResult(
                   requestId,
                   success = false,
                   message = s"Async stack collection failed: ${t.getMessage}"))

--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenRpcMessages.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenRpcMessages.scala
@@ -50,4 +50,23 @@ object GlutenRpcMessages {
   case class GlutenFilesCacheLoad(files: Array[Byte]) extends GlutenRpcMessage
 
   case class GlutenFilesCacheLoadStatus(jobId: String)
+
+  /** Start async native stack collection; driver returns a `requestId` immediately */
+  case class GlutenStartNativeStackAsync(executorId: String) extends GlutenRpcMessage
+
+  /** Internal async dump request delivered to executor (no options) */
+  case class GlutenDumpNativeStackAsyncRequest(requestId: String) extends GlutenRpcMessage
+
+  /** Executor reports async dump result back to driver */
+  case class GlutenNativeStackAsyncResult(requestId: String, success: Boolean, message: String)
+    extends GlutenRpcMessage
+
+  /** Executor reports async dump partial chunk to driver */
+  case class GlutenNativeStackAsyncChunk(requestId: String, chunk: String) extends GlutenRpcMessage
+
+  /** Query async native stack status by requestId, driver returns JSON string */
+  case class GlutenQueryNativeStackStatus(requestId: String) extends GlutenRpcMessage
+
+  /** Query async native stack raw message by requestId, driver returns plain text */
+  case class GlutenQueryNativeStackRaw(requestId: String) extends GlutenRpcMessage
 }

--- a/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenRpcMessages.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/rpc/GlutenRpcMessages.scala
@@ -67,6 +67,9 @@ object GlutenRpcMessages {
   /** Query async native stack status by requestId, driver returns JSON string */
   case class GlutenQueryNativeStackStatus(requestId: String) extends GlutenRpcMessage
 
-  /** Query async native stack raw message by requestId, driver returns plain text */
-  case class GlutenQueryNativeStackRaw(requestId: String) extends GlutenRpcMessage
+  /** Synchronous: query native C++ stack of an executor; driver will block and return plain text */
+  case class GlutenQueryNativeStackSync(executorId: String) extends GlutenRpcMessage
+
+  /** Internal sync dump request delivered to executor; executor replies with full stack text */
+  case object GlutenDumpNativeStackSyncRequest extends GlutenRpcMessage
 }

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
@@ -16,10 +16,15 @@
  */
 package org.apache.spark.sql.execution.ui
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config
+import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.ui.TypeAlias._
+import org.apache.spark.status.{ElementTrackingStore, ExecutorSummaryWrapper}
+import org.apache.spark.status.api.v1.ExecutorSummary
 import org.apache.spark.ui.{PagedDataSource, PagedTable, UIUtils, WebUIPage}
 import org.apache.spark.util.Utils
 
@@ -57,6 +62,103 @@ private[ui] class GlutenAllExecutionsPage(parent: GlutenSQLTab) extends WebUIPag
           <div class="aggregated-runningExecutions collapsible-table">
             {glutenPageTable}
           </div>
+
+      // Build Executors overview and native stack collection controls
+      val execSection: Seq[Node] =
+        try {
+          val ui = parent.parent
+          val kvStore = ui.store.store.asInstanceOf[ElementTrackingStore]
+          val wrappers = Utils
+            .tryWithResource(kvStore.view(classOf[ExecutorSummaryWrapper]).closeableIterator()) {
+              iter =>
+                import scala.collection.JavaConverters.asScalaIteratorConverter
+                iter.asScala.toList
+            }
+          val summaries: Seq[ExecutorSummary] = wrappers.map(_.info)
+
+          val maybeExec = Option(request.getParameter("executorId"))
+          val dumpResult: Seq[Node] = maybeExec
+            .map {
+              id =>
+                try {
+                  val rpcEnv: RpcEnv = SparkEnv.get.rpcEnv
+                  val driverRef: RpcEndpointRef = parent.glutenDriverEndpointRef(rpcEnv)
+                  val startMsgClass = Class.forName(
+                    "org.apache.spark.rpc.GlutenRpcMessages$GlutenStartNativeStackAsync")
+                  val startMsg = startMsgClass.getConstructors.head
+                    .newInstance(id)
+                    .asInstanceOf[AnyRef]
+                  val requestId = driverRef.askSync[String](startMsg)
+                  val base = UIUtils.prependBaseUri(request, parent.basePath)
+                  val statusUrl = s"$base/gluten/stackStatus?requestId=$requestId"
+                  Seq(<script>{
+                    scala.xml.Unparsed(s"window.location.href='" + statusUrl + "';")
+                  }</script>)
+                } catch {
+                  case t: Throwable =>
+                    logWarning("Dump native stack failed", t)
+                    Seq(<div class="alert alert-error"><pre>{t.getMessage}</pre></div>)
+                }
+            }
+            .getOrElse(Nil)
+
+          val search =
+            Option(request.getParameter("glutenExec.search")).map(_.trim).filter(_.nonEmpty)
+          val execPage = Option(request.getParameter("glutenExec.page")).map(_.toInt).getOrElse(1)
+          val parameterPath = s"${UIUtils.prependBaseUri(request, parent.basePath)}/gluten/"
+
+          val execTable = new GlutenExecutorsPagedTable(
+            request,
+            parent,
+            summaries,
+            tableHeaderId = "gluten-executors",
+            executionTag = "glutenExec",
+            basePath = UIUtils.prependBaseUri(request, parent.basePath),
+            subPath = "gluten",
+            searchText = search
+          ).table(execPage)
+
+          Seq(
+            <span id="gluten-executors" class="collapse-aggregated-runningExecutions collapse-table"
+                onClick="collapseTable('collapse-aggregated-executors','aggregated-executors')">
+            <h4>
+              <span class="collapse-table-arrow arrow-open"></span>
+              <a href="#gluten-executors">Executors</a> {summaries.size}
+            </h4>
+          </span>,
+            <div class="aggregated-executors collapsible-table">
+              <div style="display:flex; justify-content:space-between; align-items:center; gap:10px; flex-wrap:wrap; margin-bottom:10px;">
+                <form class="form-inline" action={parameterPath} method="GET">
+                  <label style="margin-right:5px;">Show</label>
+                  <select name="glutenExec.pageSize" class="form-control input-sm" onchange="this.form.submit()">
+                    <option value="10">10</option>
+                    <option value="20">20</option>
+                    <option value="50">50</option>
+                    <option value="100">100</option>
+                  </select>
+                  <span style="margin-left:5px;">entries</span>
+                </form>
+                <form class="form-inline" action={
+              parameterPath
+            } method="GET" style="margin-left:auto;">
+                  <label style="margin-right:5px;">Search:</label>
+                  <input type="text" name="glutenExec.search" value={
+              search.getOrElse("")
+            } placeholder="id/host/status" class="form-control input-sm"/>
+                </form>
+              </div>
+            {dumpResult ++ execTable}
+          </div>
+          )
+        } catch {
+          case t: Throwable =>
+            logWarning("Render Gluten Executors section failed", t)
+            Seq(<div class="alert alert-warning">Failed to render Executors overview: {
+              t.getMessage
+            }</div>)
+        }
+
+      _content ++= execSection
 
       _content
     }
@@ -149,8 +251,32 @@ private[ui] class GlutenExecutionPagedTable(
 
   override val dataSource = new GlutenExecutionDataSource(data, pageSize, sortColumn, desc)
 
-  private val parameterPath =
-    s"$basePath/$subPath/?${getParameterOtherTable(request, executionTag)}"
+  private val parameterPath = {
+    // Encode existing query parameters to avoid invalid URIs (e.g., spaces in values)
+    def encodeQuery(q: String): String = {
+      if (q == null || q.isEmpty) ""
+      else {
+        q.split("&")
+          .toSeq
+          .map {
+            kv =>
+              val idx = kv.indexOf('=')
+              if (idx >= 0) {
+                val k = kv.substring(0, idx)
+                val v = kv.substring(idx + 1)
+                s"${URLEncoder.encode(k, UTF_8.name())}=${URLEncoder.encode(v, UTF_8.name())}"
+              } else {
+                URLEncoder.encode(kv, UTF_8.name())
+              }
+          }
+          .mkString("&")
+      }
+    }
+    val otherRaw = getParameterOtherTable(request, executionTag)
+    val other = encodeQuery(otherRaw)
+    val base = s"$basePath/$subPath/"
+    if (other.nonEmpty) s"$base?$other" else s"$base?"
+  }
 
   override def tableId: String = s"$executionTag-table"
 
@@ -288,5 +414,219 @@ private[ui] class GlutenExecutionDataSource(
     } else {
       ordering
     }
+  }
+}
+
+private[ui] class GlutenExecutorsPagedTable(
+    request: HttpServletRequest,
+    parent: GlutenSQLTab,
+    data: Seq[ExecutorSummary],
+    tableHeaderId: String,
+    executionTag: String,
+    basePath: String,
+    subPath: String,
+    searchText: Option[String])
+  extends PagedTable[ExecutorSummary] {
+
+  private val (sortColumn, desc, pageSize) = getTableParameters(request, executionTag, "ID")
+  // Use space-free internal sort keys to avoid invalid URI query parameters
+  private def sortKeyFor(name: String): String = name match {
+    case "ID" => "ID"
+    case "Address" => "Address"
+    case "Status" => "Status"
+    case "Active Tasks" => "Active_Tasks"
+    case "Failed Tasks" => "Failed_Tasks"
+    case "Completed Tasks" => "Completed_Tasks"
+    case "Total Tasks" => "Total_Tasks"
+    case "Total GC Time" => "Total_GC_Time"
+    case "Total Input Bytes" => "Total_Input_Bytes"
+    case "Total Shuffle Read" => "Total_Shuffle_Read"
+    case "Total Shuffle Write" => "Total_Shuffle_Write"
+    case other => other.replace(' ', '_')
+  }
+  private def displayNameForKey(key: String): String = key match {
+    case "Active_Tasks" => "Active Tasks"
+    case "Failed_Tasks" => "Failed Tasks"
+    case "Completed_Tasks" => "Completed Tasks"
+    case "Total_Tasks" => "Total Tasks"
+    case "Total_GC_Time" => "Total GC Time"
+    case "Total_Input_Bytes" => "Total Input Bytes"
+    case "Total_Shuffle_Read" => "Total Shuffle Read"
+    case "Total_Shuffle_Write" => "Total Shuffle Write"
+    case other => other
+  }
+  private val encodedSortColumn = URLEncoder.encode(sortKeyFor(sortColumn), UTF_8.name())
+
+  private val filtered: Seq[ExecutorSummary] = searchText match {
+    case Some(q) =>
+      val qq = q.toLowerCase
+      data.filter {
+        s =>
+          s.id.toLowerCase.contains(qq) ||
+          Option(s.hostPort).exists(_.toLowerCase.contains(qq)) ||
+          (if (s.isActive) "active" else "dead").contains(qq)
+      }
+    case None => data
+  }
+
+  override val dataSource = new PagedDataSource[ExecutorSummary](pageSize) {
+    private val sorted = filtered.sorted(ordering(sortColumn, desc))
+    override def dataSize: Int = sorted.size
+    override def sliceData(from: Int, to: Int): Seq[ExecutorSummary] = sorted.slice(from, to)
+  }
+
+  private val parameterPath = {
+    // Encode existing query parameters to avoid invalid URIs (e.g., spaces in values)
+    def encodeQuery(q: String): String = {
+      if (q == null || q.isEmpty) ""
+      else {
+        q.split("&")
+          .toSeq
+          .map {
+            kv =>
+              val idx = kv.indexOf('=')
+              if (idx >= 0) {
+                val k = kv.substring(0, idx)
+                val v = kv.substring(idx + 1)
+                s"${URLEncoder.encode(k, UTF_8.name())}=${URLEncoder.encode(v, UTF_8.name())}"
+              } else {
+                URLEncoder.encode(kv, UTF_8.name())
+              }
+          }
+          .mkString("&")
+      }
+    }
+    val other = encodeQuery(getParameterOtherTable(request, executionTag))
+    val search = searchText
+      .map(s => s"$executionTag.search=${URLEncoder.encode(s, UTF_8.name())}")
+      .getOrElse("")
+    val base = s"$basePath/$subPath/"
+    val query =
+      if (other.nonEmpty && search.nonEmpty) s"$other&$search"
+      else if (other.nonEmpty) other
+      else search
+    if (query.nonEmpty) s"$base?$query" else s"$base?"
+  }
+
+  override def tableId: String = s"$executionTag-table"
+  override def tableCssClass: String =
+    "table table-bordered table-sm table-striped table-head-clickable table-cell-width-limited"
+
+  override def pageLink(page: Int): String = {
+    val sep = if (parameterPath.endsWith("?")) "" else "&"
+    parameterPath +
+      s"$sep$pageNumberFormField=$page" +
+      s"&$executionTag.sort=$encodedSortColumn" +
+      s"&$executionTag.desc=$desc" +
+      s"&$pageSizeFormField=$pageSize" +
+      s"#$tableHeaderId"
+  }
+
+  override def pageSizeFormField: String = s"$executionTag.pageSize"
+  override def pageNumberFormField: String = s"$executionTag.page"
+  override def goButtonFormPath: String = {
+    val sep = if (parameterPath.endsWith("?")) "" else "&"
+    s"$parameterPath$sep$executionTag.sort=$encodedSortColumn&$executionTag.desc=$desc#$tableHeaderId"
+  }
+
+  private val headerInfo: Seq[(String, Boolean, Option[String])] = Seq(
+    ("ID", true, None),
+    ("Address", true, None),
+    ("Status", true, None),
+    ("Active Tasks", true, None),
+    ("Failed Tasks", true, None),
+    ("Completed Tasks", true, None),
+    ("Total Tasks", true, None),
+    ("Total GC Time", true, None),
+    ("Total Input Bytes", true, None),
+    ("Total Shuffle Read", true, None),
+    ("Total Shuffle Write", true, None),
+    ("C++ Thread Dump", false, None)
+  )
+
+  override def headers: Seq[Node] = {
+    isSortColumnValid(headerInfo, displayNameForKey(sortColumn))
+    val ths: Seq[Node] = headerInfo.map {
+      case (name, sortable, _) =>
+        if (sortable) {
+          val encodedName = URLEncoder.encode(sortKeyFor(name), UTF_8.name())
+          val newDesc = if (sortKeyFor(sortColumn) == sortKeyFor(name)) !desc else false
+          val sep = if (parameterPath.endsWith("?")) "" else "&"
+          val href = parameterPath +
+            s"$sep$pageNumberFormField=1" +
+            s"&$executionTag.sort=$encodedName" +
+            s"&$executionTag.desc=$newDesc" +
+            s"&$pageSizeFormField=$pageSize" +
+            s"#$tableHeaderId"
+          <th><a href={href}>{name}</a></th>
+        } else {
+          <th>{name}</th>
+        }
+    }
+    Seq(<thead><tr>{ths}</tr></thead>)
+  }
+
+  override def row(s: ExecutorSummary): Seq[Node] = {
+    val link = UIUtils.prependBaseUri(request, parent.basePath) + s"/gluten/?executorId=${s.id}"
+    val statusText = if (s.isActive) "ACTIVE" else "DEAD"
+    def fmtBytes(v: Long): String = {
+      val abs = math.abs(v)
+      if (abs < 1024L) s"${v}B"
+      else if (abs < 1024L * 1024L) f"${v / 1024.0}%.1fK"
+      else if (abs < 1024L * 1024L * 1024L) f"${v / (1024.0 * 1024)}%.1fM"
+      else f"${v / (1024.0 * 1024 * 1024)}%.1fG"
+    }
+    <tr>
+      <td>{s.id}</td>
+      <td>{s.hostPort}</td>
+      <td>{statusText}</td>
+      <td sorttable_customkey={s.activeTasks.toString}>{s.activeTasks.toString}</td>
+      <td sorttable_customkey={s.failedTasks.toString}>{s.failedTasks.toString}</td>
+      <td sorttable_customkey={s.completedTasks.toString}>{s.completedTasks.toString}</td>
+      <td sorttable_customkey={s.totalTasks.toString}>{s.totalTasks.toString}</td>
+      <td sorttable_customkey={s.totalGCTime.toString}>{s.totalGCTime.toString}</td>
+      <td sorttable_customkey={s.totalInputBytes.toString}>{fmtBytes(s.totalInputBytes)}</td>
+      <td sorttable_customkey={s.totalShuffleRead.toString}>{fmtBytes(s.totalShuffleRead)}</td>
+      <td sorttable_customkey={s.totalShuffleWrite.toString}>{fmtBytes(s.totalShuffleWrite)}</td>
+      {
+        // Hide C++ stack link for driver executor
+        if (s.id == "driver") {
+          <td></td>
+        } else {
+          <td><a href={link}>C++ Stack</a></td>
+        }
+      }
+    </tr>
+  }
+
+  private def ordering(sortColumn: String, desc: Boolean): Ordering[ExecutorSummary] = {
+    val key = sortColumn match {
+      case "Num_Gluten_Nodes" => "Num Gluten Nodes"
+      case "Num_Fallback_Nodes" => "Num Fallback Nodes"
+      case "Active_Tasks" => "Active Tasks"
+      case "Failed_Tasks" => "Failed Tasks"
+      case "Completed_Tasks" => "Completed Tasks"
+      case "Total_Tasks" => "Total Tasks"
+      case "Total_GC_Time" => "Total GC Time"
+      case "Total_Input_Bytes" => "Total Input Bytes"
+      case "Total_Shuffle_Read" => "Total Shuffle Read"
+      case "Total_Shuffle_Write" => "Total Shuffle Write"
+      case other => other
+    }
+    val ord: Ordering[ExecutorSummary] = key match {
+      case "ID" => Ordering.by(_.id)
+      case "Address" => Ordering.by(_.hostPort)
+      case "Status" => Ordering.by(s => if (s.isActive) 1 else 0)
+      case "Active Tasks" => Ordering.by(_.activeTasks)
+      case "Failed Tasks" => Ordering.by(_.failedTasks)
+      case "Completed Tasks" => Ordering.by(_.completedTasks)
+      case "Total Tasks" => Ordering.by(_.totalTasks)
+      case "Total GC Time" => Ordering.by(_.totalGCTime)
+      case "Total Input Bytes" => Ordering.by(_.totalInputBytes)
+      case "Total Shuffle Read" => Ordering.by(_.totalShuffleRead)
+      case "Total Shuffle Write" => Ordering.by(_.totalShuffleWrite)
+      case unknown => throw QueryExecutionErrors.unknownColumnError(unknown)
+    }
+    if (desc) ord.reverse else ord
   }
 }

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
@@ -567,6 +567,8 @@ private[ui] class GlutenExecutorsPagedTable(
 
   override def row(s: ExecutorSummary): Seq[Node] = {
     val link = UIUtils.prependBaseUri(request, parent.basePath) + s"/gluten/?executorId=${s.id}"
+    val syncLink =
+      UIUtils.prependBaseUri(request, parent.basePath) + s"/gluten/stackSync?executorId=${s.id}"
     val statusText = if (s.isActive) "ACTIVE" else "DEAD"
     def fmtBytes(v: Long): String = {
       val abs = math.abs(v)
@@ -592,7 +594,11 @@ private[ui] class GlutenExecutorsPagedTable(
       if (s.id == "driver") {
         <td></td>
       } else {
-        <td><a href={link}>C++ Stack</a></td>
+        <td>
+            <a href={syncLink}>C++ Stack (Sync)</a>
+            <span> / </span>
+            <a href={link}>C++ Stack (Async)</a>
+          </td>
       }
     }
     </tr>

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenAllExecutionsPage.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution.ui
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config
 import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -589,13 +588,13 @@ private[ui] class GlutenExecutorsPagedTable(
       <td sorttable_customkey={s.totalShuffleRead.toString}>{fmtBytes(s.totalShuffleRead)}</td>
       <td sorttable_customkey={s.totalShuffleWrite.toString}>{fmtBytes(s.totalShuffleWrite)}</td>
       {
-        // Hide C++ stack link for driver executor
-        if (s.id == "driver") {
-          <td></td>
-        } else {
-          <td><a href={link}>C++ Stack</a></td>
-        }
+      // Hide C++ stack link for driver executor
+      if (s.id == "driver") {
+        <td></td>
+      } else {
+        <td><a href={link}>C++ Stack</a></td>
       }
+    }
     </tr>
   }
 

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenSQLTab.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenSQLTab.scala
@@ -34,6 +34,7 @@ class GlutenSQLTab(val sqlStore: GlutenSQLAppStatusStore, sparkUI: SparkUI)
 
   attachPage(new GlutenAllExecutionsPage(this))
   attachPage(new GlutenStackStatusPage(this))
+  attachPage(new GlutenStackSyncPage(this))
   parent.attachTab(this)
 
   /** Get the RPC endpoint reference of the Gluten driver endpoint. */

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenSQLTab.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenSQLTab.scala
@@ -36,9 +36,7 @@ class GlutenSQLTab(val sqlStore: GlutenSQLAppStatusStore, sparkUI: SparkUI)
   attachPage(new GlutenStackStatusPage(this))
   parent.attachTab(this)
 
-  /**
-   * Get the RPC endpoint reference of the Gluten driver endpoint.
-   */
+  /** Get the RPC endpoint reference of the Gluten driver endpoint. */
   def glutenDriverEndpointRef(rpcEnv: RpcEnv): RpcEndpointRef = {
     val driverHost = conf.get(config.DRIVER_HOST_ADDRESS.key, "localhost")
     val driverPort = conf.getInt(config.DRIVER_PORT.key, 7077)

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenStackStatusPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenStackStatusPage.scala
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.ui
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
+import org.apache.spark.ui.{UIUtils, WebUIPage}
+
+import org.json4s.JValue
+import org.json4s.jackson.JsonMethods
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.xml.{Node, Text}
+
+/** Status API for async C++ stack collection. Path: /gluten/stackStatus?requestId=xxxx */
+private[ui] class GlutenStackStatusPage(parent: GlutenSQLTab)
+  extends WebUIPage("stackStatus")
+  with Logging {
+
+  override def renderJson(request: HttpServletRequest): JValue = {
+    val reqIdOpt = Option(request.getParameter("requestId")).filter(_.nonEmpty)
+    reqIdOpt match {
+      case Some(id) =>
+        try {
+          val rpcEnv: RpcEnv = SparkEnv.get.rpcEnv
+          val driverRef: RpcEndpointRef = parent.glutenDriverEndpointRef(rpcEnv)
+          val msgClass =
+            Class.forName("org.apache.spark.rpc.GlutenRpcMessages$GlutenQueryNativeStackStatus")
+          val msg = msgClass.getConstructors.head.newInstance(id).asInstanceOf[AnyRef]
+          val resultStr = driverRef.askSync[String](msg)
+          parseJsonString(resultStr)
+        } catch {
+          case t: Throwable =>
+            val resultStr = s"""{"status": "error", "message":"query failed: ${t.getMessage}"}"""
+            parseJsonString(resultStr)
+        }
+    }
+  }
+
+  override def render(request: HttpServletRequest): Seq[Node] = {
+    val reqIdOpt = Option(request.getParameter("requestId")).filter(_.nonEmpty)
+    reqIdOpt match {
+      case Some(id) =>
+        val base = UIUtils.prependBaseUri(request, parent.basePath)
+        // Status API endpoint returning JSON text: `${base}/stackStatus?api=1`.
+        val statusAPI = s"$base/gluten/stackStatus/json?requestId=$id"
+        val content = Seq(
+          <div>
+            <div style="margin-top:10px;">
+              <b>Request ID:</b> {id}
+            </div>
+            <div id="stack-status" class="alert alert-info" style="margin-top:10px;">
+              Collecting...
+            </div>
+            <pre id="stack-result" class="table table-bordered" style="white-space:pre-wrap;"></pre>
+            <script>
+            {
+            scala.xml.Unparsed(
+              """
+                |window.glutenStackStatusInit = function(statusAPI) {
+                |  var statusEl = document.getElementById('stack-status');
+                |  var resultEl = document.getElementById('stack-result');
+                |  var stopped = false;
+                |  var controller = new AbortController();
+                |  function poll() {
+                |    fetch(statusAPI, { signal: controller.signal, cache: 'no-store' })
+                |      .then(function(r) { return r.json(); })
+                |      .then(function(j) {
+                |        try {
+                |          // Always update result content if present
+                |          if (j.message) { resultEl.textContent = String(j.message || ''); }
+                |          if (j.status === 'done') {
+                |            statusEl.className = 'alert alert-success';
+                |            statusEl.textContent = 'Completed';
+                |            stopped = true;
+                |          } else if (j.status === 'error') {
+                |            statusEl.className = 'alert alert-danger';
+                |            statusEl.textContent = 'Failed';
+                |            stopped = true;
+                |          } else {
+                |            statusEl.className = 'alert alert-info';
+                |            statusEl.textContent = 'Collecting...';
+                |          }
+                |        } catch (e) {
+                |          statusEl.className = 'alert alert-warning';
+                |          statusEl.textContent = 'Status parse failed';
+                |        }
+                |      })
+                |      .catch(function() {
+                |        statusEl.className = 'alert alert-warning';
+                |        statusEl.textContent = 'Status request failed';
+                |      });
+                |    if (!stopped) setTimeout(poll, 2000);
+                |  }
+                |  window.addEventListener('beforeunload', function() {
+                |    stopped = true; controller.abort();
+                |  });
+                |  poll();
+                |};
+                |""".stripMargin
+            )
+          }
+          </script>
+          <script>
+          {
+            scala.xml.Unparsed("window.glutenStackStatusInit('" + statusAPI + "');")
+          }
+          </script>
+          </div>
+        )
+        UIUtils.headerSparkPage(request, "Gluten C++ Stack", content, parent)
+      case None =>
+        Seq(<div class="alert alert-warning">Missing parameter: requestId</div>)
+    }
+  }
+
+  private def parseJsonString(str: String): JValue = {
+    JsonMethods.parse(str)
+  }
+}

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenStackStatusPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenStackStatusPage.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.ui
 
 import org.apache.spark.SparkEnv
-import org.apache.spark.internal.{config, Logging}
+import org.apache.spark.internal.Logging
 import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
 import org.apache.spark.ui.{UIUtils, WebUIPage}
 
@@ -26,7 +26,7 @@ import org.json4s.jackson.JsonMethods
 
 import javax.servlet.http.HttpServletRequest
 
-import scala.xml.{Node, Text}
+import scala.xml.Node
 
 /** Status API for async C++ stack collection. Path: /gluten/stackStatus?requestId=xxxx */
 private[ui] class GlutenStackStatusPage(parent: GlutenSQLTab)
@@ -35,7 +35,7 @@ private[ui] class GlutenStackStatusPage(parent: GlutenSQLTab)
 
   override def renderJson(request: HttpServletRequest): JValue = {
     val reqIdOpt = Option(request.getParameter("requestId")).filter(_.nonEmpty)
-    reqIdOpt match {
+    val resultStr = reqIdOpt match {
       case Some(id) =>
         try {
           val rpcEnv: RpcEnv = SparkEnv.get.rpcEnv
@@ -43,14 +43,16 @@ private[ui] class GlutenStackStatusPage(parent: GlutenSQLTab)
           val msgClass =
             Class.forName("org.apache.spark.rpc.GlutenRpcMessages$GlutenQueryNativeStackStatus")
           val msg = msgClass.getConstructors.head.newInstance(id).asInstanceOf[AnyRef]
-          val resultStr = driverRef.askSync[String](msg)
-          parseJsonString(resultStr)
+          driverRef.askSync[String](msg)
         } catch {
           case t: Throwable =>
-            val resultStr = s"""{"status": "error", "message":"query failed: ${t.getMessage}"}"""
-            parseJsonString(resultStr)
+            s"""{"status": "error", "message":"query failed: ${t.getMessage}"}"""
         }
+      case None =>
+        s"""{"status": "error", "message":">Missing parameter: requestId"}"""
+
     }
+    parseJsonString(resultStr)
   }
 
   override def render(request: HttpServletRequest): Seq[Node] = {
@@ -58,7 +60,6 @@ private[ui] class GlutenStackStatusPage(parent: GlutenSQLTab)
     reqIdOpt match {
       case Some(id) =>
         val base = UIUtils.prependBaseUri(request, parent.basePath)
-        // Status API endpoint returning JSON text: `${base}/stackStatus?api=1`.
         val statusAPI = s"$base/gluten/stackStatus/json?requestId=$id"
         val content = Seq(
           <div>

--- a/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenStackSyncPage.scala
+++ b/gluten-ui/src/main/scala/org/apache/spark/sql/execution/ui/GlutenStackSyncPage.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.ui
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.rpc.{RpcEndpointRef, RpcEnv}
+import org.apache.spark.ui.{UIUtils, WebUIPage}
+
+import javax.servlet.http.HttpServletRequest
+
+import scala.xml.Node
+
+/** 同步获取 C++ 栈的页面：/gluten/stackSync?executorId=xxxx */
+private[ui] class GlutenStackSyncPage(parent: GlutenSQLTab)
+  extends WebUIPage("stackSync")
+  with Logging {
+
+  override def render(request: HttpServletRequest): Seq[Node] = {
+    val execIdOpt = Option(request.getParameter("executorId")).filter(_.nonEmpty)
+    execIdOpt match {
+      case Some(executorId) =>
+        try {
+          val rpcEnv: RpcEnv = SparkEnv.get.rpcEnv
+          val driverRef: RpcEndpointRef = parent.glutenDriverEndpointRef(rpcEnv)
+          val msgClass =
+            Class.forName("org.apache.spark.rpc.GlutenRpcMessages$GlutenQueryNativeStackSync")
+          val msg = msgClass.getConstructors.head.newInstance(executorId).asInstanceOf[AnyRef]
+          val resultStr = driverRef.askSync[String](msg)
+          val content = Seq(
+            <div>
+              <div style="margin-top:10px;"><b>Executor:</b> {executorId}</div>
+              <div class="alert alert-info" style="margin-top:10px;">
+                Sync fetch complete (blocking).
+              </div>
+              <pre class="table table-bordered" style="white-space:pre-wrap;">
+                {resultStr}
+              </pre>
+            </div>
+          )
+          UIUtils.headerSparkPage(request, "Gluten C++ Stack (Sync)", content, parent)
+        } catch {
+          case t: Throwable =>
+            val content = Seq(
+              <div class="alert alert-danger">
+                <b>Sync fetch failed:</b>
+                <pre>{Option(t.getMessage).getOrElse(t.toString)}</pre>
+              </div>
+            )
+            UIUtils.headerSparkPage(request, "Gluten C++ Stack (Sync)", content, parent)
+        }
+      case None =>
+        Seq(<div class="alert alert-warning">Missing parameter: executorId</div>)
+    }
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

In Vanilla Spark WebUI, it is easy to get the current java jstack, which is very helpful to diagnostic the hang/slow problems. But when it comes to Spark on Gluten, the jstack is meaningless since all heavy jobs are under JNI call.

This PR adds the same ability to capture native C++ stack traces from executors directly from the Gluten SQL tab in the Spark UI. It introduces an executors overview with a per‑executor "C++ Stack" action and a dedicated "Gluten C++ Stack" status page that streams the collected stack output.

<img width="3072" height="1208" alt="image" src="https://github.com/user-attachments/assets/3cea55b8-13b4-4971-b427-d0858cd75d73" />

<img width="2490" height="1118" alt="image" src="https://github.com/user-attachments/assets/1df4f0af-2d91-4ba2-9afd-8438af50bfca" />

There are two modes, sync and async. The async mode is mainly because gdb data collection typically takes a long time, exceeding the yarn proxy timeout in our environment.

## How was this patch tested?

Manually

## Was this patch authored or co-authored using generative AI tooling?
Generated-by: TRAE with Doubao-Seed-Code



Related issue: #11677