### PR TITLE
[GLUTEN-12034][VL] Fix str_to_map MAP_KEY_DEDUP_POLICY comparison for Spark 4.1 compatibility

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -924,8 +924,11 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
       substraitExprName: String,
       children: Seq[ExpressionTransformer],
       expr: Expression): ExpressionTransformer = {
+    // Calling `.toString` on both sides ensures compatibility across all Spark versions.
+    // Starting from Spark 4.1, `SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)` returns
+    // an enum instead of a String.
     if (
-      SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)
+      SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY).toString
         != SQLConf.MapKeyDedupPolicy.EXCEPTION.toString
     ) {
       GlutenExceptionUtil.throwsNotFullySupported(

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.optimizer.NullPropagation
 import org.apache.spark.sql.execution.ProjectExec
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
@@ -1605,6 +1606,31 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
       checkGlutenPlan[ProjectExecTransformer](df)
       checkFallbackOperators(df, 0)
       df.collect()
+    }
+  }
+
+  test("str_to_map with MAP_KEY_DEDUP_POLICY EXCEPTION") {
+    withTempPath {
+      path =>
+        Seq("a:1,b:2,c:3", "x:10,y:20", "single:99")
+          .toDF("s")
+          .write
+          .parquet(path.getCanonicalPath)
+
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("str_to_map_tbl")
+        log.info("Testing str_to_map offloading with MAP_KEY_DEDUP_POLICY set to EXCEPTION")
+
+        withSQLConf(
+          SQLConf.MAP_KEY_DEDUP_POLICY.key -> SQLConf.MapKeyDedupPolicy.EXCEPTION.toString) {
+          // Explicit delimiters
+          runQueryAndCompare("SELECT s, str_to_map(s, ',', ':') FROM str_to_map_tbl") {
+            checkGlutenPlan[ProjectExecTransformer]
+          }
+          // Default delimiters (, and :)
+          runQueryAndCompare("SELECT s, str_to_map(s) FROM str_to_map_tbl") {
+            checkGlutenPlan[ProjectExecTransformer]
+          }
+        }
     }
   }
 }


### PR DESCRIPTION
Starting from Spark 4.1, [SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)](https://github.com/apache/spark/blob/3c1a8423d8d330facbfd25b55c80fc01c32f357c/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L5277) returns an enum value instead of a String. The existing comparison against the `.toString` of the `EXCEPTION` variant would always evaluate to not-equal (comparing enum != String), incorrectly rejecting `str_to_map` offloading even when the policy is set to `EXCEPTION`.

Add `.toString` on the left side so both operands are compared as Strings, restoring correct behavior across all Spark versions.

## What changes are proposed in this pull request?

Fix the code but to make code compatible with Spark 4.1

## How was this patch tested?

Added new UT test to verify the fix.

## Was this patch authored or co-authored using generative AI tooling?
GitHub Copilot CLI (powered by Claude Opus 4.6)

Related issue: #12034