### PR TITLE
[INFRA] Upgrade scalafmt to 3.10.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,7 @@
 runner.dialect = scala212
 
 # Version is required to make sure IntelliJ picks the right version
-version = 3.8.3
+version = 3.10.1
 preset = default
 
 # Max column
@@ -25,6 +25,7 @@ align.openParenDefnSite = false
 align.openParenTupleSite = false
 
 # Newlines
+newlines.source = keep
 newlines.alwaysBeforeElseAfterCurlyIf = false
 newlines.beforeCurlyLambdaParams = multiline # Newline before lambda params
 newlines.afterCurlyLambdaParams = squash # No newline after lambda params
@@ -41,14 +42,15 @@ newlines.topLevelStatementBlankLines = [
 # Scaladoc
 docstrings.style = Asterisk # Javadoc style
 docstrings.removeEmpty = true
-docstrings.oneline = fold
+docstrings.oneline = keep
+docstrings.wrapMaxColumn = 100
 docstrings.forceBlankLineBefore = true
 
 # Indentation
 indent.extendSite = 2 # This makes sure extend is not indented as the ctor parameters
 
 # Rewrites
-rewrite.rules = [AvoidInfix, Imports, RedundantBraces, SortModifiers]
+rewrite.rules = [AvoidInfix, Imports, RedundantBraces, SortModifiers, RemoveSemicolons]
 
 # Imports
 rewrite.imports.sort = scalastyle

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -25,12 +25,14 @@ align.openParenDefnSite = false
 align.openParenTupleSite = false
 
 # Newlines
-newlines.source = keep
 newlines.alwaysBeforeElseAfterCurlyIf = false
 newlines.beforeCurlyLambdaParams = multiline # Newline before lambda params
 newlines.afterCurlyLambdaParams = squash # No newline after lambda params
 newlines.inInterpolation = "avoid"
 newlines.avoidInResultType = true
+# Keep source line breaks so scalafmt does not merge manually wrapped code into
+# lines that exceed Scalastyle's 100-character limit.
+newlines.source = keep
 optIn.annotationNewlines = true
 newlines.topLevelStatementBlankLines = [
   {
@@ -42,6 +44,8 @@ newlines.topLevelStatementBlankLines = [
 # Scaladoc
 docstrings.style = Asterisk # Javadoc style
 docstrings.removeEmpty = true
+# Do not fold multiline Scaladoc into one long line, which can conflict with
+# Scalastyle's 100-character line-length check.
 docstrings.oneline = keep
 docstrings.wrapMaxColumn = 100
 docstrings.forceBlankLineBefore = true

--- a/backends-clickhouse/src-iceberg/test/scala/org/apache/gluten/execution/iceberg/ClickHouseIcebergSuite.scala
+++ b/backends-clickhouse/src-iceberg/test/scala/org/apache/gluten/execution/iceberg/ClickHouseIcebergSuite.scala
@@ -466,8 +466,8 @@ class ClickHouseIcebergSuite extends GlutenClickHouseWholeStageTransformerSuite 
 
       val df =
         spark.sql("select snapshot_id from default.iceberg_tm.snapshots where parent_id is null")
-      val value = df.collectAsList().get(0).getAs[Long](0);
-      spark.sql(s"call system.set_current_snapshot('default.iceberg_tm',$value)");
+      val value = df.collectAsList().get(0).getAs[Long](0)
+      spark.sql(s"call system.set_current_snapshot('default.iceberg_tm',$value)")
       val data = runQueryAndCompare("select * from iceberg_tm") { _ => }
       checkLengthAndPlan(data, 2)
       checkAnswer(data, Row(1, "v1") :: Row(2, "v2") :: Nil)

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHRangeExecTransformer.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/execution/CHRangeExecTransformer.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import com.google.protobuf.StringValue
 import io.substrait.proto.NamedStruct
 
-import scala.collection.JavaConverters;
+import scala.collection.JavaConverters
 
 case class CHRangeExecTransformer(range: LogicalRange)
   extends ColumnarRangeBaseExec

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/AddPreProjectionForHashJoin.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/AddPreProjectionForHashJoin.scala
@@ -169,7 +169,7 @@ case class AddPreProjectionForHashJoin(session: SparkSession)
         andExpressions.foreach {
           e =>
             if (!e.isInstanceOf[EqualTo]) {
-              return false;
+              return false
             }
             val equalExpr = e.asInstanceOf[EqualTo]
             val leftPos = if (equalExpr.left.references.subsetOf(leftOutputSet)) {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/BasicExpressionRewriteRule.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/BasicExpressionRewriteRule.scala
@@ -164,7 +164,7 @@ case class ReplaceSubStringComparison(spark: SparkSession) extends Rule[SparkPla
     val (leftPos, leftLen, leftInnerExpr) = getSubStringPositionAndLength(leftExpression)
     val (rightPos, rightLen, rightInnerExpr) = getSubStringPositionAndLength(rightExpression)
     if (leftLen != rightLen) {
-      return None;
+      return None
     }
 
     val udf = ScalaUDF(

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/CommonSubexpressionEliminateRule.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/CommonSubexpressionEliminateRule.scala
@@ -247,7 +247,7 @@ case class CommonSubexpressionEliminateRule(spark: SparkSession)
     val inputCtx = RewriteContext(exprs, sort.child)
     val outputCtx = rewrite(inputCtx)
 
-    var start = 0;
+    var start = 0
     var newOrder = Seq.empty[SortOrder]
     sort.order.foreach(
       order => {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/extension/PushdownAggregatePreProjectionAheadExpand.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/extension/PushdownAggregatePreProjectionAheadExpand.scala
@@ -111,7 +111,7 @@ case class PushdownAggregatePreProjectionAheadExpand(session: SparkSession)
         }
 
         if (!couldPushDown) {
-          return hashAggregate;
+          return hashAggregate
         }
 
         // The new ahead project node will take rootChild's output and preProjectExprs as the

--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWriteFilesExec.scala
@@ -110,14 +110,14 @@ class CHColumnarWriteFilesRDD(
 
         val writeTaskResult = commitProtocol
           .commitTask(writeResults)
-          .orElse({
+          .orElse {
             // If we are writing an empty iterator, then gluten backend would do nothing.
             // Here we fallback to use vanilla Spark write files to generate an empty file for
             // metadata only.
             Some(
               writeFilesForEmptyIterator(commitProtocol.getTaskAttemptContext, context.partitionId))
             // We have done commit task inside `writeFilesForEmptyIterator`.
-          })
+          }
           .get
         reportTaskMetrics(writeTaskResult)
         Iterator.single(writeTaskResult)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/benchmarks/GenTPCDSTableScripts.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/benchmarks/GenTPCDSTableScripts.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.TPCDSSchema
 import scala.collection.mutable.ArrayBuffer
 
 class TPCDSSchemaProvider extends TPCDSSchema {
-  def getTableSchema: Map[String, String] = tableColumns;
+  def getTableSchema: Map[String, String] = tableColumns
 }
 object GenTPCDSTableScripts {
   val providerInSpark = new TPCDSSchemaProvider()

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseHiveTableSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/hive/GlutenClickHouseHiveTableSuite.scala
@@ -216,7 +216,8 @@ class GlutenClickHouseHiveTableSuite
           case l: HiveTableScanExecTransformer => l
         }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("test hive text table using user define input format") {
@@ -241,7 +242,8 @@ class GlutenClickHouseHiveTableSuite
           case l: HiveTableScanExecTransformer => l
         }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("test hive text table with unordered columns") {
@@ -255,7 +257,8 @@ class GlutenClickHouseHiveTableSuite
           case l: HiveTableScanExecTransformer => l
         }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("test hive text table with count(1)/count(*)") {
@@ -298,7 +301,8 @@ class GlutenClickHouseHiveTableSuite
           case l: HiveTableScanExecTransformer => l
         }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("fix bug: hive text table limit with fallback") {
@@ -317,7 +321,8 @@ class GlutenClickHouseHiveTableSuite
           case l: HiveTableScanExecTransformer => l
         }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("hive text table select complex type columns with fallback") {
@@ -335,7 +340,8 @@ class GlutenClickHouseHiveTableSuite
           case l: HiveTableScanExecTransformer => l
         }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("test hive json table") {
@@ -600,7 +606,8 @@ class GlutenClickHouseHiveTableSuite
                   case l: HiveTableScanExecTransformer => l
                 }
               assert(txtFileScan.size == 1)
-            })
+            }
+          )
       }
     }
   }
@@ -624,7 +631,8 @@ class GlutenClickHouseHiveTableSuite
         val txtFileScan =
           collect(df.queryExecution.executedPlan) { case l: HiveTableScanExecTransformer => l }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("test orc/parquet table with null complex type values") {
@@ -735,7 +743,8 @@ class GlutenClickHouseHiveTableSuite
         val txtFileScan =
           collect(df.queryExecution.executedPlan) { case l: HiveTableScanExecTransformer => l }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("GLUTEN-2180: Test data field type not match") {
@@ -759,7 +768,8 @@ class GlutenClickHouseHiveTableSuite
         val txtFileScan =
           collect(df.queryExecution.executedPlan) { case l: HiveTableScanExecTransformer => l }
         assert(txtFileScan.size == 1)
-      })
+      }
+    )
   }
 
   test("test parquet push down filter skip row groups") {
@@ -1362,7 +1372,7 @@ class GlutenClickHouseHiveTableSuite
     val insert_sql = "insert into test_tbl_7502 values(1, cast('2024-10-09 20:00:00' as timestamp))"
     val select_sql = "select * from test_tbl_7502"
     spark.sql(create_table_sql)
-    spark.sql(insert_sql);
+    spark.sql(insert_sql)
     compareResultsAgainstVanillaSpark(select_sql, compareResult = true, _ => {})
     spark.sql("drop table test_tbl_7502")
   }

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
@@ -42,7 +42,7 @@ class GlutenClickHouseTPCDSMetricsSuite extends GlutenClickHouseTPCDSAbstractSui
   }
 
   test("test tpcds q47 metrics") {
-    TaskResources.runUnsafe({
+    TaskResources.runUnsafe {
       // Test getting metrics
       val inBatchIters = new java.util.ArrayList[ColumnarNativeIterator](
         Array(0).map(iter => new ColumnarNativeIterator(Iterator.empty.asJava)).toSeq.asJava)
@@ -71,7 +71,7 @@ class GlutenClickHouseTPCDSMetricsSuite extends GlutenClickHouseTPCDSAbstractSui
           .getOutputRows == 0)
       assert(nativeMetricsData.metricsDataList.get(2).getName.equals("kWindow"))
       assert(nativeMetricsData.metricsDataList.get(4).getName.equals("kWindow"))
-    })
+    }
     // Test metrics update
     val df = GlutenClickHouseMetricsUTUtils.getTPCDSQueryExecution(spark, "q47", tpcdsQueries)
     val allWholeStageTransformers = df.queryExecution.executedPlan.collect {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQEConcurrentSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHParquetAQEConcurrentSuite.scala
@@ -43,7 +43,8 @@ class GlutenClickHouseTPCHParquetAQEConcurrentSuite extends ParquetTPCHSuite {
       df =>
         val result = df.collect()
         val schema = df.schema
-        if (schema.exists(_.dataType == DoubleType)) {} else {
+        if (schema.exists(_.dataType == DoubleType)) {}
+        else {
           compareResultStr(s"q$queryNum", result, queriesResults)
         }
         checkDataFrame(noFallBack = true, NOOP, df)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -2233,7 +2233,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         |  ) t1
         |) t2 where rank = 1 order by p_partkey limit 100
         |""".stripMargin
-    runQueryAndCompare(sql)({ _ => })
+    runQueryAndCompare(sql) { _ => }
   }
 
   test("GLUTEN-7979: fix different output schema array<void> and array<string> before union") {
@@ -2283,7 +2283,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         |group by
         |    a.multi_peer_user_id
         |""".stripMargin
-    runQueryAndCompare(sql)({ _ => })
+    runQueryAndCompare(sql) { _ => }
   }
 
   test("GLUTEN-4190: crush on flattening a const null column") {
@@ -2292,7 +2292,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         | select n_nationkey, rank() over (partition by n_regionkey, null order by n_nationkey)
         |from nation
         |""".stripMargin
-    runQueryAndCompare(sql)({ _ => })
+    runQueryAndCompare(sql) { _ => }
   }
 
   test("GLUTEN-4115 aggregate without any function") {
@@ -2312,7 +2312,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         |values(0,'d', 4.0,1), (1, 'a', 1.0, 0), (0, 'b', 2.0, 1), (1, 'c', 3.0, 0) as data(a,b,c,d)
         |)
         |""".stripMargin
-    runQueryAndCompare(sql)({ _ => })
+    runQueryAndCompare(sql) { _ => }
   }
 
   test("GLUTEN-4085: Fix unix_timestamp/to_unix_timestamp") {
@@ -2412,7 +2412,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
           |  select l_orderkey, l_partkey from lineitem group by l_orderkey, l_partkey
           |)
           |""".stripMargin
-      runQueryAndCompare(sql)({ _ => })
+      runQueryAndCompare(sql) { _ => }
     }
   }
 
@@ -2448,26 +2448,26 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
     // single percentage
     val sql1 = "select l_linenumber % 10, approx_percentile(l_extendedprice, 0.5) " +
       "from lineitem group by l_linenumber % 10"
-    runQueryAndCompare(sql1)({ _ => })
+    runQueryAndCompare(sql1) { _ => }
 
     // multiple percentages
     val sql2 =
       "select l_linenumber % 10, approx_percentile(l_extendedprice, array(0.1, 0.2, 0.3)) " +
         "from lineitem group by l_linenumber % 10"
-    runQueryAndCompare(sql2)({ _ => })
+    runQueryAndCompare(sql2) { _ => }
   }
 
   test("aggregate function percentile") {
     // single percentage
     val sql1 = "select l_linenumber % 10, percentile(l_extendedprice, 0.5) " +
       "from lineitem group by l_linenumber % 10"
-    runQueryAndCompare(sql1)({ _ => })
+    runQueryAndCompare(sql1) { _ => }
 
     // multiple percentages
     val sql2 =
       "select l_linenumber % 10, percentile(l_extendedprice, array(0.1, 0.2, 0.3)) " +
         "from lineitem group by l_linenumber % 10"
-    runQueryAndCompare(sql2)({ _ => })
+    runQueryAndCompare(sql2) { _ => }
   }
 
   test("GLUTEN-5096: Bug fix regexp_extract diff") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/s3/S3AuthSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/s3/S3AuthSuite.scala
@@ -84,7 +84,7 @@ class S3AuthSuite extends AnyFunSuite {
     def withAuthMode(mode: String, assuming: Boolean): Builder = {
       val providerKey =
         if (assuming) "spark.hadoop.fs.s3a.assumed.role.credentials.provider"
-        else "spark.hadoop.fs.s3a.aws.credentials.provider";
+        else "spark.hadoop.fs.s3a.aws.credentials.provider"
 
       mode match {
         case "AKSK" =>

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/extension/GlutenCustomerExtensionSuite.scala
@@ -103,7 +103,8 @@ case class TestFileSourceScanExecTransformer(
     optionalNumCoalescedBuckets,
     dataFilters,
     tableIdentifier,
-    disableBucketedScan) {
+    disableBucketedScan
+  ) {
 
   override def getPartitions: Seq[Partition] =
     BackendsApiManager.getTransformerApiInstance

--- a/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
+++ b/backends-velox/src-celeborn/main/scala/org/apache/spark/shuffle/VeloxCelebornColumnarBatchSerializer.scala
@@ -193,7 +193,7 @@ private class CelebornColumnarBatchSerializerInstance(
 
     @throws(classOf[EOFException])
     override def readValue[T: ClassTag](): T = {
-      initStream();
+      initStream()
       if (cb != null) {
         cb.close()
         cb = null

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
@@ -444,7 +444,7 @@ case class GlutenDeltaParquetFileFormat(
             // mutable [[InternalRow]] and set the `row_index` and `is_row_deleted`
             // column values. This is not efficient. It should affect only the wide
             // tables. https://github.com/delta-io/delta/issues/2246
-            val newRow = columnarRow.copy();
+            val newRow = columnarRow.copy()
             isRowDeletedColumnOpt.foreach {
               columnMetadata =>
                 val rowIndexForFiltering = if (useMetadataRowIndex) {

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
@@ -154,15 +154,16 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
       val writePartitionColumns = IcebergCompat.isAnyEnabled(metadata)
       // Retain only a minimal selection of Spark writer options to avoid any potential
       // compatibility issues
-      val options = (writeOptions match {
-        case None => Map.empty[String, String]
-        case Some(writeOptions) =>
-          writeOptions.options.filterKeys {
-            key =>
-              key.equalsIgnoreCase(DeltaOptions.MAX_RECORDS_PER_FILE) ||
-              key.equalsIgnoreCase(DeltaOptions.COMPRESSION)
-          }.toMap
-      }) + (DeltaOptions.WRITE_PARTITION_COLUMNS -> writePartitionColumns.toString)
+      val options =
+        (writeOptions match {
+          case None => Map.empty[String, String]
+          case Some(writeOptions) =>
+            writeOptions.options.filterKeys {
+              key =>
+                key.equalsIgnoreCase(DeltaOptions.MAX_RECORDS_PER_FILE) ||
+                key.equalsIgnoreCase(DeltaOptions.COMPRESSION)
+            }.toMap
+        }) + (DeltaOptions.WRITE_PARTITION_COLUMNS -> writePartitionColumns.toString)
 
       try {
         GlutenDeltaFileFormatWriter.write(
@@ -180,9 +181,10 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
           // scalastyle:on deltahadoopconfiguration
           partitionColumns = partitioningColumns,
           bucketSpec = None,
-          statsTrackers = optionalStatsTracker.toSeq
-            ++ statsTrackers
-            ++ identityTrackerOpt.toSeq,
+          statsTrackers =
+            optionalStatsTracker.toSeq
+              ++ statsTrackers
+              ++ identityTrackerOpt.toSeq,
           options = options
         )
       } catch {

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -298,7 +298,7 @@ object GlutenDeltaJobStatsTracker extends Logging {
                   } catch {
                     case _: InterruptedException =>
                       Thread.currentThread().interrupt()
-                      return false;
+                      return false
                   }
                 if (tmp.isDefined) {
                   batch = tmp.get

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -484,7 +484,8 @@ abstract class DeltaDDLTestBase extends QueryTest with DeltaSQLTestUtils {
   testAlterTableNestedFields("struct in nested arrays")(
     initialColumnType = "array<array<struct<a: int>>>",
     fieldToAdd = "element.element.b" -> "string",
-    updatedColumnType = "array<array<struct<a: int, b: string>>>")
+    updatedColumnType = "array<array<struct<a: int, b: string>>>"
+  )
 
   testAlterTableNestedFields("struct in nested array and map")(
     initialColumnType = "array<map<int, struct<a: int>>>",

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -127,7 +127,8 @@ abstract class UpdateSuiteBase
               checkUpdate(
                 condition = Some("key >= 1 and value != 4"),
                 setClauses = "value = key + value, key = key + 5",
-                expectedResults = Row(0, 3) :: Row(7, 4) :: Row(1, 4) :: Row(6, 2) :: Nil)
+                expectedResults = Row(0, 3) :: Row(7, 4) :: Row(1, 4) :: Row(6, 2) :: Nil
+              )
             }
           }
       }

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
@@ -154,15 +154,16 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
       val writePartitionColumns = IcebergCompat.isAnyEnabled(metadata)
       // Retain only a minimal selection of Spark writer options to avoid any potential
       // compatibility issues
-      val options = (writeOptions match {
-        case None => Map.empty[String, String]
-        case Some(writeOptions) =>
-          writeOptions.options.filterKeys {
-            key =>
-              key.equalsIgnoreCase(DeltaOptions.MAX_RECORDS_PER_FILE) ||
-              key.equalsIgnoreCase(DeltaOptions.COMPRESSION)
-          }.toMap
-      }) + (DeltaOptions.WRITE_PARTITION_COLUMNS -> writePartitionColumns.toString)
+      val options =
+        (writeOptions match {
+          case None => Map.empty[String, String]
+          case Some(writeOptions) =>
+            writeOptions.options.filterKeys {
+              key =>
+                key.equalsIgnoreCase(DeltaOptions.MAX_RECORDS_PER_FILE) ||
+                key.equalsIgnoreCase(DeltaOptions.COMPRESSION)
+            }.toMap
+        }) + (DeltaOptions.WRITE_PARTITION_COLUMNS -> writePartitionColumns.toString)
 
       try {
         GlutenDeltaFileFormatWriter.write(
@@ -180,9 +181,10 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
           // scalastyle:on deltahadoopconfiguration
           partitionColumns = partitioningColumns,
           bucketSpec = None,
-          statsTrackers = optionalStatsTracker.toSeq
-            ++ statsTrackers
-            ++ identityTrackerOpt.toSeq,
+          statsTrackers =
+            optionalStatsTracker.toSeq
+              ++ statsTrackers
+              ++ identityTrackerOpt.toSeq,
           options = options
         )
       } catch {

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -302,7 +302,7 @@ object GlutenDeltaJobStatsTracker extends Logging {
                   } catch {
                     case _: InterruptedException =>
                       Thread.currentThread().interrupt()
-                      return false;
+                      return false
                   }
                 if (tmp.isDefined) {
                   batch = tmp.get

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -162,10 +162,9 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
     }
   }
 
-  override def getDecimalArithmeticExprName(exprName: String): String = if (
-    !SQLConf.get.decimalOperationsAllowPrecisionLoss
-  ) { exprName + "_deny_precision_loss" }
-  else { exprName }
+  override def getDecimalArithmeticExprName(exprName: String): String =
+    if (!SQLConf.get.decimalOperationsAllowPrecisionLoss) { exprName + "_deny_precision_loss" }
+    else { exprName }
 
   /** Transform map_entries to Substrait. */
   override def genMapEntriesTransformer(

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialGenerateExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialGenerateExec.scala
@@ -364,10 +364,10 @@ case class ColumnarPartialGenerateExec(generateExec: GenerateExec, child: SparkP
 
     Iterators
       .wrap(Iterator.single(resultBatch))
-      .recycleIterator({
+      .recycleIterator {
         rightArrowBatch.close()
         rightResultVectors.foreach(_.close())
-      })
+      }
       .create()
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -250,10 +250,10 @@ case class ColumnarPartialProjectExec(projectList: Seq[Expression], child: Spark
     a2c += System.currentTimeMillis() - start2
     Iterators
       .wrap(Iterator.single(veloxBatch))
-      .recycleIterator({
+      .recycleIterator {
         arrowBatch.close()
         targetBatch.close()
-      })
+      }
       .create()
     // TODO: should check the size <= 1, but now it has bug, will change iterator to empty
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
@@ -136,7 +136,7 @@ case class GenerateExecTransformer(
       } else {
         // Other generator function only have one param, so we just check whether
         // the only param(generator.children.head) is attribute reference or not.
-        !isAttributeReference(generator.children.head, true);
+        !isAttributeReference(generator.children.head, true)
       }
 
       parametersStr

--- a/backends-velox/src/main/scala/org/apache/gluten/metrics/MetricsUtil.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/metrics/MetricsUtil.scala
@@ -257,7 +257,9 @@ object MetricsUtil extends Logging {
     mutNode.updater match {
       case smj: SortMergeJoinMetricsUpdater =>
         val joinParams = Option(joinParamsMap.get(operatorIdx)).getOrElse {
-          val p = JoinParams(); p.postProjectionNeeded = false; p
+          val p = JoinParams()
+          p.postProjectionNeeded = false
+          p
         }
         smj.updateJoinMetrics(operatorMetrics, metrics.getSingleMetrics, joinParams)
       case ju: JoinMetricsUpdaterBase =>
@@ -266,7 +268,9 @@ object MetricsUtil extends Logging {
         operatorMetrics.add(metrics.getOperatorMetrics(curMetricsIdx))
         curMetricsIdx -= 1
         val joinParams = Option(joinParamsMap.get(operatorIdx)).getOrElse {
-          val p = JoinParams(); p.postProjectionNeeded = false; p
+          val p = JoinParams()
+          p.postProjectionNeeded = false
+          p
         }
         ju.updateJoinMetrics(operatorMetrics, metrics.getSingleMetrics, joinParams)
       case u: UnionMetricsUpdater =>

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/SparkWriteFilesCommitProtocol.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/SparkWriteFilesCommitProtocol.scala
@@ -107,11 +107,12 @@ class SparkWriteFilesCommitProtocol(
     stagingDir.toString
   }
 
-  private def enrichWriteError[T](path: => String)(f: => T): T = try {
-    f
-  } catch {
-    case t: Throwable => SparkShimLoader.getSparkShims.enrichWriteException(t, description.path)
-  }
+  private def enrichWriteError[T](path: => String)(f: => T): T =
+    try {
+      f
+    } catch {
+      case t: Throwable => SparkShimLoader.getSparkShims.enrichWriteException(t, description.path)
+    }
 
   def commitTask(): Unit = enrichWriteError(description.path) {
     val (_, taskCommitTime) = Utils.timeTakenMs {

--- a/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/expression/UDFResolver.scala
@@ -344,7 +344,7 @@ object UDFResolver extends Logging {
 
     val allowTypeConversion = checkAllowTypeConversion
     val signatures =
-      UDFMap.getOrElse(name, throw new GlutenNotSupportException(errorMessage));
+      UDFMap.getOrElse(name, throw new GlutenNotSupportException(errorMessage))
     signatures.find(sig => tryBind(sig, children.map(_.dataType), allowTypeConversion)) match {
       case Some(sig) =>
         UDFExpression(

--- a/backends-velox/src/test/scala/org/apache/gluten/utils/ParquetEncryptionDetectionSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/utils/ParquetEncryptionDetectionSuite.scala
@@ -44,14 +44,12 @@ import scala.collection.JavaConverters._
  *   1. Plain Parquet File:
  *      - Writes a Parquet file with no encryption.
  *      - Asserts that parquet is not encrypted
- *
- * 2. Encrypted Parquet File (with encrypted footer):
- *   - Writes a Parquet file with column-level encryption and an encrypted footer.
- *   - Asserts that the file is encrypted.
- *
- * 3. Encrypted Parquet File (with plaintext footer):
- *   - Writes a Parquet file with column-level encryption but a plaintext (unencrypted) footer.
- *   - Ensures the file is still detected as encrypted despite the plaintext footer.
+ *   2. Encrypted Parquet File (with encrypted footer):
+ *      - Writes a Parquet file with column-level encryption and an encrypted footer.
+ *      - Asserts that the file is encrypted.
+ *   3. Encrypted Parquet File (with plaintext footer):
+ *      - Writes a Parquet file with column-level encryption but a plaintext (unencrypted) footer.
+ *      - Ensures the file is still detected as encrypted despite the plaintext footer.
  */
 
 class ParquetEncryptionDetectionSuite extends SharedSparkSession {

--- a/gluten-arrow/src/main/scala/org/apache/gluten/utils/ArrowAbiUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/gluten/utils/ArrowAbiUtil.scala
@@ -98,7 +98,7 @@ object ArrowAbiUtil {
       array: ArrowArray): VectorSchemaRoot = {
     val provider = new CDataDictionaryProvider
 
-    val vsr = VectorSchemaRoot.create(schema, allocator);
+    val vsr = VectorSchemaRoot.create(schema, allocator)
     try {
       if (array != null) {
         Data.importIntoVectorSchemaRoot(allocator, array, vsr, provider)

--- a/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkVectorUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkVectorUtil.scala
@@ -46,9 +46,9 @@ object SparkVectorUtil {
     val buffers = new java.util.ArrayList[ArrowBuf]()
     cols.foreach(
       vector => {
-        appendNodes(vector.asInstanceOf[FieldVector], nodes, buffers);
+        appendNodes(vector.asInstanceOf[FieldVector], nodes, buffers)
       })
-    new ArrowRecordBatch(numRows, nodes, buffers);
+    new ArrowRecordBatch(numRows, nodes, buffers)
   }
 
   def getArrowBuffers(vector: FieldVector): Array[ArrowBuf] = {

--- a/gluten-core/src/main/scala/org/apache/gluten/config/ConfigBuilder.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/config/ConfigBuilder.scala
@@ -19,7 +19,7 @@ package org.apache.gluten.config
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
 
 import java.util.concurrent.TimeUnit
-import java.util.regex.Pattern;
+import java.util.regex.Pattern
 
 object BackendType extends Enumeration {
   type BackendType = Value

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNode.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNode.scala
@@ -64,7 +64,7 @@ object OffloadSingleNode {
      * with 'DummyLeafExec' nodes so they are not accessible from the rule body.
      */
     def toStrcitRule(): OffloadSingleNode = {
-      new StrictRule(rule);
+      new StrictRule(rule)
     }
   }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/injector/InjectorControl.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/injector/InjectorControl.scala
@@ -57,8 +57,8 @@ object InjectorControl {
   private object Disabler {
     implicit private[injector] class DisablerOps(disabler: Disabler) {
       def wrapRule[TreeType <: TreeNode[_]](
-          ruleBuilder: SparkSession => Rule[TreeType]): SparkSession => Rule[TreeType] = session =>
-        {
+          ruleBuilder: SparkSession => Rule[TreeType]): SparkSession => Rule[TreeType] =
+        session => {
           val rule = ruleBuilder(session)
           new Rule[TreeType] with DisablerAware {
             override val ruleName: String = rule.ruleName

--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemoryTarget.scala
@@ -79,7 +79,7 @@ class GlobalOffHeapMemoryTarget private[memory]
                   s"Requested: $size, " +
                   s"Storage: $storageUsed / $onHeapMemoryTotal, " +
                   s"Execution: $executionUsed / $onHeapMemoryTotal")
-              return 0;
+              return 0
             }
             val storageUsed = mm.offHeapStorageMemoryUsed
             val executionUsed = mm.offHeapExecutionMemoryUsed
@@ -88,7 +88,7 @@ class GlobalOffHeapMemoryTarget private[memory]
               s"Spark off-heap memory is exhausted." +
                 s" Storage: $storageUsed / $offHeapMemoryTotal," +
                 s" execution: $executionUsed / $offHeapMemoryTotal")
-            return 0;
+            return 0
           }
       }
       .getOrElse(size)

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
@@ -171,7 +171,7 @@ object ComponentSuite {
   }
 
   private trait CompatibilityHelper extends Component {
-    private var _isRuntimeCompatible: Boolean = true;
+    private var _isRuntimeCompatible: Boolean = true
 
     override def isRuntimeCompatible: Boolean = _isRuntimeCompatible
 

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergWriteExec.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergWriteExec.scala
@@ -30,8 +30,8 @@ trait IcebergWriteExec extends ColumnarV2TableWriteExec {
 
   protected def getFileFormat(format: FileFormat): Int = {
     format match {
-      case FileFormat.PARQUET => 1;
-      case FileFormat.ORC => 0;
+      case FileFormat.PARQUET => 1
+      case FileFormat.ORC => 0
       case _ => throw new UnsupportedOperationException()
     }
   }

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
@@ -472,8 +472,8 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
 
       val df =
         spark.sql("select snapshot_id from default.iceberg_tm.snapshots where parent_id is null")
-      val value = df.collectAsList().get(0).getAs[Long](0);
-      spark.sql(s"call system.set_current_snapshot('default.iceberg_tm',$value)");
+      val value = df.collectAsList().get(0).getAs[Long](0)
+      spark.sql(s"call system.set_current_snapshot('default.iceberg_tm',$value)")
       val data = runQueryAndCompare("select * from iceberg_tm") { _ => }
       checkLengthAndPlan(data, 2)
       checkAnswer(data, Row(1, "v1") :: Row(2, "v2") :: Nil)

--- a/gluten-kafka/src/main/scala/org/apache/gluten/execution/MicroBatchScanExecTransformer.scala
+++ b/gluten-kafka/src/main/scala/org/apache/gluten/execution/MicroBatchScanExecTransformer.scala
@@ -105,7 +105,7 @@ case class MicroBatchScanExecTransformer(
 
   override protected def doTransform(context: SubstraitContext): TransformContext = {
     val ctx = super.doTransform(context)
-    ctx.root.asInstanceOf[ReadRelNode].setStreamKafka(true);
+    ctx.root.asInstanceOf[ReadRelNode].setStreamKafka(true)
     ctx
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -714,7 +714,7 @@ object GlutenConfig extends ConfigRegistry {
     buildConf("spark.gluten.sql.supported.flattenNestedFunctions")
       .doc("Flatten nested functions as one for optimization.")
       .stringConf
-      .createWithDefault("and,or");
+      .createWithDefault("and,or")
 
   val PUSH_AGGREGATE_THROUGH_JOIN_ENABLED =
     buildConf("spark.gluten.sql.pushAggregateThroughJoin.enabled")
@@ -1376,13 +1376,13 @@ object GlutenConfig extends ConfigRegistry {
     buildConf("spark.gluten.sql.text.input.max.block.size")
       .doc("the max block size for text input rows")
       .bytesConf(ByteUnit.BYTE)
-      .createWithDefaultString("8KB");
+      .createWithDefaultString("8KB")
 
   val TEXT_INPUT_EMPTY_AS_DEFAULT =
     buildConf("spark.gluten.sql.text.input.empty.as.default")
       .doc("treat empty fields in CSV input as default values.")
       .booleanConf
-      .createWithDefault(false);
+      .createWithDefault(false)
 
   val ENABLE_REWRITE_DATE_TIMESTAMP_COMPARISON =
     buildConf("spark.gluten.sql.rewrite.dateTimestampComparison")

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/FileSourceScanExecTransformer.scala
@@ -59,7 +59,8 @@ case class FileSourceScanExecTransformer(
     optionalNumCoalescedBuckets,
     dataFilters,
     tableIdentifier,
-    disableBucketedScan) {
+    disableBucketedScan
+  ) {
 
   override def doCanonicalize(): FileSourceScanExecTransformer = {
     FileSourceScanExecTransformer(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConverterUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConverterUtils.scala
@@ -286,11 +286,11 @@ object ConverterUtils extends Logging {
         val elementType = parseFromTypeNode(a.getNestedType)
         ArrayType(elementType, a.getNestedType.nullable())
       case s: StructNode =>
-        val fields = s.getFieldTypes.asScala.map({
+        val fields = s.getFieldTypes.asScala.map {
           typ =>
             val field = parseFromTypeNode(typ)
             StructField("", field, typ.nullable())
-        })
+        }
         StructType(fields.toSeq)
       case _: NothingNode =>
         NullType

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/heuristic/ExpandFallbackPolicy.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/heuristic/ExpandFallbackPolicy.scala
@@ -22,6 +22,7 @@ import org.apache.gluten.extension.columnar.{FallbackTag, FallbackTags}
 import org.apache.gluten.extension.columnar.FallbackTags.add
 import org.apache.gluten.extension.columnar.transition.{BackendTransitions, ColumnarToRowLike, RowToColumnarLike}
 import org.apache.gluten.utils.PlanUtil
+
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNode
 import org.apache.spark.sql.execution._

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
@@ -117,13 +117,13 @@ case class GlutenAutoAdjustStageResourceProfile(glutenConf: GlutenConfig, spark:
     val totalCount = planNodes.size
 
     if (1.0 * fallenNodeCnt / totalCount >= glutenConf.autoAdjustStageFallenNodeThreshold) {
-      val newMemoryAmount = memoryRequest.get.amount * glutenConf.autoAdjustStageRPHeapRatio;
+      val newMemoryAmount = memoryRequest.get.amount * glutenConf.autoAdjustStageRPHeapRatio
       val newExecutorMemory =
         new ExecutorResourceRequest(ResourceProfile.MEMORY, newMemoryAmount.toLong)
       executorResource.put(ResourceProfile.MEMORY, newExecutorMemory)
 
       val newOffHeapMemoryAmount =
-        offheapRequest.get.amount * glutenConf.autoAdjustStageRPOffHeapRatio;
+        offheapRequest.get.amount * glutenConf.autoAdjustStageRPOffHeapRatio
       val newExecutorOffheap =
         new ExecutorResourceRequest(ResourceProfile.OFFHEAP_MEM, newOffHeapMemoryAmount.toLong)
       executorResource.put(ResourceProfile.OFFHEAP_MEM, newExecutorOffheap)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -21,13 +21,14 @@ import org.apache.gluten.execution.{GlutenPlan, WholeStageTransformer}
 import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.PlanUtil
+
 import org.apache.spark.sql.{Column, Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{CommandResult, LogicalPlan}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.execution.ColumnarWriteFilesExec.NoopLeaf
-import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, AdaptiveSparkPlanExec, QueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, QueryStageExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
 import org.apache.spark.sql.execution.datasources.WriteFilesExec
@@ -109,8 +110,9 @@ object GlutenImplicits {
       tmp.foreachUp {
         case _: ExecutedCommandExec =>
         case cmd: CommandResultExec => collect(cmd.commandPhysicalPlan)
-        case p: V2CommandExec if FallbackTags.nonEmpty(p) ||
-            p.logicalLink.exists(FallbackTags.getOption(_).nonEmpty) =>
+        case p: V2CommandExec
+            if FallbackTags.nonEmpty(p) ||
+              p.logicalLink.exists(FallbackTags.getOption(_).nonEmpty) =>
           GlutenExplainUtils.handleVanillaSparkPlan(p, fallbackNodeToReason)
         case _: V2CommandExec =>
         case _: DataWritingCommandExec =>
@@ -132,7 +134,9 @@ object GlutenImplicits {
             withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false") {
               // re-plan manually to skip cached data
               val newSparkPlan = SparkShimLoader.getSparkShims.createSparkPlan(
-                spark, spark.sessionState.planner, p.inputPlan.logicalLink.get)
+                spark,
+                spark.sessionState.planner,
+                p.inputPlan.logicalLink.get)
               val newExecutedPlan = QueryExecution.prepareExecutedPlan(
                 spark,
                 newSparkPlan

--- a/gluten-substrait/src/test/scala/org/apache/gluten/execution/GlutenQueryComparisonTest.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/execution/GlutenQueryComparisonTest.scala
@@ -103,7 +103,7 @@ abstract class GlutenQueryComparisonTest extends GlutenQueryTest {
     }
     // By default, we will fallback complex type scan but here we should allow
     // to test support of complex type
-    spark.conf.set("spark.gluten.sql.complexType.scan.fallback.enabled", "false");
+    spark.conf.set("spark.gluten.sql.complexType.scan.fallback.enabled", "false")
     val df = dataframe()
     if (cache) {
       df.cache()

--- a/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/sql/WithQueryPlanListener.scala
@@ -51,10 +51,10 @@ trait WithQueryPlanListener extends SharedSparkSession with AnyFunSuiteLike {
 
   override def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
       pos: Position): Unit = {
-    super.test(testName, testTags: _*)({
+    super.test(testName, testTags: _*) {
       testFun
       listeners().foreach(_.invokeAll())
-    })(pos)
+    }(pos)
   }
 
   override def beforeEach(): Unit = {

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -309,7 +309,8 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
             avg("age").cast(StringType),
             stddev_samp("age").cast(StringType),
             min("age").cast(StringType),
-            max("age").cast(StringType))
+            max("age").cast(StringType)
+          )
           checkAnswer(aggOneCol, aggResult)
 
           val describeNoCol = person2.select().describe()

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -114,10 +114,8 @@ import scala.util.control.NonFatal
  * detected, it creates three test cases:
  *
  *   - Scala UDF test case with a Scalar UDF registered as the name 'udf'.
- *
  *   - Python UDF test case with a Python UDF registered as the name 'udf' iff Python executable and
  *     pyspark are available.
- *
  *   - Scalar Pandas UDF test case with a Scalar Pandas UDF registered as the name 'udf' iff Python
  *     executable, pyspark, pandas and pyarrow are available.
  *
@@ -545,7 +543,8 @@ class GlutenSQLQueryTestSuite
         assert(
           segments.size == outputs.size * 3 + 1,
           s"Expected ${outputs.size * 3 + 1} blocks in result file but got ${segments.size}. " +
-            s"Try regenerate the result files.")
+            s"Try regenerate the result files."
+        )
         Seq.tabulate(outputs.size) {
           i =>
             QueryOutput(

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -103,7 +103,8 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to fall back the entire plan.
         assert(outputPlan == originalPlan)
@@ -124,7 +125,8 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to get the plan with columnar rule applied.
         assert(outputPlan != originalPlan)

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
@@ -1006,7 +1006,8 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
           // The top shuffle from repartition is not optimized out.
           optimizeOutRepartition = false,
           optimizeSkewJoin = true,
-          coalescedRead = false)
+          coalescedRead = false
+        )
 
         // Repartition by col and project away the partition cols
         checkSMJ(

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/velox/VeloxAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/adaptive/velox/VeloxAdaptiveQueryExecSuite.scala
@@ -994,7 +994,8 @@ class VeloxAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQLT
           // The top shuffle from repartition is not optimized out.
           optimizeOutRepartition = false,
           optimizeSkewJoin = true,
-          coalescedRead = false)
+          coalescedRead = false
+        )
 
         // Repartition by col and project away the partition cols
         checkSMJ(

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
@@ -60,7 +60,7 @@ object ParquetReadBenchmark extends SqlBasedBenchmark {
   def beforeAll(): Unit = {}
 
   override def getSparkSession: SparkSession = {
-    beforeAll();
+    beforeAll()
     val conf = new SparkConf()
       .setAppName("ParquetReadBenchmark")
       .setIfMissing("spark.master", s"local[$thrdNum]")

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
@@ -92,7 +92,8 @@ class GlutenOrcSourceSuite extends OrcSourceSuite with GlutenSQLTestsBaseTrait {
                 spark.read.orc(path),
                 Seq(
                   Row(java.sql.Timestamp.valueOf("1001-01-01 01:02:03.123456")),
-                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321"))))
+                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321")))
+              )
             }
         }
     }

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -42,7 +42,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       sql(
         "CREATE TABLE test_orc (name STRING, favorite_color STRING)" +
           " USING hive OPTIONS(fileFormat 'orc')")
-      sql("INSERT INTO test_orc VALUES('test_1', 'red')");
+      sql("INSERT INTO test_orc VALUES('test_1', 'red')")
       val df = spark.sql("select * from test_orc")
       checkAnswer(df, Seq(Row("test_1", "red")))
       checkOperatorMatch[HiveTableScanExecTransformer](df)
@@ -126,7 +126,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
           " label STRUCT<label_1:STRING, label_2:STRING>) USING hive OPTIONS(fileFormat 'parquet')")
       sql(
         "INSERT INTO test_subfield VALUES('test_1', 'red', named_struct('label_1', 'label-a'," +
-          "'label_2', 'label-b'))");
+          "'label_2', 'label-b'))")
       val df = spark.sql("select * from test_subfield where name='test_1'")
       checkAnswer(df, Seq(Row("test_1", "red", Row("label-a", "label-b"))))
       checkOperatorMatch[HiveTableScanExecTransformer](df)

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -309,7 +309,8 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
             avg("age").cast(StringType),
             stddev_samp("age").cast(StringType),
             min("age").cast(StringType),
-            max("age").cast(StringType))
+            max("age").cast(StringType)
+          )
           checkAnswer(aggOneCol, aggResult)
 
           val describeNoCol = person2.select().describe()

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenSQLQueryTestSuite.scala
@@ -117,10 +117,8 @@ import scala.util.control.NonFatal
  * detected, it creates three test cases:
  *
  *   - Scala UDF test case with a Scalar UDF registered as the name 'udf'.
- *
  *   - Python UDF test case with a Python UDF registered as the name 'udf' iff Python executable and
  *     pyspark are available.
- *
  *   - Scalar Pandas UDF test case with a Scalar Pandas UDF registered as the name 'udf' iff Python
  *     executable, pyspark, pandas and pyarrow are available.
  *
@@ -556,7 +554,8 @@ class GlutenSQLQueryTestSuite
         assert(
           segments.size == outputs.size * 3 + 1,
           s"Expected ${outputs.size * 3 + 1} blocks in result file but got ${segments.size}. " +
-            s"Try regenerate the result files.")
+            s"Try regenerate the result files."
+        )
         Seq.tabulate(outputs.size) {
           i =>
             QueryOutput(

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
@@ -295,7 +295,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -350,7 +351,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -415,7 +417,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -483,7 +486,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -540,7 +544,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -103,7 +103,8 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to fall back the entire plan.
         assert(outputPlan == originalPlan)
@@ -124,7 +125,8 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to get the plan with columnar rule applied.
         assert(outputPlan != originalPlan)

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
@@ -993,7 +993,8 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
           // The top shuffle from repartition is not optimized out.
           optimizeOutRepartition = false,
           optimizeSkewJoin = true,
-          coalescedRead = false)
+          coalescedRead = false
+        )
 
         // Repartition by col and project away the partition cols
         checkSMJ(

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/adaptive/velox/VeloxAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/adaptive/velox/VeloxAdaptiveQueryExecSuite.scala
@@ -992,7 +992,8 @@ class VeloxAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQLT
           // The top shuffle from repartition is not optimized out.
           optimizeOutRepartition = false,
           optimizeSkewJoin = true,
-          coalescedRead = false)
+          coalescedRead = false
+        )
 
         // Repartition by col and project away the partition cols
         checkSMJ(

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
@@ -61,7 +61,7 @@ object ParquetReadBenchmark extends SqlBasedBenchmark {
   def beforeAll(): Unit = {}
 
   override def getSparkSession: SparkSession = {
-    beforeAll();
+    beforeAll()
     val conf = new SparkConf()
       .setAppName("ParquetReadBenchmark")
       .setIfMissing("spark.master", s"local[$thrdNum]")

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
@@ -92,7 +92,8 @@ class GlutenOrcSourceSuite extends OrcSourceSuite with GlutenSQLTestsBaseTrait {
                 spark.read.orc(path),
                 Seq(
                   Row(java.sql.Timestamp.valueOf("1001-01-01 01:02:03.123456")),
-                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321"))))
+                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321")))
+              )
             }
         }
     }

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -38,7 +38,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       sql(
         "CREATE TABLE test_orc (name STRING, favorite_color STRING)" +
           " USING hive OPTIONS(fileFormat 'orc')")
-      sql("INSERT INTO test_orc VALUES('test_1', 'red')");
+      sql("INSERT INTO test_orc VALUES('test_1', 'red')")
       val df = spark.sql("select * from test_orc")
       checkAnswer(df, Seq(Row("test_1", "red")))
       checkOperatorMatch[HiveTableScanExecTransformer](df)

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -309,7 +309,8 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
             avg("age").cast(StringType),
             stddev_samp("age").cast(StringType),
             min("age").cast(StringType),
-            max("age").cast(StringType))
+            max("age").cast(StringType)
+          )
           checkAnswer(aggOneCol, aggResult)
 
           val describeNoCol = person2.select().describe()

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
@@ -296,7 +296,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -351,7 +352,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -416,7 +418,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -484,7 +487,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -541,7 +545,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -104,7 +104,8 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to fall back the entire plan.
         assert(outputPlan == originalPlan)
@@ -125,7 +126,8 @@ class FallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to get the plan with columnar rule applied.
         assert(outputPlan != originalPlan)

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/adaptive/clickhouse/ClickHouseAdaptiveQueryExecSuite.scala
@@ -1013,7 +1013,8 @@ class ClickHouseAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with Glute
           // The top shuffle from repartition is not optimized out.
           optimizeOutRepartition = false,
           optimizeSkewJoin = true,
-          coalescedRead = false)
+          coalescedRead = false
+        )
 
         // Repartition by col and project away the partition cols
         checkSMJ(

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/adaptive/velox/VeloxAdaptiveQueryExecSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/adaptive/velox/VeloxAdaptiveQueryExecSuite.scala
@@ -992,7 +992,8 @@ class VeloxAdaptiveQueryExecSuite extends AdaptiveQueryExecSuite with GlutenSQLT
           // The top shuffle from repartition is not optimized out.
           optimizeOutRepartition = false,
           optimizeSkewJoin = true,
-          coalescedRead = false)
+          coalescedRead = false
+        )
 
         // Repartition by col and project away the partition cols
         checkSMJ(

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/benchmarks/ParquetReadBenchmark.scala
@@ -60,7 +60,7 @@ object ParquetReadBenchmark extends SqlBasedBenchmark {
   def beforeAll(): Unit = {}
 
   override def getSparkSession: SparkSession = {
-    beforeAll();
+    beforeAll()
     val conf = new SparkConf()
       .setAppName("ParquetReadBenchmark")
       .setIfMissing("spark.master", s"local[$thrdNum]")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
@@ -92,7 +92,8 @@ class GlutenOrcSourceSuite extends OrcSourceSuite with GlutenSQLTestsBaseTrait {
                 spark.read.orc(path),
                 Seq(
                   Row(java.sql.Timestamp.valueOf("1001-01-01 01:02:03.123456")),
-                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321"))))
+                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321")))
+              )
             }
         }
     }

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -44,7 +44,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       sql(
         "CREATE TABLE test_orc (name STRING, favorite_color STRING)" +
           " USING hive OPTIONS(fileFormat 'orc')")
-      sql("INSERT INTO test_orc VALUES('test_1', 'red')");
+      sql("INSERT INTO test_orc VALUES('test_1', 'red')")
       val df = spark.sql("select * from test_orc")
       checkAnswer(df, Seq(Row("test_1", "red")))
       checkOperatorMatch[HiveTableScanExecTransformer](df)

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -319,7 +319,8 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
             avg("age").cast(StringType),
             stddev_samp("age").cast(StringType),
             min("age").cast(StringType),
-            max("age").cast(StringType))
+            max("age").cast(StringType)
+          )
           checkAnswer(aggOneCol, aggResult)
 
           val describeNoCol = person2.select().describe()

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
@@ -267,7 +267,8 @@ trait GlutenPlanStabilityTestTrait {
     withSQLConf(
       SQLConf.READ_SIDE_CHAR_PADDING.key -> "false",
       SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB"
+    ) {
       val qe = sql(queryString).queryExecution
       val plan = qe.executedPlan
       val explain = glutenNormalizeLocation(glutenNormalizeIds(qe.explainString(FormattedMode)))

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenSparkSessionJobTaggingAndCancellationSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenSparkSessionJobTaggingAndCancellationSuite.scala
@@ -56,7 +56,11 @@ class GlutenSparkSessionJobTaggingAndCancellationSuite
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(threadPool)
     try {
       Future {
-        session.range(1, 10000).map { i => Thread.sleep(100); i }.count()
+        session.range(1, 10000).map {
+          i =>
+            Thread.sleep(100)
+            i
+        }.count()
       }
 
       assert(sem.tryAcquire(1, 1, TimeUnit.MINUTES))

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
@@ -343,7 +343,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -398,7 +399,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -463,7 +465,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -531,7 +534,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -588,7 +592,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -1657,7 +1662,8 @@ class GlutenKeyGroupedPartitioningSuite
               Row(15.5, null),
               Row(15.5, 3),
               Row(40.0, 1),
-              Row(41.0, 1)))
+              Row(41.0, 1))
+          )
 
           verifyShuffle(
             s"SELECT price, id FROM testcat.ns.$items " +
@@ -1703,7 +1709,7 @@ class GlutenKeyGroupedPartitioningSuite
               Row(15.5, null),
               Row(15.5, 3),
               Row(10.0, 2))
-          );
+          )
         }
     }
   }

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
@@ -92,7 +92,8 @@ class GlutenOrcSourceSuite extends OrcSourceSuite with GlutenSQLTestsBaseTrait {
                 spark.read.orc(path),
                 Seq(
                   Row(java.sql.Timestamp.valueOf("1001-01-01 01:02:03.123456")),
-                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321"))))
+                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321")))
+              )
             }
         }
     }

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetTypeWideningSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetTypeWideningSuite.scala
@@ -142,7 +142,8 @@ class GlutenParquetTypeWideningSuite extends ParquetTypeWideningSuite with Glute
                 assert(
                   col.hasDictionaryPage,
                   "This test covers dictionary encoding but column " +
-                    s"'${col.getPath.toDotString}' in the test data is not dictionary encoded.")
+                    s"'${col.getPath.toDotString}' in the test data is not dictionary encoded."
+                )
             }
         }
     }

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
@@ -105,7 +105,8 @@ class GlutenFallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to fall back the entire plan.
         assert(outputPlan == originalPlan)
@@ -126,7 +127,8 @@ class GlutenFallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to get the plan with columnar rule applied.
         assert(outputPlan != originalPlan)

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -44,7 +44,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       sql(
         "CREATE TABLE test_orc (name STRING, favorite_color STRING)" +
           " USING hive OPTIONS(fileFormat 'orc')")
-      sql("INSERT INTO test_orc VALUES('test_1', 'red')");
+      sql("INSERT INTO test_orc VALUES('test_1', 'red')")
       val df = spark.sql("select * from test_orc")
       checkAnswer(df, Seq(Row("test_1", "red")))
       checkOperatorMatch[HiveTableScanExecTransformer](df)

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -308,7 +308,8 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
             avg("age").cast(StringType),
             stddev_samp("age").cast(StringType),
             min("age").cast(StringType),
-            max("age").cast(StringType))
+            max("age").cast(StringType)
+          )
           checkAnswer(aggOneCol, aggResult)
 
           val describeNoCol = person2.select().describe()

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenPlanStabilitySuite.scala
@@ -267,7 +267,8 @@ trait GlutenPlanStabilityTestTrait {
     withSQLConf(
       SQLConf.READ_SIDE_CHAR_PADDING.key -> "false",
       SQLConf.LEGACY_NO_CHAR_PADDING_IN_PREDICATE.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB"
+    ) {
       val qe = sql(queryString).queryExecution
       val plan = qe.executedPlan
       val explain = glutenNormalizeLocation(glutenNormalizeIds(qe.explainString(FormattedMode)))

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenSparkSessionJobTaggingAndCancellationSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenSparkSessionJobTaggingAndCancellationSuite.scala
@@ -56,7 +56,11 @@ class GlutenSparkSessionJobTaggingAndCancellationSuite
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(threadPool)
     try {
       Future {
-        session.range(1, 10000).map { i => Thread.sleep(100); i }.count()
+        session.range(1, 10000).map {
+          i =>
+            Thread.sleep(100)
+            i
+        }.count()
       }
 
       assert(sem.tryAcquire(1, 1, TimeUnit.MINUTES))

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/connector/GlutenKeyGroupedPartitioningSuite.scala
@@ -343,7 +343,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -398,7 +399,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -463,7 +465,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -531,7 +534,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -588,7 +592,8 @@ class GlutenKeyGroupedPartitioningSuite
           case (enable, expected) =>
             withSQLConf(
               SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> pushDownValues.toString,
-              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable) {
+              SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> enable
+            ) {
               val df = sql(
                 "SELECT id, name, i.price as purchase_price, p.price as sale_price " +
                   s"FROM testcat.ns.$items i JOIN testcat.ns.$purchases p " +
@@ -1657,7 +1662,8 @@ class GlutenKeyGroupedPartitioningSuite
               Row(15.5, null),
               Row(15.5, 3),
               Row(40.0, 1),
-              Row(41.0, 1)))
+              Row(41.0, 1))
+          )
 
           verifyShuffle(
             s"SELECT price, id FROM testcat.ns.$items " +
@@ -1703,7 +1709,7 @@ class GlutenKeyGroupedPartitioningSuite
               Row(15.5, null),
               Row(15.5, 3),
               Row(10.0, 2))
-          );
+          )
         }
     }
   }

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/orc/GlutenOrcSourceSuite.scala
@@ -92,7 +92,8 @@ class GlutenOrcSourceSuite extends OrcSourceSuite with GlutenSQLTestsBaseTrait {
                 spark.read.orc(path),
                 Seq(
                   Row(java.sql.Timestamp.valueOf("1001-01-01 01:02:03.123456")),
-                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321"))))
+                  Row(java.sql.Timestamp.valueOf("1582-10-15 11:12:13.654321")))
+              )
             }
         }
     }

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetTypeWideningSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetTypeWideningSuite.scala
@@ -142,7 +142,8 @@ class GlutenParquetTypeWideningSuite extends ParquetTypeWideningSuite with Glute
                 assert(
                   col.hasDictionaryPage,
                   "This test covers dictionary encoding but column " +
-                    s"'${col.getPath.toDotString}' in the test data is not dictionary encoded.")
+                    s"'${col.getPath.toDotString}' in the test data is not dictionary encoded."
+                )
             }
         }
     }

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
@@ -105,7 +105,8 @@ class GlutenFallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to fall back the entire plan.
         assert(outputPlan == originalPlan)
@@ -126,7 +127,8 @@ class GlutenFallbackStrategiesSuite extends GlutenSQLTestsTrait {
               _ => {
                 UnaryOp2(UnaryOp1Transformer(UnaryOp2(UnaryOp1Transformer(LeafOpTransformer()))))
               },
-            c => InsertBackendTransitions(c.outputsColumnar)))
+            c => InsertBackendTransitions(c.outputsColumnar))
+        )
         val outputPlan = rule.apply(originalPlan, false)
         // Expect to get the plan with columnar rule applied.
         assert(outputPlan != originalPlan)

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -44,7 +44,7 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
       sql(
         "CREATE TABLE test_orc (name STRING, favorite_color STRING)" +
           " USING hive OPTIONS(fileFormat 'orc')")
-      sql("INSERT INTO test_orc VALUES('test_1', 'red')");
+      sql("INSERT INTO test_orc VALUES('test_1', 'red')")
       val df = spark.sql("select * from test_orc")
       checkAnswer(df, Seq(Row("test_1", "red")))
       checkOperatorMatch[HiveTableScanExecTransformer](df)

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <!--spotless-->
     <spotless.version>2.27.2</spotless.version>
     <googlejavaformat.version>1.7</googlejavaformat.version>
-    <spotless.scalafmt.version>3.8.3</spotless.scalafmt.version>
+    <spotless.scalafmt.version>3.10.1</spotless.scalafmt.version>
     <spotless.delimiter>package</spotless.delimiter>
     <!-- spotless:off -->
     <spotless.license.header>
@@ -1023,7 +1023,6 @@
       <properties>
         <scala.version>2.13.17</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
-        <spotless.scalafmt.version>3.8.3</spotless.scalafmt.version>
       </properties>
       <build>
         <pluginManagement>

--- a/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/shims/spark33/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -535,10 +535,9 @@ object ParquetFileFormat extends Logging {
    *      that file. Thus we only need to retrieve the location of the last block. However, Hadoop
    *      `FileSystem` only provides API to retrieve locations of all blocks, which can be
    *      potentially expensive.
-   *
-   * 2. This optimization is mainly useful for S3, where file metadata operations can be pretty
-   * slow. And basically locality is not available when using S3 (you can't run computation on S3
-   * nodes).
+   *   2. This optimization is mainly useful for S3, where file metadata operations can be pretty
+   *      slow. And basically locality is not available when using S3 (you can't run computation on
+   *      S3 nodes).
    */
   def mergeSchemasInParallel(
       parameters: Map[String, String],

--- a/shims/spark34/src/main/scala/org/apache/spark/sql/extension/RewriteCreateTableAsSelect.scala
+++ b/shims/spark34/src/main/scala/org/apache/spark/sql/extension/RewriteCreateTableAsSelect.scala
@@ -161,7 +161,7 @@ trait V2CreateTableAsSelectBaseExec extends LeafV2CommandExec {
       writeOptions: Map[String, String],
       ident: Identifier,
       query: LogicalPlan): Seq[InternalRow] = {
-    Utils.tryWithSafeFinallyAndFailureCallbacks({
+    Utils.tryWithSafeFinallyAndFailureCallbacks {
       val relation = DataSourceV2Relation.create(table, Some(catalog), Some(ident))
       val append = AppendData.byPosition(relation, query, writeOptions)
       val qe = session.sessionState.executePlan(append)
@@ -173,7 +173,7 @@ trait V2CreateTableAsSelectBaseExec extends LeafV2CommandExec {
       }
 
       Nil
-    })(catchBlock = {
+    }(catchBlock = {
       table match {
         // Failure rolls back the staged writes and metadata changes.
         case st: StagedTable => st.abortStagedChanges()

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/action/Parameterized.scala
@@ -69,7 +69,7 @@ class Parameterized(
   private val coordinates: mutable.LinkedHashMap[Coordinate, Seq[(String, String)]] = {
     val dimCount = configDimensions.size
     val coordinateMap = mutable.LinkedHashMap[Coordinate, Seq[(String, String)]]()
-    val nextId: AtomicInteger = new AtomicInteger(1);
+    val nextId: AtomicInteger = new AtomicInteger(1)
 
     def fillCoordinates(
         dimOffset: Int,

--- a/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/stat/RamStat.scala
+++ b/tools/gluten-it/common/src/main/scala/org/apache/gluten/integration/stat/RamStat.scala
@@ -48,7 +48,7 @@ object RamStat {
       while (true) {
         val ch = in.read()
         if (ch == -1) {
-          return;
+          return
         }
         buff.append(ch.asInstanceOf[Char])
       }
@@ -70,7 +70,7 @@ object RamStat {
       while (true) {
         val ch = in.read()
         if (ch == -1) {
-          return;
+          return
         }
         buff.append(ch.asInstanceOf[Char])
       }

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -46,7 +46,7 @@
 
     <spotless.version>2.27.2</spotless.version>
     <googlejavaformat.version>1.7</googlejavaformat.version>
-    <spotless.scalafmt.version>3.8.3</spotless.scalafmt.version>
+    <spotless.scalafmt.version>3.10.1</spotless.scalafmt.version>
     <spotless.delimiter>package</spotless.delimiter>
     <!-- spotless:off -->
     <spotless.license.header>

--- a/tools/qualification-tool/pom.xml
+++ b/tools/qualification-tool/pom.xml
@@ -14,7 +14,7 @@
     <scala.binary.version>2.12</scala.binary.version>
     <spec2.version>4.2.0</spec2.version>
     <spotless.version>2.27.2</spotless.version>
-    <spotless.scalafmt.version>3.8.3</spotless.scalafmt.version>
+    <spotless.scalafmt.version>3.10.1</spotless.scalafmt.version>
     <spotless.delimiter>package</spotless.delimiter>
     <!-- spotless:off -->
     <spotless.license.header>

--- a/tools/qualification-tool/src/main/scala/org/apache/gluten/qt/QualificationTool.scala
+++ b/tools/qualification-tool/src/main/scala/org/apache/gluten/qt/QualificationTool.scala
@@ -27,57 +27,58 @@ import org.apache.spark.util.kvstore.InMemoryStore
 
 object QualificationTool {
 
-  def main(args: Array[String]): Unit = try {
-    val conf = QualificationToolConfiguration.parseCommandLineArgs(args)
-    val sparkConf = new SparkConf(false)
-    sparkConf.set("spark.appStateStore.asyncTracking.enable", "false")
+  def main(args: Array[String]): Unit =
+    try {
+      val conf = QualificationToolConfiguration.parseCommandLineArgs(args)
+      val sparkConf = new SparkConf(false)
+      sparkConf.set("spark.appStateStore.asyncTracking.enable", "false")
 
-    val primaryReportWriter = writer.PrimaryReportWriter(conf)
-    val operatorImpactReportWriter = writer.OperatorImpactReportWriter(conf)
-    val fileSource = file.HadoopFileSource(conf)
-    val executor = execution.Executor(conf)
+      val primaryReportWriter = writer.PrimaryReportWriter(conf)
+      val operatorImpactReportWriter = writer.OperatorImpactReportWriter(conf)
+      val fileSource = file.HadoopFileSource(conf)
+      val executor = execution.Executor(conf)
 
-    executor.submitTask(
-      PriorityTask(
-        TaskContext(100, "File Listing", FILE_LISTING_TASK),
-        () => {
-          Executor.updateState(RunState("LISTING FILES - COMPLETED", Progress()))
-          fileSource.getFileStatuses.foreach {
-            fileStatuses =>
-              Executor.incrementState()
-              executor.submitTask(
-                PriorityTask(
-                  TaskContext(10, fileStatuses.head.getPath.toString, EVENT_FILE_PROCESS_TASK),
-                  () => {
-                    val replayBus = new ReplayListenerBus()
-                    val kvStore = new InMemoryStore()
-                    replayBus.addListener(new SQLAppStatusListener(sparkConf, kvStore))
-                    replayBus.addListener(new AppStatusListener(sparkConf, kvStore))
-                    fileStatuses
-                      .map(_.getPath)
-                      .foreach {
-                        eventPath =>
-                          replayBus.replay(fileSource.getSource(eventPath), eventPath.toString)
-                      }
-                    generateReport(conf, kvStore, primaryReportWriter, operatorImpactReportWriter)
-                  }
-                ))
+      executor.submitTask(
+        PriorityTask(
+          TaskContext(100, "File Listing", FILE_LISTING_TASK),
+          () => {
+            Executor.updateState(RunState("LISTING FILES - COMPLETED", Progress()))
+            fileSource.getFileStatuses.foreach {
+              fileStatuses =>
+                Executor.incrementState()
+                executor.submitTask(
+                  PriorityTask(
+                    TaskContext(10, fileStatuses.head.getPath.toString, EVENT_FILE_PROCESS_TASK),
+                    () => {
+                      val replayBus = new ReplayListenerBus()
+                      val kvStore = new InMemoryStore()
+                      replayBus.addListener(new SQLAppStatusListener(sparkConf, kvStore))
+                      replayBus.addListener(new AppStatusListener(sparkConf, kvStore))
+                      fileStatuses
+                        .map(_.getPath)
+                        .foreach {
+                          eventPath =>
+                            replayBus.replay(fileSource.getSource(eventPath), eventPath.toString)
+                        }
+                      generateReport(conf, kvStore, primaryReportWriter, operatorImpactReportWriter)
+                    }
+                  ))
+            }
           }
-        }
-      ))
+        ))
 
-    executor.waitAndDisplayStatus()
-    primaryReportWriter.closeFile()
-    operatorImpactReportWriter.closeFile()
-    fileSource.close()
-    println(s"Report has been written to ${primaryReportWriter.getFileString}")
-    println(
-      s"Unsupported Operators have been written to ${operatorImpactReportWriter.getFileString}")
-  } catch {
-    case e: Throwable =>
-      e.printStackTrace(System.out)
-      throw e;
-  }
+      executor.waitAndDisplayStatus()
+      primaryReportWriter.closeFile()
+      operatorImpactReportWriter.closeFile()
+      fileSource.close()
+      println(s"Report has been written to ${primaryReportWriter.getFileString}")
+      println(
+        s"Unsupported Operators have been written to ${operatorImpactReportWriter.getFileString}")
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace(System.out)
+        throw e
+    }
 
   private def generateReport(
       conf: QualificationToolConfiguration,


### PR DESCRIPTION


## What changes are proposed in this pull request?

There are a lot of unnecessary parentheses and unnecessary semicolons at the end of the Scala code, upgrade scalafmt to support RemoveSemicolons.

## How was this patch tested?



## Was this patch authored or co-authored using generative AI tooling?

No.