### PR TITLE
[MINOR] Add Hadoop 3.4 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1427,6 +1427,12 @@
       </properties>
     </profile>
     <profile>
+      <id>hadoop-3.4</id>
+      <properties>
+        <hadoop.version>3.4.1</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
       <id>dataproc-2.2</id>
       <properties>
         <hadoop.version>3.3.6</hadoop.version>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a standalone `hadoop-3.4` Maven profile with Hadoop version 3.4.1.

## How was this patch tested?

CI

## Was this patch authored or co-authored using generative AI tooling?

No.