### PR TITLE
[VL] Metrics: Include kPreloadSplitPrepareTimeNanos in kDataSourceAddSplitWallNanos

### DIFF
--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -60,6 +60,7 @@ const std::string kPreloadSplits = "readyPreloadedSplits";
 const std::string kPageLoadTime = "pageLoadTimeNs";
 const std::string kDataSourceAddSplitWallNanos = "dataSourceAddSplitWallNanos";
 const std::string kWaitForPreloadSplitNanos = "waitForPreloadSplitNanos";
+const std::string kPreloadSplitPrepareTimeNanos = "preloadSplitPrepareTimeNanos";
 const std::string kDataSourceReadWallNanos = "dataSourceReadWallNanos";
 const std::string kNumWrittenFiles = "numWrittenFiles";
 const std::string kWriteIOTime = "writeIOWallNanos";
@@ -514,7 +515,8 @@ void WholeStageResultIterator::collectMetrics() {
       metrics_->get(Metrics::kPageLoadTime)[metricIndex] = runtimeMetric("sum", second->customStats, kPageLoadTime);
       metrics_->get(Metrics::kDataSourceAddSplitWallNanos)[metricIndex] =
           runtimeMetric("sum", second->customStats, kDataSourceAddSplitWallNanos) +
-          runtimeMetric("sum", second->customStats, kWaitForPreloadSplitNanos);
+          runtimeMetric("sum", second->customStats, kWaitForPreloadSplitNanos) +
+          runtimeMetric("sum", second->customStats, kPreloadSplitPrepareTimeNanos);
       metrics_->get(Metrics::kDataSourceReadWallNanos)[metricIndex] =
           runtimeMetric("sum", second->customStats, kDataSourceReadWallNanos);
       metrics_->get(Metrics::kNumWrittenFiles)[metricIndex] =

--- a/dev/check.py
+++ b/dev/check.py
@@ -24,7 +24,7 @@ import sys
 from util import attrdict
 import util
 
-EXTENSIONS = "cpp,h,inc,prolog"
+EXTENSIONS = "cc,cpp,h,inc,prolog"
 SCRIPTS = util.script_path()
 
 


### PR DESCRIPTION
*Breaking change on UI: Metric `data source add split time total` on Spark UI will be shown longer than before.*

Include missing `preloadSplitPrepareTimeNanos` from the [3 split-adding metrics](https://github.com/facebookincubator/velox/blob/8853645932621aeadb7fffdd9112b881ce4225f8/velox/exec/TableScan.h#L83-L93).

before:
<img width="377" height="45" alt="Screenshot 2026-03-05 at 15 15 42" src="https://github.com/user-attachments/assets/91b5adfe-960b-423c-871b-a31c7c30df0c" />
after:
<img width="377" height="45" alt="Screenshot 2026-03-05 at 15 15 53" src="https://github.com/user-attachments/assets/988adc0a-fcb6-46f2-a9a2-81fc49f39da8" />