### PR TITLE
[GLUTEN-1433][VL][FOLLOWUP] Fix TimestampNTZ schema validation never matching due to Scala object simpleName suffix

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
@@ -111,12 +111,7 @@ object VeloxValidatorApi {
           StringType | BinaryType | _: DecimalType | DateType | TimestampType |
           YearMonthIntervalType.DEFAULT | NullType =>
         true
-      case dt
-          if !enableTimestampNtzValidation &&
-            dt.getClass.getSimpleName == "TimestampNTZType" =>
-        // Allow TimestampNTZ when validation is disabled (for development/testing)
-        // Use reflection to avoid compile-time dependency on Spark 3.4+ TimestampNTZType
-        true
+      case dt if !enableTimestampNtzValidation && dt.catalogString == "timestamp_ntz" => true
       case _ => false
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -16,7 +16,8 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.backendsapi.velox.VeloxValidatorApi
+import org.apache.gluten.config.{GlutenConfig, VeloxConfig}
 
 import org.apache.spark.SparkConf
 
@@ -476,6 +477,19 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
         val executedPlan = getExecutedPlan(df)
         assert(!executedPlan.exists(plan => plan.isInstanceOf[BatchScanExecTransformer]))
         checkAnswer(df, inputDf)
+    }
+  }
+
+  testWithMinSparkVersion(
+    "Schema validation for TimestampNTZ respects enableTimestampNtzValidation",
+    "3.4") {
+    val ntzType = spark.sql("SELECT TIMESTAMP_NTZ'2024-01-01'").schema.head.dataType
+    Seq("true", "false").foreach {
+      enabled =>
+        withSQLConf(VeloxConfig.ENABLE_TIMESTAMP_NTZ_VALIDATION.key -> enabled) {
+          val result = VeloxValidatorApi.validateSchema(ntzType)
+          assert(result.isDefined == enabled.toBoolean)
+        }
     }
   }
 


### PR DESCRIPTION
## Summary

`isPrimitiveType` in `VeloxValidatorApi` uses `dt.getClass.getSimpleName == "TimestampNTZType"` to check for TimestampNTZ type. However, `TimestampNTZType` is a Scala `case object`, so `getClass.getSimpleName` returns `"TimestampNTZType$"` (with a trailing `$`), causing the check to always fail. This means `validateSchema` rejects TimestampNTZ even when `enableTimestampNtzValidation` is set to `false`.

**Fix:** Use `dt.catalogString == "timestamp_ntz"` instead, which is reliable regardless of how the type is defined in Scala.

**Test:** Added a test in `VeloxParquetDataTypeValidationSuite` to verify that `validateSchema` correctly accepts/rejects TimestampNTZ based on the `enableTimestampNtzValidation` config.

Related issue: #1433