### PR TITLE
[VL] Enable hour(timestamp_ntz) native execution in Velox backend

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -599,12 +599,9 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
           checkGlutenPlan[BatchScanExecTransformer]
         }
 
-        // Ensures the fallback of unsupported function works.
+        // hour(timestamp_ntz) runs natively; output is int (no NTZ propagation).
         runQueryAndCompare("select hour(ts) from view") {
-          df =>
-            assert(collect(df.queryExecution.executedPlan) {
-              case p if p.isInstanceOf[ProjectExec] => p
-            }.nonEmpty)
+          checkGlutenPlan[ProjectExecTransformer]
         }
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -25,6 +25,7 @@ import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.expressions.Hour
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.datasources.WriteFilesExec
@@ -270,7 +271,20 @@ object Validators {
           case p if HiveTableScanExecTransformer.isHiveTableScan(p) => true
           case _ => false
         }
-        if (isScan) {
+        val isHourOnNtz = plan match {
+          case p: ProjectExec =>
+            p.projectList.forall {
+              expr =>
+                (!containsNTZ(expr.dataType) &&
+                  !expr.references.exists(a => containsNTZ(a.dataType))) ||
+                expr.exists {
+                  case Hour(child, _) => containsNTZ(child.dataType)
+                  case _ => false
+                }
+            }
+          case _ => false
+        }
+        if (isScan || isHourOnNtz) {
           return pass()
         }
       }


### PR DESCRIPTION
Enable hour(timestamp_ntz) to run natively in the Velox backend instead of falling back to Spark.
