### PR TITLE
[VL] Support ANSI mode decimal Add/Subtract with checked overflow

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxLiteralSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxLiteralSuite.scala
@@ -139,4 +139,5 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
     validateFallbackResult("SELECT struct(cast(null as struct<a: string>))")
     validateFallbackResult("SELECT array(struct(1, 'a'), null)")
   }
+
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ArithmeticAnsiValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ArithmeticAnsiValidateSuite.scala
@@ -100,4 +100,46 @@ class ArithmeticAnsiValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  test("decimal add overflow") {
+    // Normal decimal add should succeed and match Spark results
+    runQueryAndCompare(
+      "SELECT CAST(1.0 AS DECIMAL(10,2)) + CAST(2.0 AS DECIMAL(10,2))") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+
+    // Overflow: max DECIMAL(38,0) + 1 should throw in ANSI mode
+    if (isSparkVersionGE("4.0")) {
+      intercept[SparkException] {
+        sql("SELECT CAST(99999999999999999999999999999999999999 AS DECIMAL(38,0)) + " +
+          "CAST(1 AS DECIMAL(38,0))").collect()
+      }
+    } else {
+      intercept[ArithmeticException] {
+        sql("SELECT CAST(99999999999999999999999999999999999999 AS DECIMAL(38,0)) + " +
+          "CAST(1 AS DECIMAL(38,0))").collect()
+      }
+    }
+  }
+
+  test("decimal subtract overflow") {
+    // Normal decimal subtract should succeed and match Spark results
+    runQueryAndCompare(
+      "SELECT CAST(5.0 AS DECIMAL(10,2)) - CAST(2.0 AS DECIMAL(10,2))") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+
+    // Overflow: -max DECIMAL(38,0) - 1 should throw in ANSI mode
+    if (isSparkVersionGE("4.0")) {
+      intercept[SparkException] {
+        sql("SELECT CAST(-99999999999999999999999999999999999999 AS DECIMAL(38,0)) - " +
+          "CAST(1 AS DECIMAL(38,0))").collect()
+      }
+    } else {
+      intercept[ArithmeticException] {
+        sql("SELECT CAST(-99999999999999999999999999999999999999 AS DECIMAL(38,0)) - " +
+          "CAST(1 AS DECIMAL(38,0))").collect()
+      }
+    }
+  }
+
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -621,17 +621,37 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           substraitExprName,
           expr.children.map(replaceWithExpressionTransformer0(_, attributeSeq, expressionsMap)),
           expr)
-      case CheckOverflow(b: BinaryArithmetic, decimalType, _)
+      case CheckOverflow(b: BinaryArithmetic, decimalType, nullOnOverflow)
           if !BackendsApiManager.getSettings.transformCheckOverflow &&
             DecimalArithmeticUtil.isDecimalArithmetic(b) =>
-        val arithmeticExprName =
+        val baseExprName =
           BackendsApiManager.getSparkPlanExecApiInstance.getDecimalArithmeticExprName(
             getAndCheckSubstraitName(b, expressionsMap))
+        // When nullOnOverflow is false, it's ANSI mode - use checked_ prefix for overflow errors
+        val arithmeticExprName = if (!nullOnOverflow) {
+          "checked_" + baseExprName
+        } else {
+          baseExprName
+        }
         val left =
           replaceWithExpressionTransformer0(b.left, attributeSeq, expressionsMap)
         val right =
           replaceWithExpressionTransformer0(b.right, attributeSeq, expressionsMap)
         DecimalArithmeticExpressionTransformer(arithmeticExprName, left, right, decimalType, b)
+      // Velox path: ANSI mode decimal Add/Subtract uses checked_ variants
+      // that throw on overflow instead of returning null.
+      case c @ CheckOverflow(b: BinaryArithmetic, _, nullOnOverflow)
+          if BackendsApiManager.getSettings.transformCheckOverflow &&
+            DecimalArithmeticUtil.isDecimalArithmetic(b) &&
+            !nullOnOverflow &&
+            (b.isInstanceOf[Add] || b.isInstanceOf[Subtract]) =>
+        val baseExprName =
+          BackendsApiManager.getSparkPlanExecApiInstance.getDecimalArithmeticExprName(
+            getAndCheckSubstraitName(b, expressionsMap))
+        val checkedExprName = "checked_" + baseExprName
+        val childTransformer =
+          genRescaleDecimalTransformer(checkedExprName, b, attributeSeq, expressionsMap)
+        CheckOverflowTransformer(substraitExprName, childTransformer, c)
       case c: CheckOverflow =>
         CheckOverflowTransformer(
           substraitExprName,


### PR DESCRIPTION
## Summary
  - Routes decimal `Add` and `Subtract` to Velox's `checked_add` and `checked_subtract` when ANSI mode is enabled (`nullOnOverflow = false` in `CheckOverflow`), so overflow throws instead of returning null.
  - Adds TRY mode support for decimal `Add`/`Subtract` using the `try(checked_add/checked_subtract)` pattern, consistent with how integer TRY arithmetic is already handled.
  - Previously, TRY mode for decimal arithmetic relied on a `tryCast` in `CheckOverflowTransformer` to detect overflow. This change uses the consistent `try(checked_*)` pattern instead.

  ## Dependencies
  - Depends on facebookincubator/velox#16302 (merged to upstream), which adds `checked_add` and `checked_subtract` support for decimal types.
  - The commit is on IBM/velox `oss-main` but not yet on the `dft-` branch Gluten pins to. The ANSI overflow tests will pass after the next Velox version bump in `get-velox.sh`.

  ## Test plan
  - [x] Normal decimal add/subtract succeeds and matches Spark results
  - [x] Overflow on decimal add/subtract throws in ANSI mode
  - [x] `try_add`/`try_subtract` with decimals returns null on overflow
  - [ ] Full validation after Velox version bump picks up facebookincubator/velox#16302
