### PR TITLE
[CORE][UI] Skip GlutenPlanFallbackEvent posting when gluten is disabled

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -387,4 +387,37 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
       spark.sparkContext.removeSparkListener(listener)
     }
   }
+
+  test("no fallback event emitted for vanilla Spark execution with gluten disabled") {
+    // Regression test: before the fix, GlutenQueryExecutionListener would post a
+    // GlutenPlanFallbackEvent even when spark.gluten.enabled=false (e.g. the vanilla baseline run
+    // inside runQueryAndCompare). All nodes would appear as fallback with the generic reason
+    // "Gluten does not touch it or does not support it".
+    val events = new ArrayBuffer[GlutenPlanFallbackEvent]
+    val listener = new SparkListener {
+      override def onOtherEvent(event: SparkListenerEvent): Unit = {
+        event match {
+          case e: GlutenPlanFallbackEvent => events.append(e)
+          case _ =>
+        }
+      }
+    }
+    spark.sparkContext.addSparkListener(listener)
+    try {
+      // Execute a query with gluten disabled — this mimics what runQueryAndCompare does for the
+      // vanilla baseline run. No GlutenPlanFallbackEvent should be emitted at all.
+      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+        spark.sql("SELECT c1, count(*) FROM tmp1 GROUP BY c1").collect()
+      }
+      GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
+      assert(
+        events.isEmpty,
+        s"Expected no GlutenPlanFallbackEvent for vanilla Spark execution, " +
+          s"but got ${events.size} event(s). " +
+          s"First event fallback reasons: ${events.headOption.map(_.fallbackNodeToReason)}"
+      )
+    } finally {
+      spark.sparkContext.removeSparkListener(listener)
+    }
+  }
 }

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenQueryExecutionListener.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenQueryExecutionListener.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
+import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.events.GlutenPlanFallbackEvent
 
 import org.apache.spark.SparkContext
@@ -37,6 +38,18 @@ class GlutenQueryExecutionListener(sc: SparkContext) extends SparkListener with 
       val qe = event.qe
       if (qe == null) {
         // History Server replay or edge case. Rely on per-stage events already in event log.
+        return
+      }
+
+      // Skip posting if Gluten was not involved in this query execution.
+      // This can happen when Gluten is disabled via session config (e.g., vanilla Spark
+      // baseline runs in comparison tests) but the listener is still registered globally.
+      // Read directly from qe.sparkSession's conf to avoid thread-local SQLConf issues.
+      if (
+        !qe.sparkSession.sessionState.conf.getConfString(
+          GlutenConfig.GLUTEN_ENABLED.key,
+          GlutenConfig.GLUTEN_ENABLED.defaultValueString).toBoolean
+      ) {
         return
       }
 


### PR DESCRIPTION
## Summary

When `spark.gluten.enabled=false` (e.g. the vanilla Spark baseline run inside `runQueryAndCompare`), `GlutenQueryExecutionListener` still posted a `GlutenPlanFallbackEvent`. Because no Gluten rules ran, all nodes appeared as fallback with the generic reason *"Gluten does not touch it or does not support it"*, polluting the event stream.

This was an oversight in https://github.com/apache/gluten/pull/11853, which introduced the fallback event posting but did not account for the case where Gluten is disabled entirely via session config. When Gluten is off, every node is trivially "fallback" — posting an event is misleading and noisy.

**Fix:** Early-return before `collectQueryExecutionFallbackSummary` when the session's `spark.gluten.enabled` config is `false`. The config is read directly from `qe.sparkSession.sessionState.conf` via `getConfString` to avoid thread-local `SQLConf` timing issues in the async listener thread.

## Test plan

- [x] Added regression test `FallbackSuite`: verifies no `GlutenPlanFallbackEvent` is emitted when a query runs with `spark.gluten.enabled=false`