### PR TITLE
[FLINK] Replace LinkedList with ArrayDeque and pre-size HashSet in Flink module

### DIFF
--- a/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/Utils.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/Utils.java
@@ -84,7 +84,7 @@ public class Utils {
       io.github.zhztheplayer.velox4j.type.RowType inputType,
       int[] joinKeys,
       List<int[]> upsertKeys) {
-    Set<Integer> joinKeySet = new HashSet();
+    Set<Integer> joinKeySet = new HashSet<>(joinKeys.length, 1.0f);
     Arrays.stream(joinKeys).forEach(joinKeySet::add);
     List<int[]> uniqueKeysContainedByJoinKey =
         upsertKeys.stream()

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/vectorized/VLVectorIterator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/vectorized/VLVectorIterator.java
@@ -18,17 +18,17 @@ package org.apache.gluten.vectorized;
 
 import io.github.zhztheplayer.velox4j.data.RowVector;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
 
 /** Iterator for velox RowVector. */
 public class VLVectorIterator implements Iterator<RowVector> {
 
-  private final List<RowVector> rows;
+  private final Deque<RowVector> rows;
 
   public VLVectorIterator() {
-    this.rows = new LinkedList<>();
+    this.rows = new ArrayDeque<>();
   }
 
   public boolean hasNext() {
@@ -39,7 +39,7 @@ public class VLVectorIterator implements Iterator<RowVector> {
     if (!hasNext()) {
       return null;
     }
-    return rows.remove(0);
+    return rows.removeFirst();
   }
 
   public void addRow(RowVector row) {


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR makes minor collection improvements in Flink by replacing `LinkedList` with `ArrayDeque` for the internal row buffer - provides O(1) for `add` at tail, `remove(0)` from head with better cache locality than `LinkedList` which allocates a separate node object per element, and using pre-size `HashSet` in `analyzeJoinKeys`  to avoid rehashing when the key count exceeds the default capacity (16 initial capacity x 0.75 load factor = rehash after 12 elements).

## How was this patch tested?
Existing UTs

## Was this patch authored or co-authored using generative AI tooling?
No
