### PR TITLE
[GLUTEN-10134][VL] Fix ANSI workflow: AI token limit, analyze-only artifact lookup, and --run support

### DIFF
--- a/.github/skills/ansi-analysis/analyze-ansi.py
+++ b/.github/skills/ansi-analysis/analyze-ansi.py
@@ -437,7 +437,8 @@ def _build_ai_context(summary, suites):
         suite = f["suite"].split(".")[-1]
         key = (cause, suite)
         groups[key]["count"] += 1
-        groups[key]["tests"].append(f["test"])
+        if len(groups[key]["tests"]) < 10:
+            groups[key]["tests"].append(f["test"])
         if not groups[key]["sample_msg"]:
             groups[key]["sample_msg"] = _extract_short_message(
                 f.get("message", ""))[:120]
@@ -464,7 +465,6 @@ def _build_ai_context(summary, suites):
     output = {
         "records": summary["json_record_count"],
         "by_color": json_colors,
-        "failure_count": len(summary["failures"]),
         "failures": grouped_failures,
         "categories": dict(compact_cats),
     }

--- a/.github/skills/ansi-analysis/analyze-ansi.py
+++ b/.github/skills/ansi-analysis/analyze-ansi.py
@@ -426,44 +426,49 @@ GITHUB_MODELS_API = "https://models.inference.ai.azure.com/chat/completions"
 
 
 def _build_ai_context(summary, suites):
-    """Build a compact JSON context for AI analysis."""
-    compact_failures = []
+    """Build a compact JSON context for AI analysis.
+
+    Grouped by (cause, suite) to minimize tokens for the GitHub Models API
+    (8000-token limit).
+    """
+    groups = defaultdict(lambda: {"count": 0, "tests": [], "sample_msg": ""})
     for f in summary["failures"][:100]:
         cause = classify_fail_cause(f.get("message", ""))
-        short_msg = _extract_short_message(f.get("message", ""))
-        compact_failures.append({
-            "suite": f["suite"].split(".")[-1],
-            "test": f["test"],
-            "source": f.get("source", ""),
-            "cause": cause,
-            "message": short_msg[:120],
+        suite = f["suite"].split(".")[-1]
+        key = (cause, suite)
+        groups[key]["count"] += 1
+        groups[key]["tests"].append(f["test"])
+        if not groups[key]["sample_msg"]:
+            groups[key]["sample_msg"] = _extract_short_message(
+                f.get("message", ""))[:120]
+
+    grouped_failures = []
+    for (cause, suite), g in sorted(groups.items(), key=lambda x: -x[1]["count"]):
+        grouped_failures.append({
+            "cause": cause, "suite": suite, "count": g["count"],
+            "tests": g["tests"], "sample_msg": g["sample_msg"],
         })
 
-    compact_cats = defaultdict(lambda: {"tests_pass": 0, "tests_fail": 0,
-                                         "suites": set()})
+    compact_cats = defaultdict(lambda: {"pass": 0, "fail": 0})
     for s in suites:
         cat = s.get("category", "unknown")
-        compact_cats[cat]["suites"].add(s.get("suite", ""))
         for t in s.get("tests", []):
             if t.get("status") in ("PASS", "PASSED"):
-                compact_cats[cat]["tests_pass"] += 1
+                compact_cats[cat]["pass"] += 1
             elif t.get("status") in ("FAIL", "FAILED", "ERROR"):
-                compact_cats[cat]["tests_fail"] += 1
+                compact_cats[cat]["fail"] += 1
 
     json_colors = {k: v for k, v in summary["by_color"].items()
                     if k not in ("Passed (no data)", "Skipped")}
 
     output = {
-        "json_record_count": summary["json_record_count"],
+        "records": summary["json_record_count"],
         "by_color": json_colors,
         "failure_count": len(summary["failures"]),
-        "failures": compact_failures,
-        "categories": {cat: {"tests_pass": d["tests_pass"],
-                              "tests_fail": d["tests_fail"],
-                              "suites": sorted(d["suites"])}
-                        for cat, d in compact_cats.items()},
+        "failures": grouped_failures,
+        "categories": dict(compact_cats),
     }
-    return json.dumps(output, indent=2, ensure_ascii=False)
+    return json.dumps(output, separators=(',', ':'), ensure_ascii=False)
 
 
 def call_ai_analysis(json_output, model=None):

--- a/.github/workflows/velox_backend_ansi.yml
+++ b/.github/workflows/velox_backend_ansi.yml
@@ -76,7 +76,8 @@ jobs:
         run: |
           AI_MODEL=$(echo "$COMMENT" | grep -oP '(?<=--model\s)\S+' || echo "")
           echo "ai_model=${AI_MODEL}" >> $GITHUB_OUTPUT
-          RUN_ID=$(echo "$COMMENT" | grep -oPm1 '(?<=--run\s)\d+' || echo "${{ inputs.run_id }}")
+          RUN_ID=$(echo "$COMMENT" | grep -oP '(?<=--run\s)\d+' | head -1)
+          [[ -z "$RUN_ID" ]] && RUN_ID="${{ inputs.run_id }}"
           if [[ -n "$RUN_ID" ]] && ! [[ "$RUN_ID" =~ ^[0-9]+$ ]]; then
             echo "::error::Invalid run_id: ${RUN_ID}"; exit 1
           fi

--- a/.github/workflows/velox_backend_ansi.yml
+++ b/.github/workflows/velox_backend_ansi.yml
@@ -58,6 +58,9 @@ jobs:
        (contains(github.event.comment.body, '/ansi-test') ||
         contains(github.event.comment.body, '/ansi-analyze')))
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       pr_number: ${{ steps.pr-info.outputs.pr_number }}
       pr_sha: ${{ steps.pr-info.outputs.pr_sha }}
@@ -73,9 +76,14 @@ jobs:
         run: |
           AI_MODEL=$(echo "$COMMENT" | grep -oP '(?<=--model\s)\S+' || echo "")
           echo "ai_model=${AI_MODEL}" >> $GITHUB_OUTPUT
-          RUN_ID=$(echo "$COMMENT" | grep -oP '(?<=--run\s)\d+' || echo "${{ inputs.run_id }}")
+          RUN_ID=$(echo "$COMMENT" | grep -oPm1 '(?<=--run\s)\d+' || echo "${{ inputs.run_id }}")
+          if [[ -n "$RUN_ID" ]] && ! [[ "$RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid run_id: ${RUN_ID}"; exit 1
+          fi
           echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
           if echo "$COMMENT" | grep -q '/ansi-analyze'; then
+            echo "mode=analyze-only" >> $GITHUB_OUTPUT
+          elif [[ "${{ inputs.mode }}" == "analyze-only" ]]; then
             echo "mode=analyze-only" >> $GITHUB_OUTPUT
           else
             echo "mode=full" >> $GITHUB_OUTPUT
@@ -561,9 +569,9 @@ jobs:
             RUN_ID="$EXPLICIT_RUN_ID"
           else
             echo "Searching PR #${PR_NUM} comments for latest full-mode run..."
-            RUN_ID=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100&direction=desc" --paginate \
-              --jq '[.[] | select(.body | test("ansi-mode:full ansi-run:[0-9]+"))] | first | .body // empty' \
-              | grep -oP 'ansi-run:\K[0-9]+' || echo "")
+            RUN_ID=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate \
+              --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | test("ansi-mode:full ansi-run:[0-9]+")) | .body' \
+              | grep -oP 'ansi-run:\K[0-9]+' | tail -1 || echo "")
             if [[ -n "$RUN_ID" ]]; then
               echo "Found run_id=${RUN_ID} from PR comment"
             fi

--- a/.github/workflows/velox_backend_ansi.yml
+++ b/.github/workflows/velox_backend_ansi.yml
@@ -32,6 +32,10 @@ on:
           - full
           - analyze-only
         default: 'full'
+      run_id:
+        description: 'Run ID to reuse artifacts from (analyze-only mode)'
+        required: false
+        type: string
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
@@ -60,6 +64,7 @@ jobs:
       pr_ref: ${{ steps.pr-info.outputs.pr_ref }}
       ai_model: ${{ steps.parse-args.outputs.ai_model }}
       mode: ${{ steps.parse-args.outputs.mode }}
+      run_id: ${{ steps.parse-args.outputs.run_id }}
     steps:
       - name: Parse comment args
         id: parse-args
@@ -68,6 +73,8 @@ jobs:
         run: |
           AI_MODEL=$(echo "$COMMENT" | grep -oP '(?<=--model\s)\S+' || echo "")
           echo "ai_model=${AI_MODEL}" >> $GITHUB_OUTPUT
+          RUN_ID=$(echo "$COMMENT" | grep -oP '(?<=--run\s)\d+' || echo "${{ inputs.run_id }}")
+          echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
           if echo "$COMMENT" | grep -q '/ansi-analyze'; then
             echo "mode=analyze-only" >> $GITHUB_OUTPUT
           else
@@ -91,10 +98,16 @@ jobs:
           PR_NUM: ${{ steps.pr-info.outputs.pr_number }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
+          MODE: ${{ steps.parse-args.outputs.mode }}
         run: |
-          gh pr comment "${PR_NUM}" \
-            --repo "${REPO}" \
-            --body "🔄 ANSI mode analysis started by @${TRIGGER_USER}. [View run](https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          if [[ "$MODE" != "analyze-only" ]]; then
+            BODY=$(printf '%s\n%s' \
+              "🔄 ANSI full test started by @${TRIGGER_USER}. [View run](https://github.com/${REPO}/actions/runs/${RUN_ID})" \
+              "<!-- ansi-mode:full ansi-run:${RUN_ID} -->")
+          else
+            BODY="🔄 ANSI analyze-only started by @${TRIGGER_USER}. [View run](https://github.com/${REPO}/actions/runs/${RUN_ID})"
+          fi
+          gh pr comment "${PR_NUM}" --repo "${REPO}" --body "$BODY"
 
   build-native-lib:
     needs: check-comment
@@ -534,31 +547,40 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.check-comment.outputs.pr_sha }}
-      - name: Find latest ANSI workflow run with artifacts
+      - name: Find ANSI workflow run with artifacts
         id: find-run
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           REPO="${{ github.repository }}"
-          WORKFLOW="velox_backend_ansi.yml"
-          PR_BRANCH="${{ needs.check-comment.outputs.pr_ref }}"
-          echo "Looking for latest ANSI run with artifacts on branch=${PR_BRANCH}..."
-          CANDIDATE_IDS=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?branch=${PR_BRANCH}&per_page=50" \
-            --jq '.workflow_runs[] | select(.id != ${{ github.run_id }}) | .id')
-          RUN_ID=""
-          for cid in $CANDIDATE_IDS; do
-            HAS_OFFLOAD=$(gh api "repos/${REPO}/actions/runs/${cid}/artifacts" \
-              --jq '[.artifacts[] | select(.name | startswith("ansi-offload-"))] | length')
-            if [[ "$HAS_OFFLOAD" -gt 0 ]]; then
-              RUN_ID=$cid
-              echo "Found run ${RUN_ID} with ${HAS_OFFLOAD} offload artifacts"
-              break
+          PR_NUM="${{ needs.check-comment.outputs.pr_number }}"
+          EXPLICIT_RUN_ID="${{ needs.check-comment.outputs.run_id }}"
+
+          if [[ -n "$EXPLICIT_RUN_ID" ]]; then
+            echo "Using explicitly specified run_id=${EXPLICIT_RUN_ID}"
+            RUN_ID="$EXPLICIT_RUN_ID"
+          else
+            echo "Searching PR #${PR_NUM} comments for latest full-mode run..."
+            RUN_ID=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100&direction=desc" --paginate \
+              --jq '[.[] | select(.body | test("ansi-mode:full ansi-run:[0-9]+"))] | first | .body // empty' \
+              | grep -oP 'ansi-run:\K[0-9]+' || echo "")
+            if [[ -n "$RUN_ID" ]]; then
+              echo "Found run_id=${RUN_ID} from PR comment"
             fi
-          done
+          fi
+
           if [[ -z "$RUN_ID" ]]; then
-            echo "::error::No previous ANSI workflow run with artifacts found"
+            echo "::error::No ANSI full-test run found. Run /ansi-test first, or specify --run <ID>"
             exit 1
           fi
+
+          HAS_OFFLOAD=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("ansi-offload-"))] | length')
+          if [[ "$HAS_OFFLOAD" -eq 0 ]]; then
+            echo "::error::Run ${RUN_ID} has no offload artifacts (may have expired)"
+            exit 1
+          fi
+          echo "Using run ${RUN_ID} with ${HAS_OFFLOAD} offload artifacts"
           echo "run_id=${RUN_ID}" >> $GITHUB_OUTPUT
       - name: Download artifacts from previous run
         env:

--- a/.github/workflows/velox_backend_ansi.yml
+++ b/.github/workflows/velox_backend_ansi.yml
@@ -570,9 +570,9 @@ jobs:
             RUN_ID="$EXPLICIT_RUN_ID"
           else
             echo "Searching PR #${PR_NUM} comments for latest full-mode run..."
-            RUN_ID=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100" --paginate \
+            RUN_ID=$(gh api "repos/${REPO}/issues/${PR_NUM}/comments?per_page=100&sort=created&direction=desc" \
               --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | test("ansi-mode:full ansi-run:[0-9]+")) | .body' \
-              | grep -oP 'ansi-run:\K[0-9]+' | tail -1 || echo "")
+              | grep -oP 'ansi-run:\K[0-9]+' | head -1 || echo "")
             if [[ -n "$RUN_ID" ]]; then
               echo "Found run_id=${RUN_ID} from PR comment"
             fi


### PR DESCRIPTION
## Summary

Fixes three bugs in the ANSI workflow (`velox_backend_ansi.yml`) discovered after #11975 was merged:

- **AI analysis 413 token limit**: `_build_ai_context()` exceeded the GitHub Models API 8000-token limit. Compressed by grouping failures by (cause, suite), using compact JSON, capping test lists to 10 per group, and removing redundant fields.

- **analyze-only mode could not find artifacts**: `issue_comment`-triggered runs register `head_branch=main` with no PR association in metadata. The old `find-run` searched by PR branch name and always got zero results. Replaced with **Plan E**: full-mode runs now embed a hidden marker (`<!-- ansi-mode:full ansi-run:ID -->`) in the PR starting comment; analyze-only reads the marker back to locate the correct run.

- **`--run <ID>` support**: Both `issue_comment` (`/ansi-analyze --run <ID>`) and `workflow_dispatch` (`run_id` input) now accept an explicit run ID, bypassing the marker lookup.

### Additional hardening (from code review)

- Fix `workflow_dispatch` with `mode=analyze-only` being misidentified as `full` (marker pollution)
- Restrict marker search to `github-actions[bot]` comments only (anti-spoofing)
- Validate `--run` input as numeric, take only first match
- Add explicit `permissions` block to `check-comment` job

## Files changed

- `.github/workflows/velox_backend_ansi.yml` — artifact lookup, `--run` support, hidden markers, permissions
- `.github/skills/ansi-analysis/analyze-ansi.py` — AI context compression

## Test plan

- [x] `workflow_dispatch` analyze-only + `--run 24949958444` → success ([run](https://github.com/apache/gluten/actions/runs/24960414168))
- [x] `workflow_dispatch` full mode → hidden marker written, analyze-results success ([run](https://github.com/apache/gluten/actions/runs/24960461588))
- [x] `workflow_dispatch` analyze-only (no run_id) → Plan E marker lookup found run 24960461588 → success ([run](https://github.com/apache/gluten/actions/runs/24973861084))
- [ ] `/ansi-test` via issue_comment (requires merge to main first — workflow YAML is read from default branch)

## Known remaining issue

backends-velox test jobs run all suites instead of ANSI-specific ones, causing timeouts (~20h). Will be fixed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related issue: #10134