### PR TITLE
[GLUTEN-12032][CH] Reopen some queries test for the Spark 3.5

### DIFF
--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -19,6 +19,7 @@
 #include <jni.h>
 
 #include <Builder/SerializedPlanBuilder.h>
+#include <Columns/ColumnReplicated.h>
 #include <Compression/CompressedReadBuffer.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <Join/BroadCastJoinBuilder.h>
@@ -539,7 +540,16 @@ Java_org_apache_gluten_vectorized_CHNativeBlock_nativeBlockStats(JNIEnv * env, j
     }
     else
     {
-        const auto * nullable = checkAndGetColumn<DB::ColumnNullable>(&*col.column);
+        const DB::ColumnNullable * nullable;
+        if (col.column->isReplicated())
+        {
+            auto * replicated_col = checkAndGetColumn<DB::ColumnReplicated>(&*col.column);
+            nullable = checkAndGetColumn<DB::ColumnNullable>(&*replicated_col->getNestedColumn());
+        }
+        else
+        {
+            nullable = checkAndGetColumn<DB::ColumnNullable>(&*col.column);
+        }
         const auto & null_map_data = nullable->getNullMapData();
 
         jobject block_stats = env->NewObject(

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseSQLQueryTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseSQLQueryTestSettings.scala
@@ -91,8 +91,10 @@ object ClickHouseSQLQueryTestSettings extends SQLQueryTestSettings {
     // CH- "null-propagation.sql",
     "operators.sql",
     // TODO: rebase-25.12, fix later
+    // the results are the same, but the order of the unsorted data is different.
     // "order-by-nulls-ordering.sql",
     // TODO: rebase-25.12, fix later
+    // the results are the same, but the order of the unsorted data is different.
     // "order-by-ordinal.sql",
     "outer-join.sql",
     "parse-schema-string.sql",
@@ -120,20 +122,23 @@ object ClickHouseSQLQueryTestSettings extends SQLQueryTestSettings {
     "subquery/exists-subquery/exists-having.sql",
     "subquery/exists-subquery/exists-joins-and-set-ops.sql",
     // TODO: rebase-25.12, fix later
+    // the results are the same, but the order of the unsorted data is different.
     // "subquery/exists-subquery/exists-orderby-limit.sql",
     "subquery/exists-subquery/exists-within-and-or.sql",
     "subquery/in-subquery/in-basic.sql",
     "subquery/in-subquery/in-group-by.sql",
     "subquery/in-subquery/in-having.sql",
     // TODO: rebase-25.12, fix later
+    // the results are the same, but the order of the unsorted data is different.
     // "subquery/in-subquery/in-joins.sql",
     "subquery/in-subquery/in-limit.sql",
     "subquery/in-subquery/in-multiple-columns.sql",
     // TODO: rebase-25.12, fix later
+    // the results are the same, but the order of the unsorted data is different.
     // "subquery/in-subquery/in-order-by.sql",
     // CH- "subquery/in-subquery/in-set-operations.sql",
     // TODO: rebase-25.12, fix later, will core dump
-    // "subquery/in-subquery/in-with-cte.sql",
+    "subquery/in-subquery/in-with-cte.sql",
     "subquery/in-subquery/nested-not-in.sql",
     "subquery/in-subquery/not-in-group-by.sql",
     "subquery/in-subquery/not-in-joins.sql",

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseSQLQueryTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseSQLQueryTestSettings.scala
@@ -137,7 +137,6 @@ object ClickHouseSQLQueryTestSettings extends SQLQueryTestSettings {
     // the results are the same, but the order of the unsorted data is different.
     // "subquery/in-subquery/in-order-by.sql",
     // CH- "subquery/in-subquery/in-set-operations.sql",
-    // TODO: rebase-25.12, fix later, will core dump
     "subquery/in-subquery/in-with-cte.sql",
     "subquery/in-subquery/nested-not-in.sql",
     "subquery/in-subquery/not-in-group-by.sql",


### PR DESCRIPTION
Reopen some queries test for the Spark 3.5:
- subquery/in-subquery/in-with-cte.sql

Close #12032.

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
