### PR TITLE
[CORE] Preserve original Java exceptions across JNI boundary

### DIFF
--- a/cpp/core/jni/JniCommon.h
+++ b/cpp/core/jni/JniCommon.h
@@ -48,6 +48,54 @@ static inline std::string jStringToCString(JNIEnv* env, jstring string) {
   return result;
 }
 
+// A C++ exception that carries an original Java throwable through native code.
+// When caught by JNI_METHOD_END, the original Java exception is rethrown via
+// env->Throw() instead of being replaced by a new GlutenException.
+// The jthrowable is a JNI local reference, which remains valid as long as we
+// are within the same native method frame which is before JNI_METHOD_END returns).
+class JniPendingException : public std::runtime_error {
+ public:
+  JniPendingException(jthrowable javaThrowable, const std::string& message)
+      : std::runtime_error(message), javaThrowable_(javaThrowable) {}
+
+  jthrowable javaThrowable() const {
+    return javaThrowable_;
+  }
+
+ private:
+  jthrowable javaThrowable_;
+};
+
+// Thread-local storage for the original Java throwable from a JNI callback exception.
+//
+// When checkException() detects a pending Java exception, it stores the jthrowable
+// here as a backup before throwing JniPendingException. This is needed because Velox's
+// internal exception handlers (e.g., CALL_OPERATOR in Driver.cpp) catch std::exception
+// and re-wrap it as VeloxRuntimeError, destroying the JniPendingException and its
+// jthrowable. The thread-local survives this re-wrapping, so JNI_METHOD_END can
+// recover the original Java exception from here as a fallback.
+//
+// The inline function with static thread_local ensures a single variable per thread
+// across all translation units (C++17 guarantee).
+inline jthrowable& pendingCallbackException() {
+  static thread_local jthrowable value = nullptr;
+  return value;
+}
+
+static inline void storePendingCallbackException(jthrowable t) {
+  pendingCallbackException() = t;
+}
+
+static inline jthrowable takePendingCallbackException() {
+  jthrowable t = pendingCallbackException();
+  pendingCallbackException() = nullptr;
+  return t;
+}
+
+static inline void clearPendingCallbackException() {
+  pendingCallbackException() = nullptr;
+}
+
 static inline void checkException(JNIEnv* env) {
   if (env->ExceptionCheck()) {
     jthrowable t = env->ExceptionOccurred();
@@ -73,7 +121,9 @@ static inline void checkException(JNIEnv* env) {
       }
     }
 
-    throw gluten::GlutenException(message.str());
+    // Store in thread-local as a backup before throwing.
+    storePendingCallbackException(t);
+    throw JniPendingException(t, message.str());
   }
 }
 

--- a/cpp/core/jni/JniError.h
+++ b/cpp/core/jni/JniError.h
@@ -23,16 +23,28 @@
 #include "utils/Exception.h"
 
 #ifndef JNI_METHOD_START
-#define JNI_METHOD_START try {
+#define JNI_METHOD_START           \
+  clearPendingCallbackException(); \
+  try {
 // macro ended
 #endif
 
 #ifndef JNI_METHOD_END
-#define JNI_METHOD_END(fallback_expr)                                            \
-  }                                                                              \
-  catch (std::exception & e) {                                                   \
-    env->ThrowNew(gluten::getJniErrorState()->glutenExceptionClass(), e.what()); \
-    return fallback_expr;                                                        \
+#define JNI_METHOD_END(fallback_expr)                                              \
+  }                                                                                \
+  catch (JniPendingException & e) {                                                \
+    clearPendingCallbackException();                                               \
+    env->Throw(e.javaThrowable());                                                 \
+    return fallback_expr;                                                          \
+  }                                                                                \
+  catch (std::exception & e) {                                                     \
+    jthrowable original = takePendingCallbackException();                          \
+    if (original) {                                                                \
+      env->Throw(original);                                                        \
+    } else {                                                                       \
+      env->ThrowNew(gluten::getJniErrorState()->glutenExceptionClass(), e.what()); \
+    }                                                                              \
+    return fallback_expr;                                                          \
   }
 // macro ended
 #endif

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ColumnarBatchOutIterator.java
@@ -145,6 +145,12 @@ public class ColumnarBatchOutIterator extends ClosableIterator<ColumnarBatch>
 
   @Override
   protected RuntimeException translateException(Exception e) {
+    // If the exception is already a RuntimeException that originated from Java
+    // (preserved across the JNI boundary), return it as is so that the original
+    // exception type and error condition codes are not lost.
+    if (e instanceof RuntimeException && !(e instanceof GlutenException)) {
+      return (RuntimeException) e;
+    }
     String msg = findFirstNonNullMessage(e);
     if (msg != null) {
       RuntimeException schemaEx = translateToSchemaException(msg);
@@ -152,6 +158,9 @@ public class ColumnarBatchOutIterator extends ClosableIterator<ColumnarBatch>
         schemaEx.initCause(e);
         return schemaEx;
       }
+    }
+    if (e instanceof RuntimeException) {
+      return (RuntimeException) e;
     }
     return new GlutenException(e);
   }

--- a/gluten-core/src/main/java/org/apache/gluten/iterator/ClosableIterator.java
+++ b/gluten-core/src/main/java/org/apache/gluten/iterator/ClosableIterator.java
@@ -67,8 +67,14 @@ public abstract class ClosableIterator<T> implements AutoCloseable, Serializable
   /**
    * Translates a native exception into an appropriate Java exception. Subclasses can override this
    * to translate backend-specific exceptions into Spark-compatible exceptions.
+   *
+   * <p>If the exception is already a RuntimeException that did not originate from native code it is
+   * preserved as is.
    */
   protected RuntimeException translateException(Exception e) {
+    if (e instanceof RuntimeException) {
+      return (RuntimeException) e;
+    }
     return new GlutenException(e);
   }
 }

--- a/gluten-core/src/test/scala/org/apache/gluten/iterator/IteratorSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/iterator/IteratorSuite.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.iterator
 
+import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.iterator.Iterators.{V1, WrapperBuilder}
 
 import org.apache.spark.task.TaskResources
@@ -133,5 +134,67 @@ abstract class IteratorSuite extends AnyFunSuite {
     wrapped.next
     assert(hasNextCallCount == 2)
     assert(nextCallCount == 2)
+  }
+}
+
+/**
+ * Tests that ClosableIterator preserves RuntimeException subclasses as is and wraps checked
+ * exceptions in GlutenException.
+ */
+class ClosableIteratorSuite extends AnyFunSuite {
+
+  test("RuntimeException from hasNext0 propagates as-is") {
+    val ex = new ArithmeticException("overflow")
+    val itr = new ClosableIterator[Int] {
+      override protected def hasNext0(): Boolean = throw ex
+      override protected def next0(): Int = 0
+      override protected def close0(): Unit = {}
+    }
+    val caught = intercept[ArithmeticException](itr.hasNext)
+    assert(caught eq ex)
+  }
+
+  test("RuntimeException from next0 propagates as-is") {
+    val ex = new IllegalStateException("bad state")
+    val itr = new ClosableIterator[Int] {
+      override protected def hasNext0(): Boolean = true
+      override protected def next0(): Int = throw ex
+      override protected def close0(): Unit = {}
+    }
+    val caught = intercept[IllegalStateException](itr.next())
+    assert(caught eq ex)
+  }
+
+  test("GlutenException from hasNext0 propagates as-is") {
+    val ex = new GlutenException("gluten error")
+    val itr = new ClosableIterator[Int] {
+      override protected def hasNext0(): Boolean = throw ex
+      override protected def next0(): Int = 0
+      override protected def close0(): Unit = {}
+    }
+    val caught = intercept[GlutenException](itr.hasNext)
+    assert(caught eq ex)
+  }
+
+  test("Checked exception from hasNext0 is wrapped in GlutenException") {
+    val ioEx = new java.io.IOException("io error")
+    val itr = new ClosableIterator[Int] {
+      override protected def hasNext0(): Boolean = throw ioEx
+      override protected def next0(): Int = 0
+      override protected def close0(): Unit = {}
+    }
+    val caught = intercept[GlutenException](itr.hasNext)
+    assert(caught.getCause eq ioEx)
+  }
+
+  test("Checked exception from next0 is wrapped in GlutenException") {
+    val ioEx = new java.io.IOException("io error")
+    val itr = new ClosableIterator[Int] {
+      override protected def hasNext0(): Boolean = true
+      override protected def next0(): Int = throw ioEx
+      override protected def close0(): Unit = {}
+    }
+    val caught = intercept[GlutenException](itr.next())
+    assert(caught.getCause eq ioEx)
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Java-side exceptions thrown during native callbacks (e.g. `SparkRuntimeException`) were serialized to strings and rethrown as `GlutenException`, losing the original exception type and error condition codes.

 This PR adds `JniPendingException` to carry the original `jthrowable` through C++ code, with a thread local fallback for when Velox's internal handlers (Driver.cpp CALL_OPERATOR, Expr.cpp) rewrap the C++ exception as `VeloxRuntimeError`. `JNI_METHOD_END` recovers the original throwable from either path and rethrows it via `env->Throw()`. Java-side `translateException()` is updated to preserve non GlutenException RuntimeExceptions.

## How was this patch tested?
Added UTs

## Was this patch authored or co-authored using generative AI tooling?

Assisted-by: GitHub Copilot 1.0.18

Related issue #11912 