### PR TITLE
[DOC] Update Velox Delta guide for Spark 4.0 / Delta 4.0 support

### DIFF
--- a/docs/get-started/VeloxDelta.md
+++ b/docs/get-started/VeloxDelta.md
@@ -1,6 +1,28 @@
-# Delta Lake Feature Support Status in Apache Gluten (Velox Backend, Spark 3.5)
+# Delta Lake Feature Support Status in Apache Gluten (Velox Backend)
 
-This document summarizes the current support status of **Delta Lake table features** when used with **Apache Gluten (Velox backend)** on **Apache Spark 3.5**.
+This document summarizes the support status of **Delta Lake table features** when used with **Apache Gluten (Velox backend)**.
+
+## Supported Spark / Delta combinations
+
+| Spark profile | Spark version | Scala version | Delta Lake version | Status |
+|---|---|---|---|---|
+| `spark-3.5` | Spark 3.5.x | 2.12 | 3.3.x | Supported |
+| `spark-4.0` | Spark 4.0.x | 2.13 | 4.0.x | Supported (including native Delta write path) |
+
+## Build and runtime notes
+
+Build Gluten with Delta support by enabling `-Pdelta` together with the Velox backend profile and a Spark profile.
+
+- Spark 3.5 build example:
+  - `mvn clean package -Pbackends-velox -Pdelta -Pspark-3.5 -DskipTests`
+- Spark 4.0 build example:
+  - `mvn clean package -Pbackends-velox -Pdelta -Pspark-4.0 -Pscala-2.13 -Pjava-17 -DskipTests`
+
+Native Delta write is controlled by:
+
+- `spark.gluten.sql.columnar.backend.velox.delta.enableNativeWrite`
+  - Default: `false`
+  - Type: experimental
 
 | Feature | Delta minWriterVersion | Delta minReaderVersion | Iceberg format-version | Feature type | Supported by Gluten (Velox) |
 |---|---:|---:|---:|---|---|

--- a/docs/get-started/VeloxDelta.md
+++ b/docs/get-started/VeloxDelta.md
@@ -7,7 +7,11 @@ This document summarizes the support status of **Delta Lake table features** whe
 | Spark profile | Spark version | Scala version | Delta Lake version | Status |
 |---|---|---|---|---|
 | `spark-3.5` | Spark 3.5.x | 2.12 | 3.3.x | Supported |
-| `spark-4.0` | Spark 4.0.x | 2.13 | 4.0.x | Supported (including native Delta write path) |
+| `spark-4.0` | Spark 4.0.x | 2.13 | 4.0.x | Supported |
+
+Native Delta write is supported in both Spark 3.5 and Spark 4.0 profiles. The difference between
+the two rows above is the Spark/Delta compatibility target (Spark 3.5 + Delta 3.3 vs Spark 4.0 +
+Delta 4.0), not a native-write capability gap.
 
 ## Build and runtime notes
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the Delta documentation for the Velox backend to reflect Spark 4.0 / Delta 4.0 support.

Specifically, it updates `docs/get-started/VeloxDelta.md` to:

- Broaden the scope from Spark 3.5-only wording to general Velox Delta support.
- Add a Spark/Delta compatibility table covering:
  - `spark-3.5` + Delta `3.3.x`
  - `spark-4.0` + Delta `4.0.x` (including native Delta write path support)
- Add build examples for both Spark 3.5 and Spark 4.0 profiles with `-Pdelta`.
- Document the native Delta write config:
  - `spark.gluten.sql.columnar.backend.velox.delta.enableNativeWrite`
  - default value and experimental status.

No functional/runtime code paths are changed in this PR; this is documentation-only.



