### PR TITLE
[GLUTEN-12058][VL][MINOR] Skip stage ResourceProfile adjustment rule when off-heap memory is disabled

### DIFF
--- a/docs/get-started/VeloxStageResourceAdj.md
+++ b/docs/get-started/VeloxStageResourceAdj.md
@@ -20,7 +20,11 @@ To address this issue, Apache Gluten introduces a stage-level resource auto-adju
    ```properties  
    spark.dynamicAllocation.enabled=true  
    ```  
-3. **Resource Scheduler Compatibility**:  
+3. ** Enable Off-Heap Memory**:
+   ```properties  
+   spark.memory.offHeap.enabled=true
+   ```
+4. **Resource Scheduler Compatibility**:  
    Ensure the underlying cluster resource manager (e.g., YARN, Kubernetes) supports dynamic resource allocation.
 
 ### **Key Configurations**

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
@@ -59,9 +59,6 @@ case class GlutenAutoAdjustStageResourceProfile(glutenConf: GlutenConfig, spark:
       return plan
     }
     if (!sparkConf.getBoolean(GlutenCoreConfig.SPARK_OFFHEAP_ENABLED_KEY, defaultValue = false)) {
-      logWarning(
-        s"${GlutenCoreConfig.SPARK_OFFHEAP_ENABLED_KEY} is not enabled, " +
-          s"Gluten auto adjust stage resource profile will not work.")
       return plan
     }
     // Starting here, the resource profile may differ between stages. Configure resource settings

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
@@ -58,6 +58,12 @@ case class GlutenAutoAdjustStageResourceProfile(glutenConf: GlutenConfig, spark:
     if (!SQLConf.get.adaptiveExecutionEnabled) {
       return plan
     }
+    if (!sparkConf.getBoolean(GlutenCoreConfig.SPARK_OFFHEAP_ENABLED_KEY, defaultValue = false)) {
+      logWarning(
+        s"${GlutenCoreConfig.SPARK_OFFHEAP_ENABLED_KEY} is not enabled, " +
+          s"Gluten auto adjust stage resource profile will not work.")
+      return plan
+    }
     // Starting here, the resource profile may differ between stages. Configure resource settings
     // using the default profile to prevent any impact from the previous stage. If a new resource
     // profile is applied, the settings will be updated accordingly.


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `GlutenAutoAdjustStageResourceProfile` rule is designed to adjust off-heap and heap memory for different stages. We should disable GlutenAutoAdjustStageResourceProfile rule when off-heap memory is not enabled. (We disable off-heap memory when `spark.gluten.memory.dynamic.offHeap.sizing.enabled` is enabled.)

closes #12058

## How was this patch tested?

minor fix

## Was this patch authored or co-authored using generative AI tooling?

No