### PR TITLE
[VL] Ignore null values when copy velox string buffer to arrow

### DIFF
--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -111,7 +111,7 @@ arrow::Status collectFlatVectorBufferStringView(
   auto* rawLength = reinterpret_cast<gluten::StringLengthType*>(lengthBuffer->mutable_data());
   uint64_t offset = 0;
   for (int32_t i = 0; i < flatVector->size(); i++) {
-    auto length = rawValues[i].size();
+    auto length = flatVector->isNullAt(i) ? 0 : rrawValues[i].size();
     *rawLength++ = length;
     offset += length;
   }
@@ -120,6 +120,9 @@ arrow::Status collectFlatVectorBufferStringView(
   ARROW_ASSIGN_OR_RAISE(auto valueBuffer, arrow::AllocateResizableBuffer(offset, pool));
   auto raw = reinterpret_cast<char*>(valueBuffer->mutable_data());
   for (int32_t i = 0; i < flatVector->size(); i++) {
+    if (flatVector->isNullAt(i)) {
+      continue;
+    }
     gluten::fastCopy(raw, rawValues[i].data(), rawValues[i].size());
     raw += rawValues[i].size();
   }

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -111,7 +111,7 @@ arrow::Status collectFlatVectorBufferStringView(
   auto* rawLength = reinterpret_cast<gluten::StringLengthType*>(lengthBuffer->mutable_data());
   uint64_t offset = 0;
   for (int32_t i = 0; i < flatVector->size(); i++) {
-    auto length = flatVector->isNullAt(i) ? 0 : rrawValues[i].size();
+    auto length = flatVector->isNullAt(i) ? 0 : rawValues[i].size();
     *rawLength++ = length;
     offset += length;
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bug fix for VeloxHashShuffleWriter.
Description:
* `VeloxHashShuffleWriter::write()` method will try to convert the input velox flat vectors into Arrow buffer.
* For StringView vectors, `VeloxHashShuffleWriter` calculates the total size of all input StringViews, and initializes the Arrow buffer accordingly.
* For null values, we do not actually need to copy the dirty values into Arrow buffers, thereby saving execution memory.

Test logs in our productions:
```log
I20260415 17:50:28.520978  5474 VeloxHashShuffleWriter.cc:156] collectFlatVectorBufferStringView for VARCHAR
I20260415 17:50:28.521070  5474 VeloxHashShuffleWriter.cc:110] DEBUG, lengthBufferSize = 40, flatVector->size() = 10
I20260415 17:50:28.521078  5474 VeloxHashShuffleWriter.cc:114] DEBUG flatVector = [FLAT VARCHAR: 10 elements, 9 nulls] data: 0: null
1: null
2: null
3: 114535255
4: null
5: null
6: null
7: null
8: null
I20260415 17:50:28.521092  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 0, isNull = true, rawValues[i].size() = 1957213616, length = 0,  offset = 0
I20260415 17:50:28.521100  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 1, isNull = true, rawValues[i].size() = 2588080704, length = 0,  offset = 0
I20260415 17:50:28.521106  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 2, isNull = true, rawValues[i].size() = 2706762760, length = 0,  offset = 0
I20260415 17:50:28.521111  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 3, isNull = false, rawValues[i].size() = 9, length = 9,  offset = 9
I20260415 17:50:28.521117  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 4, isNull = true, rawValues[i].size() = 0, length = 0,  offset = 9
I20260415 17:50:28.521122  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 5, isNull = true, rawValues[i].size() = 1, length = 0,  offset = 9
I20260415 17:50:28.521127  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 6, isNull = true, rawValues[i].size() = 2832791872, length = 0,  offset = 9
I20260415 17:50:28.521132  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 7, isNull = true, rawValues[i].size() = 2588222376, length = 0,  offset = 9
I20260415 17:50:28.521138  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 8, isNull = true, rawValues[i].size() = 0, length = 0,  offset = 9
I20260415 17:50:28.521143  5474 VeloxHashShuffleWriter.cc:120] DEBUG flatVector dump, i = 9, isNull = true, rawValues[i].size() = 0, length = 0,  offset = 9
```


## How was this patch tested?

Tested in out production environment.

## Was this patch authored or co-authored using generative AI tooling?

No