### PR TITLE
[GLUTEN-11921] Enable Parquet read/write test for NullType

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -76,6 +76,9 @@ const std::string kParquetWriterVersion = "parquet.writer.version";
 
 const std::string kParquetCompressionCodec = "spark.sql.parquet.compression.codec";
 
+const std::string kLegacyParquetReturnNullStructIfAllFieldsMissing =
+    "spark.sql.legacy.parquet.returnNullStructIfAllFieldsMissing";
+
 /// Spark `spark.sql.parquet.writeLegacyFormat` (passed from the JVM as "true"/"false").
 /// Used in VeloxWriterUtils to set `WriterOptions::enableStoreDecimalAsInteger` (inverted).
 /// Velox decimal storage when enableStoreDecimalAsInteger is:

--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -286,7 +286,7 @@ std::shared_ptr<facebook::velox::config::ConfigBase> createHiveConnectorSessionC
   configs[parquetSessionProperty(facebook::velox::parquet::ParquetConfig::kWriterDictionaryPageSizeLimitSession)] =
       conf->get<std::string>(kWriteParquetDictSizeBytes, "2MB");
   configs[parquetSessionProperty(facebook::velox::parquet::ParquetConfig::kNullStructIfAllFieldsMissingSession)] =
-      "true";
+      conf->get<bool>(kLegacyParquetReturnNullStructIfAllFieldsMissing, true) ? "true" : "false";
 
   overwriteVeloxConf(conf.get(), configs, kDynamicBackendConfPrefix);
   return std::make_shared<facebook::velox::config::ConfigBase>(std::move(configs));

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -503,6 +503,7 @@ object GlutenConfig extends ConfigRegistry {
     SQLConf.RUNTIME_BLOOM_FILTER_MAX_NUM_ITEMS.key,
     "spark.io.compression.codec",
     "spark.sql.decimalOperations.allowPrecisionLoss",
+    "spark.sql.legacy.parquet.returnNullStructIfAllFieldsMissing",
     // s3 config
     SPARK_S3_ACCESS_KEY,
     SPARK_S3_SECRET_KEY,

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -567,6 +567,7 @@ class VeloxTestSettings extends BackendTestSettings {
     // TODO: fix on Spark-4.1
     .excludeByPrefix("SPARK-53535") // see https://issues.apache.org/jira/browse/SPARK-53535
     .excludeByPrefix("vectorized reader: missing all struct fields")
+    .exclude("SPARK-54220: vectorized reader: missing all struct fields, struct with NullType only")
   enableSuite[GlutenParquetV1PartitionDiscoverySuite]
   enableSuite[GlutenParquetV2PartitionDiscoverySuite]
   enableSuite[GlutenParquetProtobufCompatibilitySuite]

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -567,7 +567,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // TODO: fix on Spark-4.1
     .excludeByPrefix("SPARK-53535") // see https://issues.apache.org/jira/browse/SPARK-53535
     .excludeByPrefix("vectorized reader: missing all struct fields")
-    .excludeByPrefix("SPARK-54220") // https://issues.apache.org/jira/browse/SPARK-54220
   enableSuite[GlutenParquetV1PartitionDiscoverySuite]
   enableSuite[GlutenParquetV2PartitionDiscoverySuite]
   enableSuite[GlutenParquetProtobufCompatibilitySuite]

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
@@ -22,9 +22,6 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 /** A test suite that tests basic Parquet I/O. */
 class GlutenParquetIOSuite extends ParquetIOSuite with GlutenSQLTestsBaseTrait {
-  override def testNameBlackList: Seq[String] =
-    Seq("SPARK-54220: vectorized reader: missing all struct fields, struct with NullType only")
-
   override protected def testFile(fileName: String): String = {
     getWorkspaceFilePath("sql", "core", "src", "test", "resources").toString + "/" + fileName
   }

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/GlutenParquetIOSuite.scala
@@ -17,14 +17,51 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 /** A test suite that tests basic Parquet I/O. */
 class GlutenParquetIOSuite extends ParquetIOSuite with GlutenSQLTestsBaseTrait {
+  override def testNameBlackList: Seq[String] =
+    Seq("SPARK-54220: vectorized reader: missing all struct fields, struct with NullType only")
+
   override protected def testFile(fileName: String): String = {
     getWorkspaceFilePath("sql", "core", "src", "test", "resources").toString + "/" + fileName
   }
 
   override protected def readResourceParquetFile(name: String): DataFrame = {
     spark.read.parquet(testFile(name))
+  }
+
+  testGluten(
+    "SPARK-54220: vectorized reader: missing all struct fields, struct with NullType only") {
+    val data = Seq(
+      Tuple1((null, null)),
+      Tuple1((null, null)),
+      Tuple1(null)
+    )
+    val readSchema = new StructType().add(
+      "_1",
+      new StructType()
+        .add("_3", IntegerType, nullable = true)
+        .add("_4", StringType, nullable = true),
+      nullable = true)
+    val expectedAnswer = Row(Row(null, null)) :: Row(Row(null, null)) :: Row(null) :: Nil
+
+    withParquetFile(data) {
+      file =>
+        for (offheapEnabled <- Seq(true, false)) {
+          withSQLConf(
+            SQLConf.PARQUET_VECTORIZED_READER_NESTED_COLUMN_ENABLED.key -> "true",
+            SQLConf.LEGACY_PARQUET_RETURN_NULL_STRUCT_IF_ALL_FIELDS_MISSING.key -> "false",
+            SQLConf.COLUMN_VECTOR_OFFHEAP_ENABLED.key -> offheapEnabled.toString
+          ) {
+            withAllParquetReaders {
+              val df = spark.read.schema(readSchema).parquet(file)
+              checkAnswer(df, expectedAnswer)
+            }
+          }
+        }
+    }
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
Enable parquet NullType read/write test.

With `excludeByPrefix("SPARK-54220")` removed, "SPARK-54220: NullType" test is put back for testing. And "SPARK-54220: vectorized reader: missing all struct fields, struct with NullType only" test is replaced by a variant with a check removed since it is only applicable to vanilla Spark.

This PR depends on https://github.com/facebookincubator/velox/pull/17391.

## How was this patch tested?
Pass UT in `GlutenParquetIOSuite`.

## Was this patch authored or co-authored using generative AI tooling?
No.


Related issue: #11921