### PR TITLE
[GLUTEN-12044][CH] Fix build on arm

### DIFF
--- a/cpp-ch/local-engine/Functions/LocalDigitsToAsciiDigitForDate.cpp
+++ b/cpp-ch/local-engine/Functions/LocalDigitsToAsciiDigitForDate.cpp
@@ -219,7 +219,8 @@ private:
         size_t i = 0;
         for (; i + kBlockSize <= size; i += kBlockSize)
         {
-            if (!simd8_u8::load(reinterpret_cast<const uint8_t *>(data + i)).is_ascii())
+            const auto chunk = simd8_u8(simd8_u8::load(reinterpret_cast<const uint8_t *>(data + i)));
+            if (chunk.any_bits_set_anywhere(simd8_u8(0x80)))
                 return true;
         }
         for (; i < size; ++i)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fix issue https://github.com/apache/gluten/issues/12044.
Fix an ARM64/NEON build failure in `LocalDigitsToAsciiDigitForDate`. The previous implementation called `simd8_u8::load(...).is_ascii()`, but on ARM64 the simdjson `simd8<uint8_t>::load` returns the underlying vector type, so the member call is invalid. 

This PR replaces the ASCII check with a portable SIMD predicate using `any_bits_set_anywhere(simd8_u8(0x80))` to detect any byte with the high bit set, preserving the original intent while compiling across SIMD backends.

## How was this patch tested?

- Rebuilt the failing object/target in the ARM64 cross-compilation environment and confirmed it compiles successfully.
- (Optional) Ran a full build to ensure no regressions.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Cursor (GPT-5.2)