### PR TITLE
[GLUTEN-11918][VL] Fall back Cast when per-expression timezone differs from session timezone

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -932,8 +932,8 @@ object ExpressionConverter extends SQLConfHelper with Logging {
   }
 
   /**
-   * Recursively checks whether the given data type is, or contains, a TimestampType,
-   * including nested array/map/struct/UDT element types.
+   * Recursively checks whether the given data type is, or contains, a TimestampType, including
+   * nested array/map/struct/UDT element types.
    */
   private def involvesTimestampType(dataType: DataType): Boolean = dataType match {
     case TimestampType => true

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -470,13 +470,13 @@ object ExpressionConverter extends SQLConfHelper with Logging {
         // Gluten uses session-level timezone for cast. If the per-expression timezone
         // differs from session timezone and the cast involves timestamp type, we must
         // fall back to Spark native execution to ensure correctness.
+        // Note: Spark Cast applies zoneId recursively to array/map/struct elements,
+        // so we must check nested types as well.
         c.timeZoneId.foreach {
           tz =>
             val sessionTz = SQLConf.get.sessionLocalTimeZone
             if (tz != sessionTz) {
-              val involvesTimestamp = c.child.dataType == TimestampType ||
-                c.dataType == TimestampType
-              if (involvesTimestamp) {
+              if (involvesTimestampType(c.child.dataType) || involvesTimestampType(c.dataType)) {
                 throw new GlutenNotSupportException(
                   s"Cast with per-expression timezone '$tz' different from session timezone " +
                     s"'$sessionTz' is not supported when timestamp type is involved")
@@ -929,6 +929,19 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           expr
         )
     }
+  }
+
+  /**
+   * Recursively checks whether the given data type is, or contains, a TimestampType,
+   * including nested array/map/struct/UDT element types.
+   */
+  private def involvesTimestampType(dataType: DataType): Boolean = dataType match {
+    case TimestampType => true
+    case a: ArrayType => involvesTimestampType(a.elementType)
+    case m: MapType => involvesTimestampType(m.keyType) || involvesTimestampType(m.valueType)
+    case s: StructType => s.exists(f => involvesTimestampType(f.dataType))
+    case udt: UserDefinedType[_] => involvesTimestampType(udt.sqlType)
+    case _ => false
   }
 
   private def getAndCheckSubstraitName(

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -467,6 +467,22 @@ object ExpressionConverter extends SQLConfHelper with Logging {
       case s: ScalarSubquery =>
         ScalarSubqueryTransformer(substraitExprName, s)
       case c: Cast =>
+        // Gluten uses session-level timezone for cast. If the per-expression timezone
+        // differs from session timezone and the cast involves timestamp type, we must
+        // fall back to Spark native execution to ensure correctness.
+        c.timeZoneId.foreach {
+          tz =>
+            val sessionTz = SQLConf.get.sessionLocalTimeZone
+            if (tz != sessionTz) {
+              val involvesTimestamp = c.child.dataType == TimestampType ||
+                c.dataType == TimestampType
+              if (involvesTimestamp) {
+                throw new GlutenNotSupportException(
+                  s"Cast with per-expression timezone '$tz' different from session timezone " +
+                    s"'$sessionTz' is not supported when timestamp type is involved")
+              }
+            }
+        }
         // Add trim node, as necessary.
         val newCast =
           BackendsApiManager.getSparkPlanExecApiInstance.genCastWithNewChild(c)

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -249,7 +249,7 @@ class VeloxTestSettings extends BackendTestSettings {
   // is in test-jar without shaded Guava, while SubExprEvaluationRuntime is shaded.
   enableSuite[GlutenSubexpressionEliminationSuite]
   enableSuite[GlutenTimeWindowSuite]
-  // TODO: 4.x enableSuite[GlutenToPrettyStringSuite]  // 1 failure
+  enableSuite[GlutenToPrettyStringSuite]
   enableSuite[GlutenUnsafeRowConverterSuite]
   enableSuite[GlutenUnwrapUDTExpressionSuite]
   enableSuite[GlutenV2ExpressionUtilsSuite]

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -260,7 +260,7 @@ class VeloxTestSettings extends BackendTestSettings {
   // is in test-jar without shaded Guava, while SubExprEvaluationRuntime is shaded.
   enableSuite[GlutenSubexpressionEliminationSuite]
   enableSuite[GlutenTimeWindowSuite]
-  // TODO: 4.x enableSuite[GlutenToPrettyStringSuite]  // 1 failure
+  enableSuite[GlutenToPrettyStringSuite]
   enableSuite[GlutenUnsafeRowConverterSuite]
   enableSuite[GlutenUnwrapUDTExpressionSuite]
   enableSuite[GlutenV2ExpressionUtilsSuite]


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

When CastTransformer passes expressions through Substrait, it does not carry
per-expression timezone information. Gluten/Velox only uses the session-level
timezone for cast operations. This causes incorrect results when the
per-expression timezone differs from the session timezone and the cast involves
TimestampType (e.g., timestamp to string formatting in ToPrettyString).

This patch adds a timezone consistency check in ExpressionConverter before
creating CastTransformer. If the per-expression timezone differs from the
session timezone and the cast involves TimestampType, a GlutenNotSupportException
is thrown to fall back to Spark native execution.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

Enabled GlutenToPrettyStringSuite for both Spark 4.0 and Spark 4.1 which was
previously disabled due to 1 test failure caused by this timezone issue.

ISSUE: https://github.com/apache/gluten/issues/11918

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
