### PR TITLE
[CORE] optimize driver heap memory by lazily store metadata columns and fix mismatch result when input_file_name is only in filter condition

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
@@ -161,7 +161,10 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
         val fileSizes = new JArrayList[JLong]()
         val modificationTimes = new JArrayList[JLong]()
         val partitionColumns = new JArrayList[JMap[String, String]]
-        val metadataColumns = new JArrayList[JMap[String, String]]
+        val needMetadataColumns = metadataColumnNames != null && metadataColumnNames.nonEmpty
+        val emptyMetadataColumn: JMap[String, String] =
+          java.util.Collections.emptyMap[String, String]()
+        val metadataColumns = new JArrayList[JMap[String, String]](f.files.length)
         val otherMetadataColumns = new JArrayList[JMap[String, Object]]
         val dateFormatter = DateFormatter()
         val timestampFormatter = TimestampFormatter.getFractionFormatter(ZoneOffset.UTC)
@@ -171,9 +174,13 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
             starts.add(JLong.valueOf(file.start))
             lengths.add(JLong.valueOf(file.length))
             val metadataColumn =
-              SparkShimLoader.getSparkShims
-                .generateMetadataColumns(file, metadataColumnNames)
-                .asJava
+              if (needMetadataColumns) {
+                SparkShimLoader.getSparkShims
+                  .generateMetadataColumns(file, metadataColumnNames)
+                  .asJava
+              } else {
+                emptyMetadataColumn
+              }
             metadataColumns.add(metadataColumn)
             val partitionColumn = new JHashMap[String, String]()
             for (i <- 0 until file.partitionValues.numFields) {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -91,9 +91,19 @@ class VeloxIteratorApi extends IteratorApi with Logging {
       .unzip
 
     val partitionColumns = getPartitionColumns(partitionSchema, partitionFiles)
-    val metadataColumns = partitionFiles
-      .map(
-        f => SparkShimLoader.getSparkShims.generateMetadataColumns(f, metadataColumnNames).asJava)
+    val needMetadataColumns = metadataColumnNames != null && metadataColumnNames.nonEmpty
+    val emptyMetadataColumn: java.util.Map[String, String] =
+      java.util.Collections.emptyMap[String, String]()
+    val metadataColumns: java.util.List[java.util.Map[String, String]] =
+      if (needMetadataColumns) {
+        partitionFiles
+          .map(
+            f =>
+              SparkShimLoader.getSparkShims.generateMetadataColumns(f, metadataColumnNames).asJava)
+          .asJava
+      } else {
+        java.util.Collections.nCopies(partitionFiles.size, emptyMetadataColumn)
+      }
     val otherMetadataColumns = partitionFiles
       .map(f => SparkShimLoader.getSparkShims.getOtherConstantMetadataColumnValues(f))
 
@@ -106,7 +116,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
         fileSizes.asJava,
         modificationTimes.asJava,
         partitionColumns.map(_.asJava).asJava,
-        metadataColumns.asJava,
+        metadataColumns,
         fileFormat,
         locations.toList.asJava,
         mapAsJavaMap(properties),

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BasicScanExecTransformer.scala
@@ -112,6 +112,18 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
       case _ => Seq(partition)
     }
 
+    val metadataFromSpark = getMetadataColumns().map(_.name)
+
+    val inputFileRelatedMetadataKeys = Seq(
+      InputFileName().prettyName,
+      InputFileBlockStart().prettyName,
+      InputFileBlockLength().prettyName)
+
+    val neededInputFileRelatedMetadataKeys =
+      inputFileRelatedMetadataKeys.filter(k => output.exists(_.name == k))
+
+    val metadataColumnNames = (metadataFromSpark ++ neededInputFileRelatedMetadataKeys).distinct
+
     BackendsApiManager.getIteratorApiInstance
       .genSplitInfo(
         partition.index,
@@ -119,7 +131,7 @@ trait BasicScanExecTransformer extends LeafTransformSupport with BaseDataSource 
         getPartitionSchema,
         getDataSchema,
         readFileFormat,
-        getMetadataColumns().map(_.name),
+        metadataColumnNames,
         getProperties)
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PushDownInputFileExpression.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PushDownInputFileExpression.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.execution.{BatchScanExecTransformerBase, FileSourceScan
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, NamedExpression}
 import org.apache.spark.sql.catalyst.optimizer.CollapseProjectShim
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{DeserializeToObjectExec, FileSourceScanExec, LeafExecNode, ProjectExec, SerializeFromObjectExec, SparkPlan, UnionExec}
+import org.apache.spark.sql.execution.{DeserializeToObjectExec, FileSourceScanExec, FilterExec, LeafExecNode, ProjectExec, SerializeFromObjectExec, SparkPlan, UnionExec}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
@@ -96,6 +96,12 @@ object PushDownInputFileExpression {
         }
         val newChild = addMetadataCol(child, replacedExprs)
         ProjectExec(newProjectList, newChild)
+      case f @ FilterExec(condition, child)
+          if containsInputFileRelatedExpr(condition) && hasInputFileRelatedSource(child) =>
+        val replacedExprs = mutable.Map[String, Alias]()
+        val newCondition = rewriteExpr(condition, replacedExprs)
+        val newChild = addMetadataCol(child, replacedExprs)
+        ProjectExec(f.output, FilterExec(newCondition, newChild))
     }
 
     private def addMetadataCol(

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
@@ -97,4 +97,19 @@ class GlutenColumnExpressionSuite extends ColumnExpressionSuite with GlutenSQLTe
       }
     }
   }
+
+  test("scan filter references input_file_name but project does not select it") {
+    withTempPath {
+      dir =>
+        val data = sparkContext.parallelize(0 to 10).toDF("id")
+        data.write.parquet(dir.getCanonicalPath)
+
+        // Filter references input_file_name(), but the project only selects `id`.
+        val q = spark.read
+          .parquet(dir.getCanonicalPath)
+          .filter(input_file_name().contains("parquet"))
+          .select($"id")
+        checkAnswer(q, (0 to 10).map(Row(_)))
+    }
+  }
 }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
@@ -97,4 +97,19 @@ class GlutenColumnExpressionSuite extends ColumnExpressionSuite with GlutenSQLTe
       }
     }
   }
+
+  test("scan filter references input_file_name but project does not select it") {
+    withTempPath {
+      dir =>
+        val data = sparkContext.parallelize(0 to 10).toDF("id")
+        data.write.parquet(dir.getCanonicalPath)
+
+        // Filter references input_file_name(), but the project only selects `id`.
+        val q = spark.read
+          .parquet(dir.getCanonicalPath)
+          .filter(input_file_name().contains("parquet"))
+          .select($"id")
+        checkAnswer(q, (0 to 10).map(Row(_)))
+    }
+  }
 }

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
@@ -100,4 +100,19 @@ class GlutenColumnExpressionSuite extends ColumnExpressionSuite with GlutenSQLTe
       }
     }
   }
+
+  test("scan filter references input_file_name but project does not select it") {
+    withTempPath {
+      dir =>
+        val data = sparkContext.parallelize(0 to 10).toDF("id")
+        data.write.parquet(dir.getCanonicalPath)
+
+        // Filter references input_file_name(), but the project only selects `id`.
+        val q = spark.read
+          .parquet(dir.getCanonicalPath)
+          .filter(input_file_name().contains("parquet"))
+          .select($"id")
+        checkAnswer(q, (0 to 10).map(Row(_)))
+    }
+  }
 }

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenColumnExpressionSuite.scala
@@ -100,4 +100,19 @@ class GlutenColumnExpressionSuite extends ColumnExpressionSuite with GlutenSQLTe
       }
     }
   }
+
+  test("scan filter references input_file_name but project does not select it") {
+    withTempPath {
+      dir =>
+        val data = sparkContext.parallelize(0 to 10).toDF("id")
+        data.write.parquet(dir.getCanonicalPath)
+
+        // Filter references input_file_name(), but the project only selects `id`.
+        val q = spark.read
+          .parquet(dir.getCanonicalPath)
+          .filter(input_file_name().contains("parquet"))
+          .select($"id")
+        checkAnswer(q, (0 to 10).map(Row(_)))
+    }
+  }
 }

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -171,33 +171,12 @@ trait SparkShims {
   def generateMetadataColumns(
       file: PartitionedFile,
       metadataColumnNames: Seq[String] = Seq.empty): Map[String, String] = {
-    if (metadataColumnNames == null || metadataColumnNames.isEmpty) {
-      return Map.empty
-    }
-
-    val inputFileName = InputFileName().prettyName
-    val inputFileBlockStart = InputFileBlockStart().prettyName
-    val inputFileBlockLength = InputFileBlockLength().prettyName
-
-    if (
-      !metadataColumnNames.contains(inputFileName) &&
-      !metadataColumnNames.contains(inputFileBlockStart) &&
-      !metadataColumnNames.contains(inputFileBlockLength)
-    ) {
-      return Map.empty
-    }
-
-    var metadataColumn = Map.empty[String, String]
-    if (metadataColumnNames.contains(inputFileName)) {
-      metadataColumn += (inputFileName -> file.filePath.toString)
-    }
-    if (metadataColumnNames.contains(inputFileBlockStart)) {
-      metadataColumn += (inputFileBlockStart -> file.start.toString)
-    }
-    if (metadataColumnNames.contains(inputFileBlockLength)) {
-      metadataColumn += (inputFileBlockLength -> file.length.toString)
-    }
-    metadataColumn
+    val requested = metadataColumnNames.toSet
+    Seq(
+      InputFileName().prettyName -> file.filePath.toString,
+      InputFileBlockStart().prettyName -> file.start.toString,
+      InputFileBlockLength().prettyName -> file.length.toString
+    ).collect { case (name, value) if requested.contains(name) => name -> value }.toMap
   }
 
   // For compatibility with Spark-3.5.

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -171,11 +171,33 @@ trait SparkShims {
   def generateMetadataColumns(
       file: PartitionedFile,
       metadataColumnNames: Seq[String] = Seq.empty): Map[String, String] = {
-    Map(
-      InputFileName().prettyName -> file.filePath.toString,
-      InputFileBlockStart().prettyName -> file.start.toString,
-      InputFileBlockLength().prettyName -> file.length.toString
-    )
+    if (metadataColumnNames == null || metadataColumnNames.isEmpty) {
+      return Map.empty
+    }
+
+    val inputFileName = InputFileName().prettyName
+    val inputFileBlockStart = InputFileBlockStart().prettyName
+    val inputFileBlockLength = InputFileBlockLength().prettyName
+
+    if (
+      !metadataColumnNames.contains(inputFileName) &&
+      !metadataColumnNames.contains(inputFileBlockStart) &&
+      !metadataColumnNames.contains(inputFileBlockLength)
+    ) {
+      return Map.empty
+    }
+
+    var metadataColumn = Map.empty[String, String]
+    if (metadataColumnNames.contains(inputFileName)) {
+      metadataColumn += (inputFileName -> file.filePath.toString)
+    }
+    if (metadataColumnNames.contains(inputFileBlockStart)) {
+      metadataColumn += (inputFileBlockStart -> file.start.toString)
+    }
+    if (metadataColumnNames.contains(inputFileBlockLength)) {
+      metadataColumn += (inputFileBlockLength -> file.length.toString)
+    }
+    metadataColumn
   }
 
   // For compatibility with Spark-3.5.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?


When scanning tens of millions of files, the driver may run out of heap memory during split construction.

Currently we always generate per-file metadata maps (InputFileName / InputFileBlockStart / InputFileBlockLength) for each split, even if the query does not reference these metadata columns. This causes a large number of `HashMap` instances to be kept in memory and may trigger OOM in the planner.




<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

New ut.

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: trae

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
