### PR TITLE
[BUILD] Upgrade Maven to 3.9.16

### DIFF
--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -25,7 +25,7 @@ function semver {
 
 install_maven_from_source() {
     if [ -z "$(which mvn)" ]; then
-        maven_version=3.9.12
+        maven_version=3.9.16
         maven_install_dir=/opt/maven-$maven_version
         if [ -d /opt/maven-$maven_version ]; then
             echo "Failed to install maven: ${maven_install_dir} is exists" >&2

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <fasterxml.version>2.15.0</fasterxml.version>
     <junit.version>4.13.1</junit.version>
     <!-- Maven version for build/mvn wrapper script -->
-    <maven.version>3.9.12</maven.version>
+    <maven.version>3.9.16</maven.version>
     <junit5.version>5.11.4</junit5.version>
     <flexmark.version>0.62.2</flexmark.version>
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Bump maven version to  3.9.15 

Align with upstream:
  apache/spark#55398 - Bump Maven to 3.9.15
  apache/hadoop#8479 - Bump Maven to 3.9.15


Maven 3.9.15 (2025-10-24)
Bug Fixes

- [MNG-8742] Fix module ordering error when --resume-from and --projects are used together
- [MNG-8755] Fix mvnw wrapper handling of paths with spaces on Windows
- [MNG-8760] NPE in MavenProject.getCompileClasspathElements() on Java 24
- [MNG-8768] Regression in maven-compiler-plugin interaction with the --release flag

Improvements

- [MNG-8735] Improved -X debug output to reduce leakage of sensitive info (passwords, tokens)
- [MNG-8748] maven-resolver HTTP connection pool default tuning (~5% performance gain)

Dependency Updates

- maven-resolver 1.9.23 → 1.9.24
- guava 33.3.1-jre → 33.4.0-jre
- commons-lang3 3.17.0 → 3.18.0



<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Pass CI.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
