### PR TITLE
[GLUTEN-11749][VL] Throw exception if cannot get the pre-built hash table from ObjectStore correctly

### DIFF
--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -79,9 +79,6 @@ const std::string kVeloxSplitPreloadPerDriver = "spark.gluten.sql.columnar.backe
 const std::string kHashProbeDynamicFilterPushdownEnabled =
     "spark.gluten.sql.columnar.backend.velox.hashProbe.dynamicFilterPushdown.enabled";
 
-const std::string kHashTableBuildOncePerExecutor = "spark.gluten.velox.buildHashTableOncePerExecutor.enabled";
-const bool kHashTableBuildOncePerExecutorDefault = true;
-
 const std::string kHashProbeBloomFilterPushdownMaxSize =
     "spark.gluten.sql.columnar.backend.velox.hashProbe.bloomFilterPushdown.maxSize";
 

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -79,6 +79,9 @@ const std::string kVeloxSplitPreloadPerDriver = "spark.gluten.sql.columnar.backe
 const std::string kHashProbeDynamicFilterPushdownEnabled =
     "spark.gluten.sql.columnar.backend.velox.hashProbe.dynamicFilterPushdown.enabled";
 
+const std::string kHashTableBuildOncePerExecutor = "spark.gluten.velox.buildHashTableOncePerExecutor.enabled";
+const bool kHashTableBuildOncePerExecutorDefault = true;
+
 const std::string kHashProbeBloomFilterPushdownMaxSize =
     "spark.gluten.sql.columnar.backend.velox.hashProbe.bloomFilterPushdown.maxSize";
 

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -399,24 +399,32 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   } else if (
       sJoin.has_advanced_extension() &&
       SubstraitParser::configSetInOptimization(sJoin.advanced_extension(), "isBHJ=")) {
+    bool hashTableBuildOncePerExecutorEnabled =
+        veloxCfg_->get<bool>(kHashTableBuildOncePerExecutor, kHashTableBuildOncePerExecutorDefault);
+
     std::string hashTableId = sJoin.hashtableid();
 
     std::shared_ptr<core::OpaqueHashTable> opaqueSharedHashTable = nullptr;
     bool joinHasNullKeys = false;
 
-    try {
-      auto hashTableBuilder = ObjectStore::retrieve<gluten::HashTableBuilder>(getJoin(hashTableId));
-      joinHasNullKeys = hashTableBuilder->joinHasNullKeys();
-      auto originalShared = hashTableBuilder->hashTable();
-      opaqueSharedHashTable = std::shared_ptr<core::OpaqueHashTable>(
-          originalShared, reinterpret_cast<core::OpaqueHashTable*>(originalShared.get()));
+    if (hashTableBuildOncePerExecutorEnabled) {
+      std::cout << "the hashTableBuildOncePerExecutorEnabled is set" << "\n";
+      try {
+        auto hashTableBuilder = ObjectStore::retrieve<gluten::HashTableBuilder>(getJoin(hashTableId));
+        joinHasNullKeys = hashTableBuilder->joinHasNullKeys();
+        auto originalShared = hashTableBuilder->hashTable();
+        opaqueSharedHashTable = std::shared_ptr<core::OpaqueHashTable>(
+            originalShared, reinterpret_cast<core::OpaqueHashTable*>(originalShared.get()));
 
-      LOG(INFO) << "Successfully retrieved and aliased HashTable for reuse. ID: " << hashTableId;
-    } catch (const std::exception& e) {
-      LOG(WARNING)
-          << "Error retrieving HashTable from ObjectStore: " << e.what()
-          << ". Falling back to building new table. To ensure correct results, please verify that spark.gluten.velox.buildHashTableOncePerExecutor.enabled is set to false.";
-      opaqueSharedHashTable = nullptr;
+        LOG(INFO) << "Successfully retrieved and aliased HashTable for reuse. ID: " << hashTableId;
+      } catch (const std::exception& e) {
+        throw GlutenException(
+            "Error retrieving HashTable from ObjectStore: " + std::string(e.what()) +
+            " You can set spark.gluten.velox.buildHashTableOncePerExecutor.enabled"
+            " to false as workaround.");
+      }
+    } else {
+      std::cout << "the hashTableBuildOncePerExecutorEnabled is false" << "\n";
     }
 
     // Create HashJoinNode node

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -400,7 +400,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
       sJoin.has_advanced_extension() &&
       SubstraitParser::configSetInOptimization(sJoin.advanced_extension(), "isBHJ=")) {
     bool hashTableBuildOncePerExecutorEnabled =
-        veloxCfg_->get<bool>(kHashTableBuildOncePerExecutor, kHashTableBuildOncePerExecutorDefault);
+        SubstraitParser::configSetInOptimization(
+            sJoin.advanced_extension(), "isHashTableBuildOncePerExecutor=");
 
     std::string hashTableId = sJoin.hashtableid();
 
@@ -408,7 +409,6 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
     bool joinHasNullKeys = false;
 
     if (hashTableBuildOncePerExecutorEnabled) {
-      std::cout << "the hashTableBuildOncePerExecutorEnabled is set" << "\n";
       try {
         auto hashTableBuilder = ObjectStore::retrieve<gluten::HashTableBuilder>(getJoin(hashTableId));
         joinHasNullKeys = hashTableBuilder->joinHasNullKeys();
@@ -423,8 +423,6 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
             " You can set spark.gluten.velox.buildHashTableOncePerExecutor.enabled"
             " to false as workaround.");
       }
-    } else {
-      std::cout << "the hashTableBuildOncePerExecutorEnabled is false" << "\n";
     }
 
     // Create HashJoinNode node

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
@@ -282,6 +282,12 @@ trait HashJoinLikeExecTransformer extends BaseJoinExec with TransformSupport {
     // isBHJ: 0 for SHJ, 1 for BHJ
     // isNullAwareAntiJoin: 0 for false, 1 for true
     // buildHashTableId: the unique id for the hash table of build plan
+    val isHashTableBuildOncePerExecutor =
+      if (
+        BackendsApiManager.getSettings.enableHashTableBuildOncePerExecutor() &&
+        GlutenConfig.get.enableColumnarBroadcastExchange
+      ) { 1 }
+      else 0
     joinParametersStr
       .append("isBHJ=")
       .append(isBHJ)
@@ -293,12 +299,7 @@ trait HashJoinLikeExecTransformer extends BaseJoinExec with TransformSupport {
       .append(buildHashTableId)
       .append("\n")
       .append("isHashTableBuildOncePerExecutor=")
-      .append(
-        if (
-          BackendsApiManager.getSettings.enableHashTableBuildOncePerExecutor() &&
-          GlutenConfig.get.enableColumnarBroadcastExchange
-        ) 1
-        else 0)
+      .append(isHashTableBuildOncePerExecutor)
       .append("\n")
       .append("isExistenceJoin=")
       .append(if (joinType.isInstanceOf[ExistenceJoin]) 1 else 0)

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/JoinExecTransformer.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.expression._
 import org.apache.gluten.metrics.MetricsUpdater
 import org.apache.gluten.sql.shims.SparkShimLoader
@@ -290,6 +291,14 @@ trait HashJoinLikeExecTransformer extends BaseJoinExec with TransformSupport {
       .append("\n")
       .append("buildHashTableId=")
       .append(buildHashTableId)
+      .append("\n")
+      .append("isHashTableBuildOncePerExecutor=")
+      .append(
+        if (
+          BackendsApiManager.getSettings.enableHashTableBuildOncePerExecutor() &&
+          GlutenConfig.get.enableColumnarBroadcastExchange
+        ) 1
+        else 0)
       .append("\n")
       .append("isExistenceJoin=")
       .append(if (joinType.isInstanceOf[ExistenceJoin]) 1 else 0)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
When enabling `HashTableBuildOncePerExecutor`, we need use the pre-built hash table. If not, it should throw exception directly.
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->


Related issue: #11749