### PR TITLE
[VL] Fix duplicate File prefix in FileSourceScanExecTransformer node name on Spark 4.1

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -108,6 +108,11 @@ abstract class FileSourceScanExecTransformerBase(
     disableBucketedScan)
   with DatasourceScanTransformer {
 
+  // Override nodeNamePrefix to empty to prevent double "File" prefix in simpleString.
+  // AbstractFileSourceScanExec (Spark 4.1 shim) sets nodeNamePrefix = "File",
+  // but nodeName already uses getClass.getSimpleName which starts with "File".
+  override val nodeNamePrefix: String = ""
+
   // Note: "metrics" is made transient to avoid sending driver-side metrics to tasks.
   @transient override lazy val metrics: Map[String, SQLMetric] =
     BackendsApiManager.getMetricsApiInstance


### PR DESCRIPTION
## What changes were proposed in this pull request?

Override `nodeNamePrefix` to `""` in `FileSourceScanExecTransformerBase` to prevent the scan node from displaying as `FileFileSourceScanExecTransformer` instead of `FileSourceScanExecTransformer` in physical plans on Spark 4.1.

## Root cause

1. The Spark 4.1 shim `AbstractFileSourceScanExec` sets `nodeNamePrefix = "File"`
2. `FileSourceScanExecTransformerBase` overrides `nodeName` using `getClass.getSimpleName` which already starts with "File"
3. `simpleString` concatenates `nodeNamePrefix + nodeName` producing `"File" + "FileSourceScanExecTransformer ..." = "FileFileSourceScanExecTransformer ..."`

The existing bug report #11402 also incidentally shows `FileFileSourceScanExecTransformer` in its plan output, confirming this is not environment-specific.

## Fix

Add `override val nodeNamePrefix: String = ""` in `FileSourceScanExecTransformerBase` to prevent the inherited "File" prefix from being prepended to the already-complete `nodeName`.

## Does this PR introduce any user-facing change?

Yes (cosmetic). Physical plan display shows correct node name (`FileSourceScanExecTransformer`) instead of `FileFileSourceScanExecTransformer`.

## How was this tested?

Existing tests. The test class `TestFileSourceScanExecTransformer` already demonstrates the `nodeNamePrefix` override pattern.