### PR TITLE
[CH][Feat] EC-safe reads for Parquet/ORC and libhdfs3 striped reader

### DIFF
--- a/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.cpp
+++ b/cpp-ch/local-engine/Storages/Parquet/ParquetMeta.cpp
@@ -19,6 +19,8 @@
 
 #include <Formats/FormatFactory.h>
 #include <Formats/FormatSettings.h>
+#include <IO/SeekableReadBuffer.h>
+#include <IO/WithFileSize.h>
 #include <Processors/Formats/Impl/ArrowBufferedStreams.h>
 #include <Processors/Formats/Impl/ArrowColumnToCHColumn.h>
 #include <Processors/Formats/Impl/ArrowFieldIndexUtil.h>
@@ -46,7 +48,21 @@ std::unique_ptr<parquet::ParquetFileReader> ParquetMetaBuilder::openInputParquet
         .seekable_read = true,
     };
     std::atomic<int> is_stopped{0};
-    auto arrow_file = asArrowFile(read_buffer, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES);
+    /// Parquet open reads the footer with RandomAccessFile::ReadAt(). Arrow's default ReadAt is Seek()+Read().
+    /// On HDFS EC (striped) files, libhdfs3's seek+read cursor path can return wrong bytes for sparse footer
+    /// reads while pread (readBigAt → hdfsPread → preadInternal) matches the range read path Spark uses.
+    std::shared_ptr<arrow::io::RandomAccessFile> arrow_file;
+    if (format_settings.seekable_read && isBufferWithFileSize(read_buffer))
+    {
+        if (auto * seekable = dynamic_cast<SeekableReadBuffer *>(&read_buffer);
+            seekable && seekable->supportsReadAt())
+        {
+            arrow_file = std::make_shared<RandomAccessFileFromRandomAccessReadBuffer>(
+                *seekable, getFileSizeFromReadBuffer(read_buffer), nullptr);
+        }
+    }
+    if (!arrow_file)
+        arrow_file = asArrowFile(read_buffer, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES);
 
     return parquet::ParquetFileReader::Open(arrow_file, parquet::default_reader_properties(), nullptr);
 }

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ORCFormatFile.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ORCFormatFile.cpp
@@ -21,7 +21,6 @@
 #include <numeric>
 #include <Formats/FormatFactory.h>
 #include <IO/SeekableReadBuffer.h>
-#include <Processors/Formats/Impl/ArrowBufferedStreams.h>
 #include <Processors/Formats/Impl/NativeORCBlockInputFormat.h>
 #include <Storages/SubstraitSource/OrcUtil.h>
 #include <Poco/Util/AbstractConfiguration.h>
@@ -115,7 +114,7 @@ std::vector<StripeInformation> ORCFormatFile::collectRequiredStripes(DB::ReadBuf
         .seekable_read = true,
     };
     std::atomic<int> is_stopped{0};
-    auto arrow_file = DB::asArrowFile(*read_buffer, format_settings, is_stopped, "ORC", ORC_MAGIC_BYTES);
+    auto arrow_file = OrcUtil::openArrowRandomAccessFileForOrc(*read_buffer, format_settings, is_stopped);
     auto orc_reader = OrcUtil::createOrcReader(arrow_file);
     total_stripes = orc_reader->getNumberOfStripes();
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.cpp
@@ -16,6 +16,8 @@
  */
 #include "OrcUtil.h"
 #include <IO/Operators.h>
+#include <IO/SeekableReadBuffer.h>
+#include <IO/WithFileSize.h>
 #include <IO/WriteBufferFromString.h>
 #include <Processors/Formats/Impl/ArrowBufferedStreams.h>
 #include <arrow/result.h>
@@ -70,6 +72,26 @@ namespace ErrorCodes
 }
 namespace local_engine
 {
+std::shared_ptr<arrow::io::RandomAccessFile> OrcUtil::openArrowRandomAccessFileForOrc(
+    DB::ReadBuffer & read_buffer,
+    const DB::FormatSettings & format_settings,
+    std::atomic<int> & is_stopped)
+{
+    std::shared_ptr<arrow::io::RandomAccessFile> arrow_file;
+    if (format_settings.seekable_read && DB::isBufferWithFileSize(read_buffer))
+    {
+        if (auto * seekable = dynamic_cast<DB::SeekableReadBuffer *>(&read_buffer);
+            seekable && seekable->supportsReadAt())
+        {
+            arrow_file = std::make_shared<DB::RandomAccessFileFromRandomAccessReadBuffer>(
+                *seekable, DB::getFileSizeFromReadBuffer(read_buffer), nullptr);
+        }
+    }
+    if (!arrow_file)
+        arrow_file = DB::asArrowFile(read_buffer, format_settings, is_stopped, "ORC", ORC_MAGIC_BYTES);
+    return arrow_file;
+}
+
 uint64_t ArrowInputFile::getLength() const
 {
     ORC_ASSIGN_OR_THROW(int64_t size, file->GetSize())
@@ -147,7 +169,7 @@ void OrcUtil::getFileReaderAndSchema(
     const DB::FormatSettings & format_settings,
     std::atomic<int> & is_stopped)
 {
-    auto arrow_file = DB::asArrowFile(in, format_settings, is_stopped, "ORC", ORC_MAGIC_BYTES);
+    auto arrow_file = OrcUtil::openArrowRandomAccessFileForOrc(in, format_settings, is_stopped);
     if (is_stopped)
         return;
 

--- a/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.h
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/OrcUtil.h
@@ -18,6 +18,9 @@
 #include <Processors/Formats/Impl/ArrowColumnToCHColumn.h>
 #include <Processors/Formats/Impl/ORCBlockInputFormat.h>
 
+#include <arrow/io/interfaces.h>
+#include <atomic>
+
 /// there are destructor not be overrided warnings in orc lib, ignore them
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsuggest-destructor-override"
@@ -49,6 +52,13 @@ private:
 class OrcUtil
 {
 public:
+    /// Same as ParquetMetaBuilder::openInputParquetFile: on HDFS EC, Arrow's default ReadAt is Seek()+Read();
+    /// ORC postscript/footer reads need readBigAt (pread) for correct tail bytes.
+    static std::shared_ptr<arrow::io::RandomAccessFile> openArrowRandomAccessFileForOrc(
+        DB::ReadBuffer & read_buffer,
+        const DB::FormatSettings & format_settings,
+        std::atomic<int> & is_stopped);
+
     static std::unique_ptr<orc::Reader> createOrcReader(std::shared_ptr<arrow::io::RandomAccessFile> file_);
 
     static size_t countIndicesForType(std::shared_ptr<arrow::DataType> type);

--- a/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
+++ b/cpp-ch/local-engine/Storages/SubstraitSource/ReadBufferBuilder.cpp
@@ -299,6 +299,15 @@ public:
             modified_time = file_info.properties().modificationtime();
         }
 
+#if USE_PARQUET
+        if (file_info.has_parquet() || (file_info.has_iceberg() && file_info.iceberg().has_parquet()))
+            file_size = std::nullopt;
+#endif
+#if USE_ORC
+        if (file_info.has_orc() || (file_info.has_iceberg() && file_info.iceberg().has_orc()))
+            file_size = std::nullopt;
+#endif
+
         std::unique_ptr<SeekableReadBuffer> read_buffer;
         if (!read_settings.enable_filesystem_cache)
         {


### PR DESCRIPTION
- HDFS ReadBufferBuilder: do not trust Substrait properties.filesize for Parquet/ORC (incl. Iceberg); always stat real length for footer/postscript.
- Parquet: prefer RandomAccessFileFromRandomAccessReadBuffer when readBigAt is available so footer ReadAt uses pread, not seek+read.
- ORC (Gluten): OrcUtil path mirrors the same Arrow RandomAccessFile choice where applicable.

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
Manual test, CI.

## Was this patch authored or co-authored using generative AI tooling?
Cursor
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
