### PR TITLE
[GLUTEN-8063][VL] Export cpuNanos metric for InputIteratorTransformer

### DIFF
--- a/backends-velox/src/main/java/org/apache/gluten/metrics/Metrics.java
+++ b/backends-velox/src/main/java/org/apache/gluten/metrics/Metrics.java
@@ -29,6 +29,7 @@ public class Metrics implements IMetrics {
   public long[] outputBytes;
   public long[] cpuCount;
   public long[] wallNanos;
+  public long[] cpuNanos;
   public long[] scanTime;
   public long[] peakMemoryBytes;
   public long[] numMemoryAllocations;
@@ -79,6 +80,7 @@ public class Metrics implements IMetrics {
       long[] outputBytes,
       long[] cpuCount,
       long[] wallNanos,
+      long[] cpuNanos,
       long veloxToArrow,
       long[] peakMemoryBytes,
       long[] numMemoryAllocations,
@@ -122,6 +124,7 @@ public class Metrics implements IMetrics {
     this.outputBytes = outputBytes;
     this.cpuCount = cpuCount;
     this.wallNanos = wallNanos;
+    this.cpuNanos = cpuNanos;
     this.scanTime = scanTime;
     this.singleMetric.veloxToArrow = veloxToArrow;
     this.peakMemoryBytes = peakMemoryBytes;
@@ -174,6 +177,7 @@ public class Metrics implements IMetrics {
         outputBytes[index],
         cpuCount[index],
         wallNanos[index],
+        cpuNanos[index],
         peakMemoryBytes[index],
         numMemoryAllocations[index],
         spilledInputBytes[index],

--- a/backends-velox/src/main/java/org/apache/gluten/metrics/OperatorMetrics.java
+++ b/backends-velox/src/main/java/org/apache/gluten/metrics/OperatorMetrics.java
@@ -27,6 +27,7 @@ public class OperatorMetrics implements IOperatorMetrics {
   public long outputBytes;
   public long cpuCount;
   public long wallNanos;
+  public long cpuNanos;
   public long scanTime;
   public long peakMemoryBytes;
   public long numMemoryAllocations;
@@ -73,6 +74,7 @@ public class OperatorMetrics implements IOperatorMetrics {
       long outputBytes,
       long cpuCount,
       long wallNanos,
+      long cpuNanos,
       long peakMemoryBytes,
       long numMemoryAllocations,
       long spilledInputBytes,
@@ -114,6 +116,7 @@ public class OperatorMetrics implements IOperatorMetrics {
     this.outputBytes = outputBytes;
     this.cpuCount = cpuCount;
     this.wallNanos = wallNanos;
+    this.cpuNanos = cpuNanos;
     this.scanTime = scanTime;
     this.peakMemoryBytes = peakMemoryBytes;
     this.numMemoryAllocations = numMemoryAllocations;

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxMetricsApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxMetricsApi.scala
@@ -75,7 +75,8 @@ class VeloxMetricsApi extends MetricsApi with Logging {
 
     Map(
       "cpuCount" -> SQLMetrics.createMetric(sparkContext, "cpu wall time count"),
-      "wallNanos" -> wallNanosMetric
+      "wallNanos" -> wallNanosMetric,
+      "cpuNanos" -> SQLMetrics.createNanoTimingMetric(sparkContext, "cpu time")
     ) ++ outputMetrics
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/metrics/InputIteratorMetricsUpdater.scala
@@ -25,6 +25,7 @@ case class InputIteratorMetricsUpdater(metrics: Map[String, SQLMetric], forBroad
       val operatorMetrics = opMetrics.asInstanceOf[OperatorMetrics]
       metrics("cpuCount") += operatorMetrics.cpuCount
       metrics("wallNanos") += operatorMetrics.wallNanos
+      metrics("cpuNanos") += operatorMetrics.cpuNanos
       if (!forBroadcast) {
         if (operatorMetrics.outputRows == 0 && operatorMetrics.outputVectors == 0) {
           // Sometimes, velox does not update metrics for intermediate operator,

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -273,7 +273,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
       env,
       metricsBuilderClass,
       "<init>",
-      "([J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[JLjava/lang/String;)V");
+      "([J[J[J[J[J[J[J[J[J[J[JJ[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[J[JLjava/lang/String;)V");
 
   nativeColumnarToRowInfoClass =
       createGlobalClassReferenceOrError(env, "Lorg/apache/gluten/vectorized/NativeColumnarToRowInfo;");
@@ -578,6 +578,7 @@ JNIEXPORT jobject JNICALL Java_org_apache_gluten_metrics_IteratorMetricsJniWrapp
       longArray[Metrics::kOutputBytes],
       longArray[Metrics::kCpuCount],
       longArray[Metrics::kWallNanos],
+      longArray[Metrics::kCpuNanos],
       metrics ? metrics->veloxToArrow : -1,
       longArray[Metrics::kPeakMemoryBytes],
       longArray[Metrics::kNumMemoryAllocations],

--- a/cpp/core/utils/Metrics.h
+++ b/cpp/core/utils/Metrics.h
@@ -52,6 +52,7 @@ struct Metrics {
     // CpuWallTiming.
     kCpuCount,
     kWallNanos,
+    kCpuNanos,
 
     kPeakMemoryBytes,
     kNumMemoryAllocations,

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -457,6 +457,7 @@ void WholeStageResultIterator::collectMetrics() {
       metrics_->get(Metrics::kOutputBytes)[metricIndex] = 0;
       metrics_->get(Metrics::kCpuCount)[metricIndex] = 0;
       metrics_->get(Metrics::kWallNanos)[metricIndex] = 0;
+      metrics_->get(Metrics::kCpuNanos)[metricIndex] = 0;
       metrics_->get(Metrics::kPeakMemoryBytes)[metricIndex] = 0;
       metrics_->get(Metrics::kNumMemoryAllocations)[metricIndex] = 0;
       metricIndex += 1;
@@ -477,6 +478,7 @@ void WholeStageResultIterator::collectMetrics() {
       metrics_->get(Metrics::kOutputBytes)[metricIndex] = second->outputBytes;
       metrics_->get(Metrics::kCpuCount)[metricIndex] = second->cpuWallTiming.count;
       metrics_->get(Metrics::kWallNanos)[metricIndex] = second->cpuWallTiming.wallNanos;
+      metrics_->get(Metrics::kCpuNanos)[metricIndex] = second->cpuWallTiming.cpuNanos;
       metrics_->get(Metrics::kPeakMemoryBytes)[metricIndex] = second->peakMemoryBytes;
       metrics_->get(Metrics::kNumMemoryAllocations)[metricIndex] = second->numMemoryAllocations;
       metrics_->get(Metrics::kSpilledInputBytes)[metricIndex] = second->spilledInputBytes;


### PR DESCRIPTION
## Summary
  Surfaces Velox's `cpuWallTiming.cpuNanos` as a separate Spark SQL metric (`cpu time`) on `InputIteratorTransformer`. Currently only `wallNanos` and `cpuCount` are exposed — `cpuNanos` is available from Velox but not propagated to Gluten. This change threads it through: C++ → JNI → Java → Scala SQLMetric. The metric automatically appears in Spark UI and event logs.

  ## Motivation
  Related to #10618. `InputIteratorTransformer` sits at the boundary between Spark (shuffle/broadcast) and Velox. Its wall time includes I/O waits, not just CPU work. Exposing `cpuNanos` separately lets users distinguish compute-bound vs I/O-bound bottlenecks. For most other operators, `cpuNanos ≈ wallNanos` — this boundary operator is where they diverge the most.

Velox already tracks `cpuNanos` on every operator — exposing it as-is is the simplest approach and better than not surfacing CPU time at all.

  ## Open questions
  - Any concerns with the metric name / label (`cpu time`)?
  - Should any other operators also expose `cpuNanos`? (e.g., operators that spill to disk)

  Tests will be added once the approach is confirmed.


Related issue: #8063