### PR TITLE
[CI] Correct job names to align with tested Spark versions

### DIFF
--- a/.github/workflows/velox_backend_enhanced.yml
+++ b/.github/workflows/velox_backend_enhanced.yml
@@ -170,12 +170,12 @@ jobs:
         with:
           name: arrow-jars-enhanced-centos-7-${{github.sha}}
           path: /root/.m2/repository/org/apache/arrow/
-      - name: Prepare spark.test.home for Spark 3.4.4 (other tests)
+      - name: Prepare spark.test.home for Spark 3.5.5 (other tests)
         run: |
           dnf module -y install python39 && \
           alternatives --set python3 /usr/bin/python3.9 && \
           pip3 install setuptools==77.0.3 && \
-          pip3 install pyspark==3.4.4 cython && \
+          pip3 install pyspark==3.5.5 cython && \
           pip3 install pandas==2.2.3 pyarrow==20.0.0
       - name: Build and Run unit test for Spark 3.5.5 (other tests)
         run: |

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -1416,7 +1416,7 @@ jobs:
         run: |
           rm -rf /opt/shims/spark41
           bash .github/workflows/util/install-spark-resources.sh 4.1
-      - name: Build and Run unit test for Spark 4.0 (slow tests)
+      - name: Build and Run unit test for Spark 4.1 (slow tests)
         run: |
           cd $GITHUB_WORKSPACE/
           yum install -y java-17-openjdk-devel


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update Spark versions in Velox backend CI workflows:
- `velox_backend_enhanced.yml`: Upgrade pyspark dependency from 3.4.4 to 3.5.5 and align the build step name.
- `velox_backend_x86.yml`: Update Spark 4.0 slow tests step to target Spark 4.1.

## How was this patch tested?

Existing CI workflows will validate the changes.

## Was this patch authored or co-authored using generative AI tooling?

No.