### PR TITLE
 [CORE] Return unmodifiable Set from ConsistentHash.getPartition()

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
+++ b/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
@@ -162,7 +162,8 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
   public Set<Partition<T>> getPartition(T node) {
     lock.readLock().lock();
     try {
-      return nodes.get(node);
+      Set<Partition<T>> partitions = nodes.get(node);
+      return partitions == null ? null : Collections.unmodifiableSet(partitions);
     } finally {
       lock.readLock().unlock();
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?
`ConsistentHash` is annotated with `@ThreadSafe` and guards all access with a `ReadWriteLock` but `getPartition()` returns a direct reference to the internal mutable `HashSet`. This PR wraps the returned set with `Collections.unmodifiableSet()` similar to `getNodes()` which already returns a copy.

## How was this patch tested?
Existing UTs

## Was this patch authored or co-authored using generative AI tooling?
No
