### PR TITLE
[CORE] Deduplicate fallback reason when merging Appendable tags

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -17,17 +17,13 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.config.{GlutenConfig, VeloxConfig}
-import org.apache.gluten.events.GlutenPlanFallbackEvent
 
 import org.apache.spark.SparkConf
-import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.execution.{ColumnarBroadcastExchangeExec, ColumnarShuffleExchangeExec, SortExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEShuffleReadExec}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, SortMergeJoinExec}
 import org.apache.spark.utils.GlutenSuiteUtils
-
-import scala.collection.mutable.ArrayBuffer
 
 class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPlanHelper {
   protected val rootPath: String = getClass.getResource("/").getPath
@@ -315,80 +311,53 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
   }
 
   test("get correct fallback reason on nodes without logicalLink") {
-    val events = new ArrayBuffer[GlutenPlanFallbackEvent]
-    val listener = new SparkListener {
-      override def onOtherEvent(event: SparkListenerEvent): Unit = {
-        event match {
-          case e: GlutenPlanFallbackEvent => events.append(e)
-          case _ =>
-        }
-      }
-    }
-    // Drain any pending events from previous tests before registering the listener.
-    // Spark's LiveListenerBus is async, so events posted but not yet dispatched will
-    // still be delivered to listeners added afterwards, contaminating `events` here.
-    GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
-    spark.sparkContext.addSparkListener(listener)
     withSQLConf(GlutenConfig.COLUMNAR_SORT_ENABLED.key -> "false") {
-      try {
-        val df = spark.sql("""
-                             |SELECT
-                             |  c1,
-                             |  c2,
-                             |  ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c2) as row_num,
-                             |  RANK() OVER (PARTITION BY c1 ORDER BY c2) as rank_num
-                             |FROM tmp1
-                             |
-                             |""".stripMargin)
-        df.collect()
-        GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
-        val sort = find(df.queryExecution.executedPlan) {
-          _.isInstanceOf[SortExec]
-        }
-        assert(sort.isDefined)
-        val fallbackReasons = events.flatMap(_.fallbackNodeToReason.values)
-        assert(fallbackReasons.nonEmpty)
-        assert(
-          fallbackReasons.forall(
-            _.contains("[FallbackByUserOptions] Validation failed on node Sort")))
-      } finally {
-        spark.sparkContext.removeSparkListener(listener)
+      GlutenSuiteUtils.withFallbackEventListener(spark.sparkContext) {
+        events =>
+          val df = spark.sql("""
+                               |SELECT
+                               |  c1,
+                               |  c2,
+                               |  ROW_NUMBER() OVER (PARTITION BY c1 ORDER BY c2) as row_num,
+                               |  RANK() OVER (PARTITION BY c1 ORDER BY c2) as rank_num
+                               |FROM tmp1
+                               |
+                               |""".stripMargin)
+          df.collect()
+          GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
+          val sort = find(df.queryExecution.executedPlan) {
+            _.isInstanceOf[SortExec]
+          }
+          assert(sort.isDefined)
+          val fallbackReasons = events.flatMap(_.fallbackNodeToReason.values)
+          assert(fallbackReasons.nonEmpty)
+          assert(
+            fallbackReasons.forall(
+              _.contains("[FallbackByUserOptions] Validation failed on node Sort")))
       }
     }
   }
 
   test("fallback when nested loop join has unsupported expression") {
-    val events = new ArrayBuffer[GlutenPlanFallbackEvent]
-    val listener = new SparkListener {
-      override def onOtherEvent(event: SparkListenerEvent): Unit = {
-        event match {
-          case e: GlutenPlanFallbackEvent => events.append(e)
-          case _ =>
+    GlutenSuiteUtils.withFallbackEventListener(spark.sparkContext) {
+      events =>
+        val df = spark.sql("""
+                             |select tmp1.c1, tmp1.c2 from tmp1
+                             |left join tmp2 on (
+                             |  tmp1.c1 = regexp_extract(tmp2.c1, '(?<=@)[^.]+(?=\.)', 0)
+                             |  or tmp2.c1 > 10
+                             |)
+                             |""".stripMargin)
+        df.collect()
+        GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
+
+        val nestedLoopJoin = find(df.queryExecution.executedPlan) {
+          _.isInstanceOf[BroadcastNestedLoopJoinExec]
         }
-      }
-    }
-    spark.sparkContext.addSparkListener(listener)
-
-    try {
-      val df = spark.sql("""
-                           |select tmp1.c1, tmp1.c2 from tmp1
-                           |left join tmp2 on (
-                           |  tmp1.c1 = regexp_extract(tmp2.c1, '(?<=@)[^.]+(?=\.)', 0)
-                           |  or tmp2.c1 > 10
-                           |)
-                           |""".stripMargin)
-      df.collect()
-      GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
-
-      val nestedLoopJoin = find(df.queryExecution.executedPlan) {
-        _.isInstanceOf[BroadcastNestedLoopJoinExec]
-      }
-      assert(nestedLoopJoin.isDefined)
-      val fallbackReasons = events.flatMap(_.fallbackNodeToReason.values)
-      assert(fallbackReasons.nonEmpty)
-      assert(fallbackReasons.forall(_.contains("regexp_extract due to Pattern")))
-    } finally {
-      spark.sparkContext.removeSparkListener(listener)
+        assert(nestedLoopJoin.isDefined)
+        val fallbackReasons = events.flatMap(_.fallbackNodeToReason.values)
+        assert(fallbackReasons.nonEmpty)
+        assert(fallbackReasons.forall(_.contains("regexp_extract due to Pattern")))
     }
   }
 
@@ -397,31 +366,20 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
     // GlutenPlanFallbackEvent even when spark.gluten.enabled=false (e.g. the vanilla baseline run
     // inside runQueryAndCompare). All nodes would appear as fallback with the generic reason
     // "Gluten does not touch it or does not support it".
-    val events = new ArrayBuffer[GlutenPlanFallbackEvent]
-    val listener = new SparkListener {
-      override def onOtherEvent(event: SparkListenerEvent): Unit = {
-        event match {
-          case e: GlutenPlanFallbackEvent => events.append(e)
-          case _ =>
-        }
+    withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+      GlutenSuiteUtils.withFallbackEventListener(spark.sparkContext) {
+        events =>
+          // Execute a query with gluten disabled — this mimics what runQueryAndCompare does for
+          // the vanilla baseline run. No GlutenPlanFallbackEvent should be emitted at all.
+          spark.sql("SELECT c1, count(*) FROM tmp1 GROUP BY c1").collect()
+          GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
+          assert(
+            events.isEmpty,
+            s"Expected no GlutenPlanFallbackEvent for vanilla Spark execution, " +
+              s"but got ${events.size} event(s). " +
+              s"First event fallback reasons: ${events.headOption.map(_.fallbackNodeToReason)}"
+          )
       }
-    }
-    spark.sparkContext.addSparkListener(listener)
-    try {
-      // Execute a query with gluten disabled — this mimics what runQueryAndCompare does for the
-      // vanilla baseline run. No GlutenPlanFallbackEvent should be emitted at all.
-      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
-        spark.sql("SELECT c1, count(*) FROM tmp1 GROUP BY c1").collect()
-      }
-      GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
-      assert(
-        events.isEmpty,
-        s"Expected no GlutenPlanFallbackEvent for vanilla Spark execution, " +
-          s"but got ${events.size} event(s). " +
-          s"First event fallback reasons: ${events.headOption.map(_.fallbackNodeToReason)}"
-      )
-    } finally {
-      spark.sparkContext.removeSparkListener(listener)
     }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/spark/utils/GlutenSuiteUtils.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/utils/GlutenSuiteUtils.scala
@@ -16,8 +16,33 @@
  */
 package org.apache.spark.utils
 
+import org.apache.gluten.events.GlutenPlanFallbackEvent
+
 import org.apache.spark.SparkContext
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
+
+import scala.collection.mutable.ArrayBuffer
 
 object GlutenSuiteUtils {
   def waitUntilEmpty(ctx: SparkContext): Unit = ctx.listenerBus.waitUntilEmpty()
+
+  // Drain any pending events from previous tests before registering the listener.
+  // Spark's LiveListenerBus is async, so events posted but not yet dispatched would
+  // still be delivered to a listener added afterwards, contaminating the buffer.
+  // After the body finishes, callers should invoke waitUntilEmpty before reading
+  // the events buffer.
+  def withFallbackEventListener(ctx: SparkContext)(
+      body: ArrayBuffer[GlutenPlanFallbackEvent] => Unit): Unit = {
+    waitUntilEmpty(ctx)
+    val events = new ArrayBuffer[GlutenPlanFallbackEvent]
+    val listener = new SparkListener {
+      override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
+        case e: GlutenPlanFallbackEvent => events.append(e)
+        case _ =>
+      }
+    }
+    ctx.addSparkListener(listener)
+    try body(events)
+    finally ctx.removeSparkListener(listener)
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackTag.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/FallbackTag.scala
@@ -22,6 +22,8 @@ import org.apache.spark.sql.execution.SparkPlan
 
 import org.apache.commons.lang3.exception.ExceptionUtils
 
+import scala.collection.immutable.HashSet
+
 sealed trait FallbackTag {
   val stacktrace: Option[String] =
     if (FallbackTags.DEBUG) {
@@ -33,8 +35,16 @@ sealed trait FallbackTag {
 
 object FallbackTag {
 
-  /** A tag that stores one reason text of fall back. */
-  case class Appendable(override val reason: String) extends FallbackTag
+  /** A tag that stores distinct reason texts of fall back. */
+  case class Appendable private (private val reasonSet: HashSet[String]) extends FallbackTag {
+    override def reason(): String = reasonSet.mkString("; ")
+
+    def append(other: Appendable): Appendable = Appendable(reasonSet ++ other.reasonSet)
+  }
+
+  object Appendable {
+    def apply(reason: String): Appendable = new Appendable(HashSet(reason))
+  }
 
   /**
    * A tag that stores reason text of fall back. Other reasons will be discarded when this tag is
@@ -93,7 +103,7 @@ object FallbackTags {
         case (exclusive: FallbackTag.Exclusive, _) =>
           exclusive
         case (l: FallbackTag.Appendable, r: FallbackTag.Appendable) =>
-          FallbackTag.Appendable(s"${l.reason}; ${r.reason}")
+          l.append(r)
       }
     mergedTagOption
       .foreach(mergedTag => plan.setTagValue(TAG, mergedTag))

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/FallbackTagSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/FallbackTagSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar
+
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class FallbackTagSuite extends AnyFunSuite {
+
+  test("repeated tagging with the same reason does not grow the reason string") {
+    // Simulates AQE re-running fallback rules across stages on the same logicalLink,
+    // or several physical nodes sharing one logicalLink with the same fallback reason
+    // (see GlutenFallbackReporter.printFallbackReason). Without dedup, the reason
+    // would grow unboundedly to "r; r; r; r; r".
+    val plan = LocalRelation()
+    val reason = "manually fallback by user"
+    (1 to 5).foreach(_ => FallbackTags.add(plan, reason))
+    assert(FallbackTags.get(plan).reason() == reason)
+  }
+
+  test("distinct Appendable reasons are still concatenated") {
+    val plan = LocalRelation()
+    FallbackTags.add(plan, "reason A")
+    FallbackTags.add(plan, "reason B")
+    assert(FallbackTags.get(plan).reason().split("; ").toSet == Set("reason A", "reason B"))
+  }
+
+  test("Appendable reasons with substring overlap are still distinct") {
+    val plan = LocalRelation()
+    FallbackTags.add(plan, "reason A")
+    FallbackTags.add(plan, "reason")
+    assert(FallbackTags.get(plan).reason().split("; ").toSet == Set("reason A", "reason"))
+  }
+}


### PR DESCRIPTION
## Summary

When AQE re-runs columnar rules across stages, `GlutenFallbackReporter` repeatedly calls
`FallbackTags.add` on the same shared `logicalLink` with the same reason. The previous merge
logic in `FallbackTags.add` unconditionally concatenated `Appendable` reasons, producing strings
like `"r; r; r; ..."` that grow with every AQE iteration. This is especially noticeable when users
manually fall back specific node types and the same fixed reason is added many times.

The relevant comment at `GlutenFallbackReporter.scala:66-71` already explains the trigger:

> With in next round stage in AQE, the physical plan would be a new instance that can not preserve
> the tag, so we need to set the fallback reason to logical plan ... If a logical plan mapping to
> several physical plan, we add all reason into that logical plan to make sure we do not lose any
> fallback reason.

This PR makes `FallbackTag.Appendable` store fallback reasons in a `HashSet[String]` and merge
`Appendable` tags with set union. `reason()` joins the set only when the reason text is reported,
so duplicate reasons are removed precisely without relying on substring checks.

The reason order is not significant here; the important behavior is that the reported text contains
each distinct fallback reason once.

## Drive-by: stabilize FallbackSuite

While testing, the existing test `no fallback event emitted for vanilla Spark execution with gluten
disabled` (added in #12027) turned out to be flaky. Spark's `LiveListenerBus` dispatches events
asynchronously, so `GlutenPlanFallbackEvent`s posted by the previous test in the suite can still be
delivered to the listener registered by the next test, contaminating its `events` buffer. The dedup
change subtly shifted CPU/scheduling timing and exposed it.

Fix is bundled in this PR since it's directly triggered by these changes:

- Added `GlutenSuiteUtils.withFallbackEventListener` that drains the bus before registering the
  listener and removes it afterwards.
- All three event-listener tests in `FallbackSuite`, which previously duplicated the same listener
  boilerplate, now go through this helper.

## Test plan

- [x] Added `FallbackTagSuite` in `gluten-core` covering:
  - repeated `add` of the same reason does not grow the reason string
  - distinct `Appendable` reasons are preserved
  - reasons with substring overlap are still treated as distinct reasons
- [x] Verified the substring-overlap test fails with the previous `contains`-based implementation
  and passes after switching `Appendable` to `HashSet`-based dedup.
- [x] `mvn -pl gluten-core -DwildcardSuites=org.apache.gluten.extension.columnar.FallbackTagSuite test`
- [x] `FallbackSuite` continues to pass with the new helper; the previously flaky test is now stable
  across reruns.
