### PR TITLE
[VL][CI] Fix clang-tidy CI failure

### DIFF
--- a/.github/workflows/cpp_clang_tidy.yml
+++ b/.github/workflows/cpp_clang_tidy.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+      # Workspaces bind-mounted into containers are often owned by a different UID than the
+      # container user; Git 2.35+ refuses operations unless the directory is marked safe.
+      - name: Configure Git safe directory (container)
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Detect C++ file changes
         id: filter
         run: |


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

The Clang Tidy workflow runs in `apache/gluten:centos-8-jdk8` with the workspace bind-mounted from the GitHub Actions runner. Git 2.35+ treats that layout as “dubious ownership,” so commands such as `git fetch` in **Detect C++ file changes** exit with code 128 and the job fails ([issue #12020](https://github.com/apache/gluten/issues/12020)).

Add a step immediately after `actions/checkout` that runs:

`git config --global --add safe.directory "$GITHUB_WORKSPACE"`

so subsequent Git usage in the job is allowed without weakening safety beyond this checkout directory.

Fixes #12020


## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor agent (GPT-based), session assisting with workflow edit and PR text.