### PR TITLE
[VL] Remove unused libprotobuf.so.32 from shared library loaders and build script

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderCentos7.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderCentos7.scala
@@ -40,7 +40,6 @@ class SharedLibraryLoaderCentos7 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libevent-2.0.so.5", "libevent-2.0.so")
     loader.loadAndCreateLink("libgflags.so.2.2", "libgflags.so")
     loader.loadAndCreateLink("libglog.so.0", "libglog.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
     loader.loadAndCreateLink("libre2.so.10", "libre2.so")
     loader.loadAndCreateLink("libzstd.so.1", "libzstd.so")
     loader.loadAndCreateLink("liblz4.so.1", "liblz4.so")

--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderCentos8.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderCentos8.scala
@@ -45,7 +45,6 @@ class SharedLibraryLoaderCentos8 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libgflags.so.2.2", "libgflags.so")
     loader.loadAndCreateLink("libglog.so.1", "libglog.so")
     loader.loadAndCreateLink("libdwarf.so.1", "libdwarf.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
     loader.loadAndCreateLink("libre2.so.0", "libre2.so")
     loader.loadAndCreateLink("libsodium.so.23", "libsodium.so")
     loader.loadAndCreateLink("libgeos.so.3.10.7", "libgeos.so")

--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderCentos9.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderCentos9.scala
@@ -41,7 +41,6 @@ class SharedLibraryLoaderCentos9 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libgflags.so.2.2", "libgflags.so")
     loader.loadAndCreateLink("libglog.so.1", "libglog.so")
     loader.loadAndCreateLink("libdwarf.so.0", "libdwarf.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
     loader.loadAndCreateLink("libre2.so.9", "libre2.so")
     loader.loadAndCreateLink("libsodium.so.23", "libsodium.so")
     loader.loadAndCreateLink("libgeos.so.3.10.7", "libgeos.so")

--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderDebian11.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderDebian11.scala
@@ -48,7 +48,6 @@ class SharedLibraryLoaderDebian11 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libevent-2.1.so.7", "libevent-2.1.so")
     loader.loadAndCreateLink("libsnappy.so.1", "libsnappy.so")
     loader.loadAndCreateLink("libcurl.so.4", "libcurl.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
   }
 
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderDebian12.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderDebian12.scala
@@ -54,7 +54,6 @@ class SharedLibraryLoaderDebian12 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libglog.so.1", "libglog.so")
     loader.loadAndCreateLink("libevent-2.1.so.7", "libevent-2.1.so")
     loader.loadAndCreateLink("libcurl.so.4", "libcurl.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
   }
 
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderOpenEuler2403.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderOpenEuler2403.scala
@@ -42,7 +42,6 @@ class SharedLibraryLoaderOpenEuler2403 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libidn.so.12", "libidn.so")
     loader.loadAndCreateLink("libntlm.so.0", "libntlm.so")
     loader.loadAndCreateLink("libgsasl.so.7", "libgsasl.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
     loader.loadAndCreateLink("libre2.so.11", "libre2.so")
     loader.loadAndCreateLink("libsodium.so.26", "libsodium.so")
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderUbuntu2004.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderUbuntu2004.scala
@@ -58,7 +58,6 @@ class SharedLibraryLoaderUbuntu2004 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libidn.so.11", "libidn.so")
     loader.loadAndCreateLink("libntlm.so.0", "libntlm.so")
     loader.loadAndCreateLink("libgsasl.so.7", "libgsasl.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
     loader.loadAndCreateLink("libicudata.so.66", "libicudata.so")
     loader.loadAndCreateLink("libicuuc.so.66", "libicuuc.so")
     loader.loadAndCreateLink("libxml2.so.2", "libxml2.so")

--- a/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderUbuntu2204.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/spi/SharedLibraryLoaderUbuntu2204.scala
@@ -44,7 +44,6 @@ class SharedLibraryLoaderUbuntu2204 extends SharedLibraryLoader {
     loader.loadAndCreateLink("libidn.so.12", "libidn.so")
     loader.loadAndCreateLink("libntlm.so.0", "libntlm.so")
     loader.loadAndCreateLink("libgsasl.so.7", "libgsasl.so")
-    loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")
     loader.loadAndCreateLink("libxml2.so.2", "libxml2.so")
     loader.loadAndCreateLink("libre2.so.9", "libre2.so")
     loader.loadAndCreateLink("libsnappy.so.1", "libsnappy.so")

--- a/dev/build-thirdparty.sh
+++ b/dev/build-thirdparty.sh
@@ -44,28 +44,28 @@ function process_setup_centos_9 {
 function process_setup_centos_8 {
   cp /usr/lib64/{libre2.so.0,libdouble-conversion.so.3,libevent-2.1.so.6,libdwarf.so.1,libicudata.so.60,libicui18n.so.60,libicuuc.so.60,libsodium.so.23} $THIRDPARTY_LIB/
   cp /usr/local/lib/{libboost_context.so.1.84.0,libboost_filesystem.so.1.84.0,libboost_program_options.so.1.84.0,libboost_regex.so.1.84.0,libboost_system.so.1.84.0,libboost_thread.so.1.84.0,libboost_atomic.so.1.84.0} $THIRDPARTY_LIB/
-  cp /usr/local/lib64/{libgflags.so.2.2,libglog.so.1} $THIRDPARTY_LIB/
+  cp /usr/local/lib64/{libgflags.so.2.2,libglog.so.1,libgeos.so.3.10.7} $THIRDPARTY_LIB/
 }
 
 function process_setup_centos_7 {
   cp /usr/local/lib64/{libgflags.so.2.2,libglog.so.0,libgeos.so.3.10.7} $THIRDPARTY_LIB/
   cp /usr/lib64/{libdouble-conversion.so.1,libevent-2.0.so.5,libzstd.so.1,libntlm.so.0,libgsasl.so.7,liblz4.so.1} $THIRDPARTY_LIB/
-  cp /usr/local/lib/{libre2.so.10,libboost_context.so.1.84.0,libboost_filesystem.so.1.84.0,libboost_program_options.so.1.84.0,libboost_system.so.1.84.0,libboost_thread.so.1.84.0,libboost_regex.so.1.84.0,libboost_atomic.so.1.84.0,libprotobuf.so.32} $THIRDPARTY_LIB/
+  cp /usr/local/lib/{libre2.so.10,libboost_context.so.1.84.0,libboost_filesystem.so.1.84.0,libboost_program_options.so.1.84.0,libboost_system.so.1.84.0,libboost_thread.so.1.84.0,libboost_regex.so.1.84.0,libboost_atomic.so.1.84.0} $THIRDPARTY_LIB/
 }
 
 function process_setup_debian_11 {
   cp /usr/lib/x86_64-linux-gnu/{libre2.so.9,libthrift-0.13.0.so,libdouble-conversion.so.3,libevent-2.1.so.7,libgflags.so.2.2,libglog.so.0,libsnappy.so.1,libunwind.so.8,libcurl.so.4,libicui18n.so.67,libicuuc.so.67,libnghttp2.so.14,librtmp.so.1,libssh2.so.1,libpsl.so.5,libldap_r-2.4.so.2,liblber-2.4.so.2,libbrotlidec.so.1,libicudata.so.67,libsasl2.so.2,libbrotlicommon.so.1} $THIRDPARTY_LIB/
-  cp /usr/local/lib/{libprotobuf.so.32,libboost_context.so.1.84.0,libboost_regex.so.1.84.0} $THIRDPARTY_LIB/
+  cp /usr/local/lib/{libboost_context.so.1.84.0,libboost_regex.so.1.84.0} $THIRDPARTY_LIB/
 }
 
 function process_setup_debian_12 {
   cp /usr/lib/x86_64-linux-gnu/{libthrift-0.17.0.so,libdouble-conversion.so.3,libevent-2.1.so.7,libgflags.so.2.2,libglog.so.1,libsnappy.so.1,libunwind.so.8,libcurl.so.4,libicui18n.so.72,libicuuc.so.72,libnghttp2.so.14,librtmp.so.1,libssh2.so.1,libpsl.so.5,libldap-2.5.so.0,liblber-2.5.so.0,libbrotlidec.so.1,libicudata.so.72,libsasl2.so.2,libbrotlicommon.so.1,libcrypto.so.3,libssl.so.3,libgssapi_krb5.so.2,libkrb5.so.3,libk5crypto.so.3,libkrb5support.so.0,libkeyutils.so.1} $THIRDPARTY_LIB/
-  cp /usr/local/lib/{libprotobuf.so.32,libboost_context.so.1.84.0,libboost_regex.so.1.84.0} $THIRDPARTY_LIB/
+  cp /usr/local/lib/{libboost_context.so.1.84.0,libboost_regex.so.1.84.0} $THIRDPARTY_LIB/
 }
 
 function process_setup_openeuler_24 {
   cp /usr/lib64/{libre2.so.11,libdouble-conversion.so.3,libevent-2.1.so.7,libdwarf.so.0,libgsasl.so.7,libicudata.so.74,libicui18n.so.74,libicuuc.so.74,libidn.so.12,libntlm.so.0,libsodium.so.26} $THIRDPARTY_LIB/
-  cp /usr/local/lib/{libboost_context.so.1.84.0,libboost_filesystem.so.1.84.0,libboost_program_options.so.1.84.0,libboost_regex.so.1.84.0,libboost_system.so.1.84.0,libboost_thread.so.1.84.0,libboost_atomic.so.1.84.0,libprotobuf.so.32} $THIRDPARTY_LIB/
+  cp /usr/local/lib/{libboost_context.so.1.84.0,libboost_filesystem.so.1.84.0,libboost_program_options.so.1.84.0,libboost_regex.so.1.84.0,libboost_system.so.1.84.0,libboost_thread.so.1.84.0,libboost_atomic.so.1.84.0} $THIRDPARTY_LIB/
   cp /usr/local/lib64/{libgflags.so.2.2,libglog.so.1} $THIRDPARTY_LIB/
 }
 


### PR DESCRIPTION
## Summary

`libvelox.so` no longer depends on `libprotobuf.so.32` (verified via `ldd`). This PR removes the unnecessary loading and copying of this library:

- Remove `loader.loadAndCreateLink("libprotobuf.so.32", "libprotobuf.so")` from all 8 OS-specific `SharedLibraryLoader` implementations (CentOS 7/8/9, Ubuntu 20.04/22.04, Debian 11/12, openEuler 24.03)
- Remove `libprotobuf.so.32` from `cp` commands in `dev/build-thirdparty.sh` for CentOS 7, Debian 11/12, and openEuler 24.03
- Add missing `libgeos.so.3.10.7` to `process_setup_centos_8` in `dev/build-thirdparty.sh` to align with its `SharedLibraryLoaderCentos8`

## Test plan

- [x] Verify `ldd libvelox.so` does not show `libprotobuf.so.32` dependency
- [x] Build and run on CentOS 8 to confirm no missing library errors