### PR TITLE
[CORE] Preserve fallback tag for nodes without logicalLink in RemoveFallbackTagRule

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -324,6 +324,10 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
         }
       }
     }
+    // Drain any pending events from previous tests before registering the listener.
+    // Spark's LiveListenerBus is async, so events posted but not yet dispatched will
+    // still be delivered to listeners added afterwards, contaminating `events` here.
+    GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
     spark.sparkContext.addSparkListener(listener)
     withSQLConf(GlutenConfig.COLUMNAR_SORT_ENABLED.key -> "false") {
       try {
@@ -345,7 +349,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
         val fallbackReasons = events.flatMap(_.fallbackNodeToReason.values)
         assert(fallbackReasons.nonEmpty)
         assert(
-          fallbackReasons.exists(
+          fallbackReasons.forall(
             _.contains("[FallbackByUserOptions] Validation failed on node Sort")))
       } finally {
         spark.sparkContext.removeSparkListener(listener)

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackTag.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackTag.scala
@@ -115,7 +115,21 @@ object FallbackTags {
 
 case class RemoveFallbackTagRule() extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
-    plan.foreach(FallbackTags.untag)
+    plan.foreach {
+      // Nodes without a logicalLink (e.g. SortExec/BroadcastExchange added by
+      // EnsureRequirements) have no place to forward the fallback reason via
+      // GlutenFallbackReporter. Keep the tag on the physical node so that
+      // GlutenExplainUtils.handleVanillaSparkPlan can still read it directly.
+      // We intentionally do NOT inject a synthetic logicalLink here, because
+      // AdaptiveSparkPlanExec.setLogicalLinkForNewQueryStage relies on these
+      // EnsureRequirements-generated nodes having no logicalLink in order to
+      // walk down to the real logical node; a synthetic link would poison
+      // AQE's stage-to-logical-plan mapping (breaking AQEPropagateEmptyRelation,
+      // ValidateSparkPlan-driven re-plans, etc.).
+      case p if FallbackTags.nonEmpty(p) && p.logicalLink.isEmpty =>
+      case p =>
+        FallbackTags.untag(p)
+    }
     plan
   }
 }


### PR DESCRIPTION
## Summary

For `SparkPlan` nodes that lack a `logicalLink` (e.g., `SortExec` / `BroadcastExchange` generated by `EnsureRequirements`), `GlutenFallbackReporter` cannot copy their `FallbackTag` onto a logical plan, so the subsequent `RemoveFallbackTagRule` removed their tag without persisting it anywhere. This caused the fallback reason to be lost when `GlutenQueryExecutionListener` re-walks the finalized plan at SQL execution end, resulting in a generic *"Gluten does not touch it or does not support it"* reason instead of the actual fallback reason.

In #11853, the test assertion for "get correct fallback reason on nodes without logicalLink" was changed from `forall` to `exists`, which hid this issue — among the `fallbackReasons`, one event's reason had degraded to the generic message because the physical plan tag was removed by `RemoveFallbackTagRule`, but `exists` only required *some* reasons to be correct, masking the fact that others were wrong.

**Fix:** In `RemoveFallbackTagRule`, skip untagging for nodes that have a `FallbackTag` but no `logicalLink`. Their tag stays on the physical node and is read by `GlutenExplainUtils.handleVanillaSparkPlan` via `FallbackTags.getOption(p)` (the existing fallback branch) in both the per-stage `GlutenFallbackReporter` event and the end-of-SQL plan walk. The tag is regenerated by Gluten validation on every AQE stage's `postStageCreationRules`, so it survives across AQE re-planning iterations as well.

With this fix, the test assertion is changed back to `forall`, verifying that **all** fallback events now report the correct reason.

### Why not synthesize a logicalLink?

An earlier attempt synthesized a dummy `LeafNode` (`FallbackLogicalPlan`) and attached it via `SparkPlan.LOGICAL_PLAN_TAG` so the existing `p.logicalLink.flatMap(FallbackTags.getOption)` path would find it. That approach poisoned `AdaptiveSparkPlanExec.setLogicalLinkForNewQueryStage`, which intentionally relies on `EnsureRequirements`-generated nodes having no `logicalLink` in order to walk down to the real logical node. With a synthetic link in place, the stage's `logicalLink` was set to the dummy, which never appeared in the original logical plan; AQE's `replaceWithQueryStages` then could not insert the `LogicalQueryStage` wrapper, breaking AQE rules that match `LogicalQueryStage(_, stage: ...QueryStageExec)` such as `AQEPropagateEmptyRelation`.
Keeping the tag on the physical node sidesteps the AQE contract entirely.

## Test plan

- [x] Existing test "get correct fallback reason on nodes without logicalLink" now uses `forall` and verifies all fallback reasons are correct