### PR TITLE
[CORE] Upgrade Paimon to 1.4.1

### DIFF
--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -1269,7 +1269,7 @@ jobs:
           export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
           export PATH=$JAVA_HOME/bin:$PATH
           java -version
-          $MVN_CMD clean test -Pspark-4.0 -Pscala-2.13 -Pjava-17 -Pbackends-velox -Pdelta \
+          $MVN_CMD clean test -Pspark-4.0 -Pscala-2.13 -Pjava-17 -Pbackends-velox -Pdelta -Ppaimon \
           -Pspark-ut -DargLine="-Dspark.test.home=/opt/shims/spark40/spark_home/" \
           -DtagsToExclude=org.apache.spark.tags.ExtendedSQLTest,org.apache.gluten.tags.UDFTest,org.apache.gluten.tags.EnhancedFeaturesTest,org.apache.gluten.tags.SkipTest
       - name: Upload test report
@@ -1317,7 +1317,7 @@ jobs:
           export JAVA_HOME=/usr/lib/jvm/java-17-openjdk
           export PATH=$JAVA_HOME/bin:$PATH
           java -version
-          $MVN_CMD clean test -Pspark-4.0 -Pscala-2.13 -Pjava-17 -Pbackends-velox -Pdelta -Pspark-ut \
+          $MVN_CMD clean test -Pspark-4.0 -Pscala-2.13 -Pjava-17 -Pbackends-velox -Pdelta -Ppaimon -Pspark-ut \
           -DargLine="-Dspark.test.home=/opt/shims/spark40/spark_home/" \
           -DtagsToInclude=org.apache.spark.tags.ExtendedSQLTest
       - name: Upload test report

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -586,7 +586,7 @@
         </dependency>
         <dependency>
           <groupId>org.apache.paimon</groupId>
-          <artifactId>paimon-spark-${sparkbundle.version}</artifactId>
+          <artifactId>paimon-spark-${sparkbundle.version}_${scala.binary.version}</artifactId>
           <version>${paimon.version}</version>
           <scope>provided</scope>
         </dependency>

--- a/dev/release/build-release.sh
+++ b/dev/release/build-release.sh
@@ -67,5 +67,5 @@ done
 
 for spark_version in 4.0
 do
-  ${GLUTEN_HOME}/build/mvn clean install -Pjava-17 -Pscala-2.13 -Pbackends-velox -Pspark-${spark_version} -Piceberg -DskipTests
+  ${GLUTEN_HOME}/build/mvn clean install -Pjava-17 -Pscala-2.13 -Pbackends-velox -Pspark-${spark_version} -Piceberg,paimon -DskipTests
 done

--- a/gluten-paimon/pom.xml
+++ b/gluten-paimon/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.paimon</groupId>
-      <artifactId>paimon-spark-${sparkbundle.version}</artifactId>
+      <artifactId>paimon-spark-${sparkbundle.version}_${scala.binary.version}</artifactId>
       <version>${paimon.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <sparkshim.artifactId>spark-sql-columnar-shims-spark35</sparkshim.artifactId>
     <iceberg.version>1.10.0</iceberg.version>
     <iceberg.binary.version>10</iceberg.binary.version>
-    <paimon.version>1.2.0</paimon.version>
+    <paimon.version>1.4.1</paimon.version>
     <delta.package.name>delta-spark</delta.package.name>
     <delta.version>3.3.2</delta.version>
     <delta.binary.version>33</delta.binary.version>
@@ -1257,7 +1257,6 @@
         <delta.version>4.0.1</delta.version>
         <delta.binary.version>40</delta.binary.version>
         <hudi.version>1.1.0</hudi.version>
-        <paimon.version>1.3.0</paimon.version>
         <fasterxml.version>2.18.2</fasterxml.version>
         <fasterxml.jackson.version>2.18.2</fasterxml.jackson.version>
         <fasterxml.jackson.databind.version>2.18.2</fasterxml.jackson.databind.version>
@@ -1338,7 +1337,6 @@
         <delta.version>4.0.0</delta.version>
         <delta.binary.version>40</delta.binary.version>
         <hudi.version>1.1.0</hudi.version>
-        <paimon.version>1.3.0</paimon.version>
         <fasterxml.version>2.18.2</fasterxml.version>
         <fasterxml.jackson.version>2.18.2</fasterxml.jackson.version>
         <fasterxml.jackson.databind.version>2.18.2</fasterxml.jackson.databind.version>


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Upgrade default Paimon version from 1.2.0 to 1.4.1
- Remove hardcoded Paimon 1.3.0 from Spark 4.0 and Spark 4.1 profiles to inherit from the default
- Fix Paimon artifact name to include the Scala binary version suffix (`_${scala.binary.version}`) as required by Paimon 1.3+

## How was this patch tested?

Existing tests.

## Was this patch authored or co-authored using generative AI tooling?

No.