### PR TITLE
[VL] Fix Iceberg row level scan/write regressions on Spark 4.0

### DIFF
--- a/backends-velox/src-iceberg/main/scala/org/apache/gluten/extension/OffloadIcebergWrite.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/gluten/extension/OffloadIcebergWrite.scala
@@ -38,9 +38,14 @@ case class OffloadIcebergAppend() extends OffloadSingleNode {
 
 case class OffloadIcebergReplaceData() extends OffloadSingleNode {
   override def offload(plan: SparkPlan): SparkPlan = plan match {
-    case r: ReplaceDataExec if supportsWrite(r.write) =>
+    case r: ReplaceDataExec if supportsWrite(r.write) && !ansiFallbackEnabled =>
       VeloxIcebergReplaceDataExec(r)
     case other => other
+  }
+
+  private def ansiFallbackEnabled: Boolean = {
+    val glutenConf = GlutenConfig.get
+    glutenConf.enableAnsiMode && glutenConf.enableAnsiFallback
   }
 }
 

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
@@ -528,11 +528,17 @@ class VeloxIcebergSuite extends IcebergSuite {
                     |  (3, 'Name3', 35)
                     |""".stripMargin)
 
-        spark.sql("""
-                    |update iceberg_cow_update_ansi_tb
-                    |set name = 'Name4'
-                    |where id = 1
-                    |""".stripMargin)
+        val df = spark.sql("""
+                             |update iceberg_cow_update_ansi_tb
+                             |set name = 'Name4'
+                             |where id = 1
+                             |""".stripMargin)
+
+        assert(
+          !df.queryExecution.executedPlan
+            .asInstanceOf[CommandResultExec]
+            .commandPhysicalPlan
+            .isInstanceOf[VeloxIcebergReplaceDataExec])
 
         checkAnswer(
           spark.sql("""

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
@@ -149,6 +149,44 @@ class VeloxIcebergSuite extends IcebergSuite {
     }
   }
 
+  test("iceberg delete fallback summary after command commit") {
+    withTable("iceberg_cow_summary_tb") {
+      spark.sql("""
+                  |create table iceberg_cow_summary_tb (
+                  |  id int,
+                  |  name string,
+                  |  p string
+                  |) using iceberg
+                  |tblproperties (
+                  |  'format-version' = '2',
+                  |  'write.delete.mode' = 'copy-on-write',
+                  |  'write.update.mode' = 'copy-on-write',
+                  |  'write.merge.mode' = 'copy-on-write'
+                  |);
+                  |""".stripMargin)
+
+      spark.sql("""
+                  |insert into table iceberg_cow_summary_tb
+                  |values (1, 'a1', 'p1'), (2, 'a2', 'p1'), (3, 'a3', 'p2');
+                  |""".stripMargin)
+
+      val df = spark.sql("""
+                           |delete from iceberg_cow_summary_tb where name = 'a1';
+                           |""".stripMargin)
+
+      checkAnswer(
+        spark.sql("""
+                    |select * from iceberg_cow_summary_tb order by id
+                    |""".stripMargin),
+        Seq(Row(2, "a2", "p1"), Row(3, "a3", "p2"))
+      )
+
+      // Regression test for fallback summary collection after Iceberg commit cleanup.
+      val summary = df.fallbackSummary()
+      assert(summary.physicalPlanDescription.nonEmpty)
+    }
+  }
+
   test("iceberg insert partition table bucket transform") {
     withTable("iceberg_tb2") {
       spark.sql("""

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
@@ -503,4 +503,46 @@ class VeloxIcebergSuite extends IcebergSuite {
       )
     }
   }
+
+  test("iceberg read cow table - update with ansi fallback") {
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      withTable("iceberg_cow_update_ansi_tb") {
+        spark.sql("""
+                    |create table iceberg_cow_update_ansi_tb (
+                    |  id int,
+                    |  name string,
+                    |  age int
+                    |) using iceberg
+                    |tblproperties (
+                    |  'format-version' = '2',
+                    |  'write.delete.mode' = 'copy-on-write',
+                    |  'write.update.mode' = 'copy-on-write',
+                    |  'write.merge.mode' = 'copy-on-write'
+                    |)
+                    |""".stripMargin)
+
+        spark.sql("""
+                    |insert into table iceberg_cow_update_ansi_tb values
+                    |  (1, 'Name1', 23),
+                    |  (2, 'Name2', 30),
+                    |  (3, 'Name3', 35)
+                    |""".stripMargin)
+
+        spark.sql("""
+                    |update iceberg_cow_update_ansi_tb
+                    |set name = 'Name4'
+                    |where id = 1
+                    |""".stripMargin)
+
+        checkAnswer(
+          spark.sql("""
+                      |select id, name, age
+                      |from iceberg_cow_update_ansi_tb
+                      |order by id
+                      |""".stripMargin),
+          Seq(Row(1, "Name4", 23), Row(2, "Name2", 30), Row(3, "Name3", 35))
+        )
+      }
+    }
+  }
 }

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/enhanced/VeloxIcebergSuite.scala
@@ -498,7 +498,7 @@ class VeloxIcebergSuite extends IcebergSuite {
         Seq(
           Row(1, "Name4", 23, new java.math.BigDecimal("3400.00")),
           Row(2, "Name2", 30, new java.math.BigDecimal("5500.00")),
-          Row(3, "Name1", 35, new java.math.BigDecimal("6500.00"))
+          Row(3, "Name3", 35, new java.math.BigDecimal("6500.00"))
         )
       )
     }

--- a/cpp/velox/compute/iceberg/IcebergWriter.cc
+++ b/cpp/velox/compute/iceberg/IcebergWriter.cc
@@ -25,6 +25,8 @@
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 
+#include <unordered_map>
+
 using namespace facebook::velox;
 using namespace facebook::velox::connector::hive;
 using namespace facebook::velox::connector::hive::iceberg;
@@ -236,12 +238,42 @@ void IcebergWriter::write(const VeloxColumnarBatch& batch) {
   auto inputRowVector = batch.getRowVector();
   auto inputRowType = asRowType(inputRowVector->type());
 
-  if (inputRowType->size() != rowType_->size()) {
-    const auto& children = inputRowVector->children();
-    std::vector<VectorPtr> dataColumns(children.begin() + 1, children.begin() + 1 + rowType_->size());
+  auto schemasMatch = inputRowType->size() == rowType_->size();
+  if (schemasMatch) {
+    for (size_t i = 0; i < rowType_->size(); ++i) {
+      if (inputRowType->nameOf(i) != rowType_->nameOf(i)) {
+        schemasMatch = false;
+        break;
+      }
+    }
+  }
+
+  if (!schemasMatch) {
+    std::vector<VectorPtr> filteredChildren;
+    filteredChildren.reserve(rowType_->size());
+
+    std::unordered_map<std::string, size_t> inputColumnIndices;
+    inputColumnIndices.reserve(inputRowType->size());
+    for (size_t i = 0; i < inputRowType->size(); ++i) {
+      inputColumnIndices.emplace(inputRowType->nameOf(i), i);
+    }
+
+    for (size_t i = 0; i < rowType_->size(); ++i) {
+      const auto& columnName = rowType_->nameOf(i);
+      const auto it = inputColumnIndices.find(columnName);
+      VELOX_CHECK(
+          it != inputColumnIndices.end(),
+          "Column '{}' not found in input batch for Iceberg write",
+          columnName);
+      filteredChildren.push_back(inputRowVector->childAt(it->second));
+    }
 
     auto filteredRowVector = std::make_shared<RowVector>(
-        pool_.get(), rowType_, inputRowVector->nulls(), inputRowVector->size(), std::move(dataColumns));
+        pool_.get(),
+        rowType_,
+        inputRowVector->nulls(),
+        inputRowVector->size(),
+        std::move(filteredChildren));
 
     dataSink_->appendData(filteredRowVector);
   } else {

--- a/gluten-iceberg/src/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
+++ b/gluten-iceberg/src/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
@@ -17,6 +17,7 @@
 package org.apache.gluten.substrait.rel;
 
 import io.substrait.proto.ReadRel;
+import org.apache.gluten.ContentFileUtil;
 import org.apache.iceberg.DeleteFile;
 
 import java.util.ArrayList;
@@ -93,7 +94,7 @@ public class IcebergLocalFilesNode extends LocalFilesNode {
               "Unsupported FileCount " + delete.content().name() + " for delete file.");
       }
       deleteFileBuilder.setFileContent(fileContent);
-      deleteFileBuilder.setFilePath(delete.path().toString());
+      deleteFileBuilder.setFilePath(ContentFileUtil.getFilePath(delete));
       deleteFileBuilder.setFileSize(delete.fileSizeInBytes());
       deleteFileBuilder.setRecordCount(delete.recordCount());
       switch (delete.format()) {

--- a/gluten-iceberg/src/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
+++ b/gluten-iceberg/src/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
@@ -16,8 +16,9 @@
  */
 package org.apache.gluten.substrait.rel;
 
-import io.substrait.proto.ReadRel;
 import org.apache.gluten.ContentFileUtil;
+
+import io.substrait.proto.ReadRel;
 import org.apache.iceberg.DeleteFile;
 
 import java.util.ArrayList;

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -355,7 +355,7 @@ object IcebergScanTransformer {
 
   def supportsBatchScan(scan: Scan): Boolean = {
     GlutenIcebergSourceUtil.supportsBatchScan(scan) &&
-      !GlutenIcebergSourceUtil.isMetadataScan(scan)
+    !GlutenIcebergSourceUtil.isMetadataScan(scan)
   }
 
   private def containsUuidOrFixedType(dataType: Type): Boolean = {

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, DynamicPru
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.Scan
+import org.apache.spark.sql.execution.ExecSubqueryExpression
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
@@ -343,10 +344,12 @@ object IcebergScanTransformer {
       RowIndexMetadataColumnNames
 
   def apply(batchScan: BatchScanExec): IcebergScanTransformer = {
+    val output =
+      batchScan.output.map(a => a.withName(AvroSchemaUtil.makeCompatibleName(a.name)))
     new IcebergScanTransformer(
-      batchScan.output.map(a => a.withName(AvroSchemaUtil.makeCompatibleName(a.name))),
+      output,
       batchScan.scan,
-      batchScan.runtimeFilters,
+      runtimeFiltersFor(output, batchScan.runtimeFilters),
       table = SparkShimLoader.getSparkShims.getBatchScanExecTable(batchScan),
       keyGroupedPartitioning = SparkShimLoader.getSparkShims.getKeyGroupedPartitioning(batchScan),
       commonPartitionValues = SparkShimLoader.getSparkShims.getCommonPartitionValues(batchScan)
@@ -374,6 +377,31 @@ object IcebergScanTransformer {
       case s: org.apache.iceberg.types.Types.StructType =>
         s.fields().stream().anyMatch(f => containsMetadataColumn(f))
       case _ => field.fieldId() >= (Integer.MAX_VALUE - 200)
+    }
+  }
+
+  private def runtimeFiltersFor(
+      output: Seq[AttributeReference],
+      runtimeFilters: Seq[Expression]): Seq[Expression] = {
+    if (output.exists(isRowLevelMetadataColumn)) {
+      // Runtime filters are optional pruning. Subquery filters on row-level metadata can be
+      // re-planned by AQE while native Iceberg writes call executeColumnar(), which is unsafe.
+      runtimeFilters.filterNot(containsSubquery)
+    } else {
+      runtimeFilters
+    }
+  }
+
+  private def isRowLevelMetadataColumn(attr: AttributeReference): Boolean = {
+    val name = attr.name.toLowerCase(Locale.ROOT)
+    name == MetadataColumns.FILE_PATH.name().toLowerCase(Locale.ROOT) ||
+    RowIndexMetadataColumnNames.contains(name)
+  }
+
+  private def containsSubquery(expression: Expression): Boolean = {
+    expression.exists {
+      case _: ExecSubqueryExpression => true
+      case _ => false
     }
   }
 }

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -97,9 +97,9 @@ case class IcebergScanTransformer(
       if (notSupport) {
         return ValidationResult.failed("Contains not supported data type or metadata column")
       }
-      // Allow input_file_name() and related metadata functions
+      // Allow Spark's input_file_* functions plus Iceberg copy-on-write metadata columns.
       val allowedMetadataColumns =
-        IcebergScanTransformer.InputFileRelatedMetadataColumnNames
+        IcebergScanTransformer.SupportedMetadataColumnNames
       val hasUnsupportedMetadata = scan.readSchema().fieldNames.exists {
         f =>
           MetadataColumns.isMetadataColumn(f) &&
@@ -188,11 +188,17 @@ case class IcebergScanTransformer(
       !readSchemaFields.contains(name)
   }
 
+  private lazy val nonRowIndexMetadataColumns = metadataColumns.filterNot {
+    attr =>
+      IcebergScanTransformer.RowIndexMetadataColumnNames.contains(
+        attr.name.toLowerCase(Locale.ROOT))
+  }
+
   override def getMetadataColumns(): Seq[AttributeReference] = {
     val extraMetadataColumns = inputFileRelatedMetadataColumns.filterNot {
-      metadataAttr => metadataColumns.exists(_.name.equalsIgnoreCase(metadataAttr.name))
+      metadataAttr => nonRowIndexMetadataColumns.exists(_.name.equalsIgnoreCase(metadataAttr.name))
     }
-    metadataColumns ++ extraMetadataColumns
+    nonRowIndexMetadataColumns ++ extraMetadataColumns
   }
 
   override lazy val fileFormat: ReadFileFormat = GlutenIcebergSourceUtil.getFileFormat(scan)
@@ -271,19 +277,26 @@ case class IcebergScanTransformer(
       case (iceberg: Types.StructType, currentType: Types.StructType, sparkStruct: StructType) =>
         sparkStruct.forall {
           sparkField =>
-            val currentField = new Schema(currentType.fields()).findField(sparkField.name)
-            // Find not exists column
-            if (currentField == null) {
-              false
+            if (
+              IcebergScanTransformer.SupportedMetadataColumnNames.contains(
+                sparkField.name.toLowerCase(Locale.ROOT))
+            ) {
+              true
             } else {
-              val field = new Schema(iceberg.fields()).findField(currentField.fieldId())
-              // The field does not exist in old schema, add column case
-              if (field == null) {
-                true
+              val currentField = new Schema(currentType.fields()).findField(sparkField.name)
+              // Find not exists column
+              if (currentField == null) {
+                false
               } else {
-                // Maybe rename column
-                field.name() == sparkField.name &&
-                typesMatch(field.`type`(), currentField.`type`(), sparkField.dataType)
+                val field = new Schema(iceberg.fields()).findField(currentField.fieldId())
+                // The field does not exist in old schema, add column case
+                if (field == null) {
+                  true
+                } else {
+                  // Maybe rename column
+                  field.name() == sparkField.name &&
+                  typesMatch(field.`type`(), currentField.`type`(), sparkField.dataType)
+                }
               }
             }
         }
@@ -313,6 +326,14 @@ object IcebergScanTransformer {
   private val InputFileRelatedMetadataColumnNames =
     Set("input_file_name", "input_file_block_start", "input_file_block_length")
 
+  private val RowIndexMetadataColumnNames =
+    Set(MetadataColumns.ROW_POSITION.name().toLowerCase(Locale.ROOT))
+
+  private val SupportedMetadataColumnNames =
+    InputFileRelatedMetadataColumnNames ++
+      Set(MetadataColumns.FILE_PATH.name().toLowerCase(Locale.ROOT)) ++
+      RowIndexMetadataColumnNames
+
   def apply(batchScan: BatchScanExec): IcebergScanTransformer = {
     new IcebergScanTransformer(
       batchScan.output.map(a => a.withName(AvroSchemaUtil.makeCompatibleName(a.name))),
@@ -325,8 +346,8 @@ object IcebergScanTransformer {
   }
 
   def supportsBatchScan(scan: Scan): Boolean = {
-    scan.getClass == GlutenIcebergSourceUtil.getClassOfSparkBatchQueryScan &&
-    !GlutenIcebergSourceUtil.isMetadataScan(scan)
+    GlutenIcebergSourceUtil.supportsBatchScan(scan) &&
+      !GlutenIcebergSourceUtil.isMetadataScan(scan)
   }
 
   private def containsUuidOrFixedType(dataType: Type): Boolean = {

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -188,7 +188,15 @@ case class IcebergScanTransformer(
       !readSchemaFields.contains(name)
   }
 
-  private lazy val nonRowIndexMetadataColumns = metadataColumns.filterNot {
+  private lazy val requestedMetadataColumns =
+    (metadataColumns ++ output.filter {
+      attr =>
+        val name = attr.name.toLowerCase(Locale.ROOT)
+        IcebergScanTransformer.SupportedMetadataColumnNames.contains(name) &&
+        MetadataColumns.isMetadataColumn(attr.name)
+    }).distinctBy(_.exprId)
+
+  private lazy val nonRowIndexMetadataColumns = requestedMetadataColumns.filterNot {
     attr =>
       IcebergScanTransformer.RowIndexMetadataColumnNames.contains(
         attr.name.toLowerCase(Locale.ROOT))

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -325,7 +325,8 @@ object IcebergScanTransformer {
   }
 
   def supportsBatchScan(scan: Scan): Boolean = {
-    scan.getClass == GlutenIcebergSourceUtil.getClassOfSparkBatchQueryScan
+    scan.getClass == GlutenIcebergSourceUtil.getClassOfSparkBatchQueryScan &&
+    !GlutenIcebergSourceUtil.isMetadataScan(scan)
   }
 
   private def containsUuidOrFixedType(dataType: Type): Boolean = {

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -16,8 +16,8 @@
  */
 package org.apache.iceberg.spark.source
 
-import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.ContentFileUtil
+import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.SparkDataSourceRDDPartition
 import org.apache.gluten.substrait.rel.{IcebergLocalFilesBuilder, SplitInfo}

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -45,6 +45,11 @@ object GlutenIcebergSourceUtil {
     classOf[SparkBatchQueryScan]
   }
 
+  def isMetadataScan(sparkScan: Scan): Boolean = sparkScan match {
+    case scan: SparkBatchQueryScan => scan.table().isInstanceOf[BaseMetadataTable]
+    case _ => false
+  }
+
   def deleteExists(p: SparkDataSourceRDDPartition): Boolean = {
     p.inputPartitions.exists {
       case ip: SparkInputPartition =>

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.iceberg._
 import org.apache.iceberg.spark.SparkSchemaUtil
 
-import java.lang.{Class, Long => JLong}
+import java.lang.{Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 import java.util.Locale
 
@@ -40,13 +40,18 @@ object GlutenIcebergSourceUtil {
   private val InputFileNameCol = "input_file_name"
   private val InputFileBlockStartCol = "input_file_block_start"
   private val InputFileBlockLengthCol = "input_file_block_length"
+  private val IcebergFilePathCol = MetadataColumns.FILE_PATH.name()
 
-  def getClassOfSparkBatchQueryScan(): Class[SparkBatchQueryScan] = {
-    classOf[SparkBatchQueryScan]
+  def supportsBatchScan(scan: Scan): Boolean = {
+    scan.isInstanceOf[SparkPartitioningAwareScan[_]]
+  }
+
+  private def getScanTasks(scan: SparkPartitioningAwareScan[_]): List[ScanTask] = {
+    scan.tasks().asScala.toList.asInstanceOf[List[ScanTask]]
   }
 
   def isMetadataScan(sparkScan: Scan): Boolean = sparkScan match {
-    case scan: SparkBatchQueryScan => scan.table().isInstanceOf[BaseMetadataTable]
+    case scan: SparkPartitioningAwareScan[_] => scan.table().isInstanceOf[BaseMetadataTable]
     case _ => false
   }
 
@@ -124,6 +129,8 @@ object GlutenIcebergSourceUtil {
           case InputFileNameCol => metadataColumns.put(name, filePath)
           case InputFileBlockStartCol => metadataColumns.put(name, start.toString)
           case InputFileBlockLengthCol => metadataColumns.put(name, length.toString)
+          case icebergName if icebergName == IcebergFilePathCol.toLowerCase(Locale.ROOT) =>
+            metadataColumns.put(name, filePath)
           case _ =>
         }
     }
@@ -131,9 +138,8 @@ object GlutenIcebergSourceUtil {
   }
 
   def getFileFormat(sparkScan: Scan): ReadFileFormat = sparkScan match {
-    case scan: SparkBatchQueryScan =>
-      val tasks = scan.tasks().asScala
-      asFileScanTask(tasks.toList).foreach {
+    case scan: SparkPartitioningAwareScan[_] =>
+      asFileScanTask(getScanTasks(scan)).foreach {
         task =>
           task.file().format() match {
             case FileFormat.PARQUET => return ReadFileFormat.ParquetReadFormat
@@ -141,15 +147,14 @@ object GlutenIcebergSourceUtil {
             case _ =>
           }
       }
-      throw new GlutenNotSupportException("Iceberg Only support parquet and orc file format.")
+      throw new GlutenNotSupportException("Iceberg only supports parquet and orc file format.")
     case _ =>
-      throw new GlutenNotSupportException("Only support iceberg SparkBatchQueryScan.")
+      throw new GlutenNotSupportException("Only support iceberg SparkPartitioningAwareScan.")
   }
 
   def getReadPartitionSchema(sparkScan: Scan): StructType = sparkScan match {
-    case scan: SparkBatchQueryScan =>
-      val tasks = scan.tasks().asScala
-      asFileScanTask(tasks.toList).foreach {
+    case scan: SparkPartitioningAwareScan[_] =>
+      asFileScanTask(getScanTasks(scan)).foreach {
         task =>
           val spec = task.spec()
           if (spec.isPartitioned) {
@@ -186,9 +191,9 @@ object GlutenIcebergSourceUtil {
           }
       }
       throw new UnsupportedOperationException(
-        "Failed to get partition schema from iceberg SparkBatchQueryScan.")
+        "Failed to get partition schema from iceberg SparkPartitioningAwareScan.")
     case _ =>
-      throw new UnsupportedOperationException("Only support iceberg SparkBatchQueryScan.")
+      throw new UnsupportedOperationException("Only support iceberg SparkPartitioningAwareScan.")
   }
 
   private def asFileScanTask(tasks: List[ScanTask]): List[FileScanTask] = {

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -17,6 +17,7 @@
 package org.apache.iceberg.spark.source
 
 import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.ContentFileUtil
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.SparkDataSourceRDDPartition
 import org.apache.gluten.substrait.rel.{IcebergLocalFilesBuilder, SplitInfo}
@@ -81,7 +82,7 @@ object GlutenIcebergSourceUtil {
         val tasks = partition.taskGroup[ScanTask]().tasks().asScala
         asFileScanTask(tasks.toList).foreach {
           task =>
-            val filePath = task.file().path().toString
+            val filePath = ContentFileUtil.getFilePath(task.file())
             paths.add(BackendsApiManager.getTransformerApiInstance.encodeFilePathIfNeed(filePath))
             starts.add(task.start())
             lengths.add(task.length())

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
@@ -29,6 +29,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
   override protected def sparkConf: SparkConf = {
     super.sparkConf
       .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .set("spark.sql.ansi.enabled", "false")
       .set("spark.sql.files.maxPartitionBytes", "1g")
       .set("spark.sql.shuffle.partitions", "1")
       .set("spark.memory.offHeap.size", "2g")
@@ -79,6 +80,34 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
       assert(
         rows.forall(row => !row.isNullAt(1) && row.getString(1).nonEmpty),
         s"Expected non-empty input_file_name values, got: ${rows.mkString(", ")}")
+    }
+  }
+
+  test("iceberg metadata columns") {
+    withTable("iceberg_metadata_tb") {
+      spark.sql("""
+                  |CREATE TABLE iceberg_metadata_tb (id INT, data STRING)
+                  |USING iceberg
+                  |""".stripMargin)
+      spark.sql("""
+                  |INSERT INTO iceberg_metadata_tb VALUES
+                  |(1, 'a'), (2, 'b'), (3, 'c')
+                  |""".stripMargin)
+
+      val df = runAndCompare("""
+                               |SELECT id, _file, _pos
+                               |FROM iceberg_metadata_tb
+                               |ORDER BY id
+                               |""".stripMargin)
+
+      val rows = df.collect()
+      checkGlutenPlan[IcebergScanTransformer](df)
+      assert(
+        rows.forall(row => !row.isNullAt(1) && row.getString(1).nonEmpty),
+        s"Expected non-empty _file values, got: ${rows.mkString(", ")}")
+      assert(
+        rows.forall(row => !row.isNullAt(2) && row.getLong(2) >= 0L),
+        s"Expected non-null non-negative _pos values, got: ${rows.mkString(", ")}")
     }
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/V2WritePostRule.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/V2WritePostRule.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.extension.columnar
 
+import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.ColumnarV2TableWriteExec
 
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -31,10 +32,20 @@ case class V2WritePostRule() extends Rule[SparkPlan] {
        * guarantee to generate columnar outputs. thus avoiding the case of c2r->aqe->r2c->writer.
        */
       write.query match {
-        case aqe: AdaptiveSparkPlanExec if !aqe.supportsColumnar =>
+        case aqe: AdaptiveSparkPlanExec if !aqe.supportsColumnar && canForceColumnarAqe(write) =>
           write.withNewQuery(aqe.copy(supportsColumnar = true))
         case _ => write
       }
     case other => other
+  }
+
+  private def canForceColumnarAqe(write: ColumnarV2TableWriteExec): Boolean = {
+    val glutenConf = GlutenConfig.get
+    val ansiFallbackEnabled = glutenConf.enableAnsiMode && glutenConf.enableAnsiFallback
+    !ansiFallbackEnabled && !hasFallbackTag(write.query)
+  }
+
+  private def hasFallbackTag(plan: SparkPlan): Boolean = {
+    plan.exists { case p: SparkPlan => FallbackTags.nonEmpty(p) }
   }
 }

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -286,6 +286,7 @@ class Spark40Shims extends SparkShims {
 
   def isRowIndexMetadataColumn(name: String): Boolean =
     name == ParquetFileFormat.ROW_INDEX_TEMPORARY_COLUMN_NAME ||
+      name.equalsIgnoreCase("_pos") ||
       name.equalsIgnoreCase("__delta_internal_is_row_deleted")
 
   def findRowIndexColumnIndexInSchema(sparkSchema: StructType): Int = {
@@ -300,7 +301,18 @@ class Spark40Shims extends SparkShims {
               "must be of LongType or IntegerType")
         }
         idx
-      case _ => -1
+      case _ =>
+        sparkSchema.fields.zipWithIndex.find {
+          case (field: StructField, _: Int) =>
+            field.name.equalsIgnoreCase("_pos")
+        } match {
+          case Some((field: StructField, idx: Int)) =>
+            if (field.dataType != LongType && field.dataType != IntegerType) {
+              throw new RuntimeException("_pos must be of LongType or IntegerType")
+            }
+            idx
+          case _ => -1
+        }
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->
This PR fixes several related Iceberg row-level issues in the Velox backend:

- support `_file` and `_pos` metadata columns
- drop subquery runtime filters from row level metadata scans
- fallback Iceberg metadata table scans to Spark
- honor ANSI fallback in the Iceberg update/write path
- align native Iceberg write columns by name after schema evolution