### PR TITLE
[GLUTEN-11969] Enable Java 17 release flag for Spark 4+ build

### DIFF
--- a/dev/buildbundle-veloxbe.sh
+++ b/dev/buildbundle-veloxbe.sh
@@ -27,7 +27,10 @@ function build_for_spark {
   major_version=$(echo $spark_version | cut -d'.' -f1)
 
   if [ "$major_version" -ge 4 ]; then
-    ${MVN_CMD} clean install -Pbackends-velox -Pspark-$spark_version -Pjava-17 -Pscala-2.13 -DskipTests
+    # Force Java 17 release target to override any `maven.compiler.source/target=1.8`
+    # that may be injected by a user's ~/.m2/settings.xml (e.g. an active jdk-8 profile),
+    # which would otherwise cause scalac to fail with: "'1.8' is not a valid choice for '-release'".
+    ${MVN_CMD} clean install -Pbackends-velox -Pspark-$spark_version -Pjava-17 -Pscala-2.13 -DskipTests -Dmaven.compiler.release=17
   else
     ${MVN_CMD} clean install -Pbackends-velox -Pspark-$spark_version -DskipTests
   fi


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?


Adding -Dmaven.compiler.release=17 in the Spark 4+ command explicitly forces the release target to 17, making the Java/Scala compilation pipeline consistent.
After this override, the build no longer falls back to 1.8-style release values,



For Spark 4.x, the build should target Java 17.
But the project’s default properties still originate from Java 8 in some paths, so Scala/Maven can end up with a release argument equivalent to 1.8, which is incompatible with the Spark 4 + Scala 2.13 + JDK17 toolchain.
So the build effectively mixed:
Expected: Java 17
Leaked/default value: 1.8 release semantics




<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

UT


CHANGE BEFORE

./dev/buildbundle-veloxbe.sh --spark_version=4.1 failed!

CHANGE AFTER

./dev/buildbundle-veloxbe.sh --spark_version=4.1 succeed!

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

NO

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->


Related issue: #11969