### PR TITLE
[VL] Add Spark 4.1 TimeType support

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxValidatorApi.scala
@@ -19,6 +19,7 @@ package org.apache.gluten.backendsapi.velox
 import org.apache.gluten.backendsapi.{BackendsApiManager, ValidatorApi}
 import org.apache.gluten.config.VeloxConfig
 import org.apache.gluten.execution.ValidationResult
+import org.apache.gluten.expression.ConverterUtils
 import org.apache.gluten.substrait.`type`.TypeNode
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.expression.ExpressionNode
@@ -107,6 +108,7 @@ object VeloxValidatorApi {
   private def isPrimitiveType(dataType: DataType): Boolean = {
     val enableTimestampNtzValidation = VeloxConfig.get.enableTimestampNtzValidation
     dataType match {
+      case dt if ConverterUtils.isSupportedTimeType(dt) => true
       case BooleanType | ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType |
           StringType | BinaryType | _: DecimalType | DateType | TimestampType |
           YearMonthIntervalType.DEFAULT | NullType =>

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxColumnarToRowExec.scala
@@ -19,6 +19,7 @@ package org.apache.gluten.execution
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.columnarbatch.{ColumnarBatches, VeloxColumnarBatches}
 import org.apache.gluten.exception.GlutenNotSupportException
+import org.apache.gluten.expression.ConverterUtils
 import org.apache.gluten.iterator.Iterators
 import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.vectorized.{NativeColumnarToRowInfo, NativeColumnarToRowJniWrapper}
@@ -41,6 +42,7 @@ case class VeloxColumnarToRowExec(child: SparkPlan) extends ColumnarToRowExecBas
     // Depending on the input type, VeloxColumnarToRowConverter.
     for (field <- schema.fields) {
       field.dataType match {
+        case dt if ConverterUtils.isSupportedTimeType(dt) =>
         case _: BooleanType =>
         case _: ByteType =>
         case _: ShortType =>

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxLiteralSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxLiteralSuite.scala
@@ -34,6 +34,7 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
       .set("spark.sql.shuffle.partitions", "1")
       .set("spark.memory.offHeap.size", "2g")
       .set("spark.unsafe.exceptionOnMemoryLeak", "true")
+      .set("spark.sql.ansi.enabled", "false")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
       .set("spark.sql.sources.useV1SourceList", "avro")
   }
@@ -54,6 +55,16 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
         assert(plan.find(_.isInstanceOf[ProjectExecTransformer]).isEmpty, sql)
         assert(plan.find(_.isInstanceOf[ProjectExec]).isDefined, sql)
     }
+  }
+
+  def validateOffloadPlan(sql: String): Unit = {
+    val df = spark.sql(sql)
+    val plan = df.queryExecution.executedPlan
+    assert(plan.find(_.isInstanceOf[ProjectExecTransformer]).isDefined, sql)
+    assert(plan.find(_.isInstanceOf[ProjectExec]).isEmpty, sql)
+    val wholeStageTransformers = plan.collect { case w: WholeStageTransformer => w }
+    assert(wholeStageTransformers.nonEmpty, sql)
+    wholeStageTransformers.foreach(_.nativePlanString())
   }
 
   test("Struct Literal") {
@@ -133,6 +144,14 @@ class VeloxLiteralSuite extends VeloxWholeStageTransformerSuite {
     validateOffloadResult("SELECT TIMESTAMP'2020-12-31', TIMESTAMP'2020-12-30'")
     validateOffloadResult("SELECT X'1234', X'a'")
     validateOffloadResult("SELECT DATE'2020-12-31', DATE'2020-12-30'")
+  }
+
+  testWithMinSparkVersion("Time Literal", "4.1") {
+    // Spark 4.1 cannot collect TIME through Row encoders yet, so this validates planning and
+    // native plan conversion without comparing collected results.
+    validateOffloadPlan("SELECT TIME'12:34:56.123456', TIME'00:00:00'")
+    validateOffloadPlan("SELECT array(TIME'12:34:56.123456', TIME'00:00:00')")
+    validateOffloadPlan("SELECT struct(TIME'12:34:56.123456')")
   }
 
   test("Literal Fallback") {

--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.cc
@@ -22,20 +22,172 @@
 #include "memory/VeloxColumnarBatch.h"
 #include "utils/Exception.h"
 #include "velox/row/UnsafeRowFast.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+#include "velox/vector/LazyVector.h"
 
 using namespace facebook;
 
 namespace gluten {
+namespace {
+
+constexpr int64_t kMicrosToNanos = 1000;
+
+bool isTimeMicroUtc(const velox::TypePtr& type) {
+  return type->equivalent(*velox::TIME_MICRO_UTC());
+}
+
+bool containsTimeMicroUtc(const velox::TypePtr& type) {
+  if (isTimeMicroUtc(type)) {
+    return true;
+  }
+
+  switch (type->kind()) {
+    case velox::TypeKind::ARRAY:
+      return containsTimeMicroUtc(type->asArray().elementType());
+    case velox::TypeKind::MAP:
+      return containsTimeMicroUtc(type->asMap().keyType()) || containsTimeMicroUtc(type->asMap().valueType());
+    case velox::TypeKind::ROW: {
+      const auto& rowType = type->asRow();
+      for (const auto& child : rowType.children()) {
+        if (containsTimeMicroUtc(child)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    default:
+      return false;
+  }
+}
+
+velox::VectorPtr normalizeTimeForSparkUnsafeRow(const velox::VectorPtr& vector, velox::memory::MemoryPool* pool);
+
+velox::VectorPtr normalizeTimeScalarForSparkUnsafeRow(const velox::VectorPtr& vector, velox::memory::MemoryPool* pool) {
+  velox::DecodedVector decoded(*vector);
+  auto normalized = velox::BaseVector::create(velox::BIGINT(), vector->size(), pool);
+  auto* flat = normalized->asFlatVector<int64_t>();
+
+  for (auto row = 0; row < vector->size(); ++row) {
+    if (decoded.isNullAt(row)) {
+      flat->setNull(row, true);
+    } else {
+      flat->set(row, decoded.valueAt<int64_t>(row) * kMicrosToNanos);
+    }
+  }
+  return normalized;
+}
+
+velox::VectorPtr loadedFlatVector(const velox::VectorPtr& vector) {
+  auto loaded = velox::BaseVector::loadedVectorShared(vector);
+  velox::BaseVector::flattenVector(loaded);
+  if (loaded->isLazy()) {
+    loaded = loaded->as<velox::LazyVector>()->loadedVectorShared();
+  }
+  return loaded;
+}
+
+velox::VectorPtr normalizeArrayForSparkUnsafeRow(const velox::VectorPtr& vector, velox::memory::MemoryPool* pool) {
+  auto array = loadedFlatVector(vector)->as<velox::ArrayVector>();
+  auto elements = normalizeTimeForSparkUnsafeRow(array->elements(), pool);
+  if (elements == array->elements()) {
+    return vector;
+  }
+  return std::make_shared<velox::ArrayVector>(
+      pool,
+      velox::ARRAY(elements->type()),
+      array->nulls(),
+      array->size(),
+      array->offsets(),
+      array->sizes(),
+      elements,
+      array->getNullCount());
+}
+
+velox::VectorPtr normalizeMapForSparkUnsafeRow(const velox::VectorPtr& vector, velox::memory::MemoryPool* pool) {
+  auto map = loadedFlatVector(vector)->as<velox::MapVector>();
+  auto keys = normalizeTimeForSparkUnsafeRow(map->mapKeys(), pool);
+  auto values = normalizeTimeForSparkUnsafeRow(map->mapValues(), pool);
+  if (keys == map->mapKeys() && values == map->mapValues()) {
+    return vector;
+  }
+  return std::make_shared<velox::MapVector>(
+      pool,
+      velox::MAP(keys->type(), values->type()),
+      map->nulls(),
+      map->size(),
+      map->offsets(),
+      map->sizes(),
+      keys,
+      values,
+      map->getNullCount(),
+      map->hasSortedKeys());
+}
+
+velox::RowVectorPtr normalizeRowForSparkUnsafeRow(
+    const velox::RowVectorPtr& rowVector,
+    velox::memory::MemoryPool* pool) {
+  std::vector<velox::VectorPtr> children;
+  children.reserve(rowVector->childrenSize());
+  bool changed = false;
+  for (const auto& child : rowVector->children()) {
+    auto normalized = normalizeTimeForSparkUnsafeRow(child, pool);
+    changed = changed || normalized != child;
+    children.emplace_back(std::move(normalized));
+  }
+
+  if (!changed) {
+    return rowVector;
+  }
+
+  std::vector<velox::TypePtr> childTypes;
+  childTypes.reserve(children.size());
+  for (const auto& child : children) {
+    childTypes.emplace_back(child->type());
+  }
+  return std::make_shared<velox::RowVector>(
+      pool,
+      velox::ROW(velox::asRowType(rowVector->type())->names(), std::move(childTypes)),
+      rowVector->nulls(),
+      rowVector->size(),
+      std::move(children),
+      rowVector->getNullCount());
+}
+
+velox::VectorPtr normalizeTimeForSparkUnsafeRow(const velox::VectorPtr& vector, velox::memory::MemoryPool* pool) {
+  if (!containsTimeMicroUtc(vector->type())) {
+    return vector;
+  }
+
+  if (isTimeMicroUtc(vector->type())) {
+    return normalizeTimeScalarForSparkUnsafeRow(vector, pool);
+  }
+
+  switch (vector->typeKind()) {
+    case velox::TypeKind::ARRAY:
+      return normalizeArrayForSparkUnsafeRow(vector, pool);
+    case velox::TypeKind::MAP:
+      return normalizeMapForSparkUnsafeRow(vector, pool);
+    case velox::TypeKind::ROW:
+      return normalizeRowForSparkUnsafeRow(std::dynamic_pointer_cast<velox::RowVector>(loadedFlatVector(vector)), pool);
+    default:
+      return vector;
+  }
+}
+
+} // namespace
 
 void VeloxColumnarToRowConverter::refreshStates(facebook::velox::RowVectorPtr rowVector, int64_t startRow) {
-  auto vectorLength = rowVector->size();
-  numCols_ = rowVector->childrenSize();
+  rowVectorForUnsafeRow_ = normalizeRowForSparkUnsafeRow(rowVector, veloxPool_.get());
 
-  fast_ = std::make_unique<velox::row::UnsafeRowFast>(rowVector);
+  auto vectorLength = rowVectorForUnsafeRow_->size();
+  numCols_ = rowVectorForUnsafeRow_->childrenSize();
+
+  fast_ = std::make_unique<velox::row::UnsafeRowFast>(rowVectorForUnsafeRow_);
 
   int64_t totalMemorySize;
 
-  if (auto fixedRowSize = velox::row::UnsafeRowFast::fixedRowSize(velox::asRowType(rowVector->type()))) {
+  if (auto fixedRowSize = velox::row::UnsafeRowFast::fixedRowSize(velox::asRowType(rowVectorForUnsafeRow_->type()))) {
     auto rowSize = fixedRowSize.value();
     // make sure it has at least one row
     numRows_ = std::max<int32_t>(1, std::min<int64_t>(memThreshold_ / rowSize, vectorLength - startRow));

--- a/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.h
+++ b/cpp/velox/operators/serializer/VeloxColumnarToRowConverter.h
@@ -42,6 +42,7 @@ class VeloxColumnarToRowConverter final : public ColumnarToRowConverter {
   std::shared_ptr<facebook::velox::memory::MemoryPool> veloxPool_;
   std::shared_ptr<facebook::velox::row::UnsafeRowFast> fast_;
   facebook::velox::BufferPtr veloxBuffers_;
+  facebook::velox::RowVectorPtr rowVectorForUnsafeRow_;
   int64_t memThreshold_;
 };
 

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -76,6 +76,8 @@ TypePtr SubstraitParser::parseType(const ::substrait::Type& substraitType, bool 
       return UNKNOWN();
     case ::substrait::Type::KindCase::kDate:
       return DATE();
+    case ::substrait::Type::KindCase::kTime:
+      return TIME_MICRO_UTC();
     case ::substrait::Type::KindCase::kTimestampTz:
       return TIMESTAMP();
     case ::substrait::Type::KindCase::kDecimal: {
@@ -356,6 +358,9 @@ int64_t SubstraitParser::getLiteralValue(const ::substrait::Expression::Literal&
     memcpy(&decimalValue, decimal.c_str(), 16);
     return static_cast<int64_t>(decimalValue);
   }
+  if (literal.has_time()) {
+    return literal.time();
+  }
   return literal.i64();
 }
 
@@ -431,6 +436,7 @@ const std::unordered_map<std::string, std::string> SubstraitParser::typeMap_ = {
     {"fp32", "REAL"},
     {"fp64", "DOUBLE"},
     {"date", "DATE"},
+    {"time", "TIME MICRO UTC"},
     {"ts", "TIMESTAMP"},
     {"str", "VARCHAR"},
     {"vbin", "VARBINARY"},

--- a/cpp/velox/substrait/SubstraitToVeloxExpr.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxExpr.cc
@@ -131,6 +131,8 @@ TypePtr getScalarType(const ::substrait::Expression::Literal& literal) {
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kDate:
       return DATE();
+    case ::substrait::Expression_Literal::LiteralTypeCase::kTime:
+      return TIME_MICRO_UTC();
     case ::substrait::Expression_Literal::LiteralTypeCase::kTimestampTz:
       return TIMESTAMP();
     case ::substrait::Expression_Literal::LiteralTypeCase::kString:

--- a/cpp/velox/substrait/VeloxSubstraitSignature.cc
+++ b/cpp/velox/substrait/VeloxSubstraitSignature.cc
@@ -24,6 +24,9 @@ std::string VeloxSubstraitSignature::toSubstraitSignature(const TypePtr& type) {
   if (type->isDate()) {
     return "date";
   }
+  if (type->equivalent(*TIME_MICRO_UTC())) {
+    return "time";
+  }
 
   switch (type->kind()) {
     case TypeKind::BOOLEAN:
@@ -157,6 +160,10 @@ TypePtr VeloxSubstraitSignature::fromSubstraitSignature(const std::string& signa
 
   if (signature == "date") {
     return DATE();
+  }
+
+  if (signature == "time") {
+    return TIME_MICRO_UTC();
   }
 
   if (signature == "nothing") {

--- a/cpp/velox/substrait/VeloxToSubstraitType.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitType.cc
@@ -31,6 +31,12 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
     substraitType->set_allocated_date(substraitDate);
     return *substraitType;
   }
+  if (type->equivalent(*velox::TIME_MICRO_UTC())) {
+    auto substraitTime = google::protobuf::Arena::CreateMessage<::substrait::Type_Time>(&arena);
+    substraitTime->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+    substraitType->set_allocated_time(substraitTime);
+    return *substraitType;
+  }
 
   switch (type->kind()) {
     case velox::TypeKind::BOOLEAN: {

--- a/cpp/velox/tests/FunctionTest.cc
+++ b/cpp/velox/tests/FunctionTest.cc
@@ -25,6 +25,7 @@
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include "substrait/SubstraitParser.h"
+#include "substrait/SubstraitToVeloxExpr.h"
 #include "substrait/SubstraitToVeloxPlan.h"
 #include "substrait/TypeUtils.h"
 #include "substrait/VariantToVectorConverter.h"
@@ -75,6 +76,22 @@ TEST_F(FunctionTest, getIdxFromNodeName) {
   std::string nodeName = "n1_0";
   int index = SubstraitParser::getIdxFromNodeName(nodeName);
   ASSERT_EQ(index, 0);
+}
+
+TEST_F(FunctionTest, substraitTime) {
+  ::substrait::Type type;
+  type.mutable_time()->set_nullability(::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+  auto parsedType = SubstraitParser::parseType(type);
+  ASSERT_TRUE(parsedType->equivalent(*TIME_MICRO_UTC()));
+
+  ::substrait::Expression_Literal literal;
+  literal.set_time(45'296'123'456L);
+  ASSERT_EQ(SubstraitParser::getLiteralValue<int64_t>(literal), 45'296'123'456L);
+
+  SubstraitVeloxExprConverter exprConverter(pool(), {});
+  auto constant = exprConverter.toVeloxExpr(literal);
+  ASSERT_TRUE(constant->type()->equivalent(*TIME_MICRO_UTC()));
+  ASSERT_EQ(constant->value().value<TypeKind::BIGINT>(), 45'296'123'456L);
 }
 
 TEST_F(FunctionTest, getNameBeforeDelimiter) {

--- a/cpp/velox/tests/VeloxColumnarToRowTest.cc
+++ b/cpp/velox/tests/VeloxColumnarToRowTest.cc
@@ -94,4 +94,13 @@ TEST_F(VeloxColumnarToRowTest, Buffer_int64_int64_with_null) {
   testRowBufferAddr(vector, expectArr, sizeof(expectArr));
 }
 
+TEST_F(VeloxColumnarToRowTest, Buffer_time_micro_utc) {
+  auto vector = makeRowVector({makeFlatVector<int64_t>({1, 2}, TIME_MICRO_UTC())});
+
+  uint8_t expectArr[] = {
+      0, 0, 0, 0, 0, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 208, 7, 0, 0, 0, 0, 0, 0,
+  };
+  testRowBufferAddr(vector, expectArr, sizeof(expectArr));
+}
+
 } // namespace gluten

--- a/cpp/velox/tests/VeloxSubstraitSignatureTest.cc
+++ b/cpp/velox/tests/VeloxSubstraitSignatureTest.cc
@@ -56,6 +56,7 @@ TEST_F(VeloxSubstraitSignatureTest, toSubstraitSignatureWithType) {
   ASSERT_EQ(toSubstraitSignature(VARBINARY()), "vbin");
   ASSERT_EQ(toSubstraitSignature(TIMESTAMP()), "ts");
   ASSERT_EQ(toSubstraitSignature(DATE()), "date");
+  ASSERT_EQ(toSubstraitSignature(TIME_MICRO_UTC()), "time");
   ASSERT_EQ(toSubstraitSignature(ARRAY(BOOLEAN())), "list");
   ASSERT_EQ(toSubstraitSignature(ARRAY(INTEGER())), "list");
   ASSERT_EQ(toSubstraitSignature(MAP(INTEGER(), BIGINT())), "map");
@@ -107,6 +108,7 @@ TEST_F(VeloxSubstraitSignatureTest, fromSubstraitSignature) {
   ASSERT_EQ(fromSubstraitSignature("vbin")->kind(), TypeKind::VARBINARY);
   ASSERT_EQ(fromSubstraitSignature("ts")->kind(), TypeKind::TIMESTAMP);
   ASSERT_EQ(fromSubstraitSignature("date")->kind(), TypeKind::INTEGER);
+  ASSERT_TRUE(fromSubstraitSignature("time")->equivalent(*TIME_MICRO_UTC()));
   ASSERT_EQ(fromSubstraitSignature("dec<18,2>")->kind(), TypeKind::BIGINT);
   ASSERT_EQ(fromSubstraitSignature("dec<19,2>")->kind(), TypeKind::HUGEINT);
 

--- a/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
+++ b/cpp/velox/tests/VeloxToSubstraitTypeTest.cc
@@ -62,4 +62,11 @@ TEST_F(VeloxToSubstraitTypeTest, basic) {
   testTypeConversion(ROW({}, {}));
 }
 
+TEST_F(VeloxToSubstraitTypeTest, time) {
+  google::protobuf::Arena arena;
+  auto substraitType = typeConvertor_->toSubstraitType(arena, TIME_MICRO_UTC());
+  ASSERT_EQ(substraitType.kind_case(), ::substrait::Type::KindCase::kTime);
+  ASSERT_TRUE(SubstraitParser::parseType(substraitType)->equivalent(*TIME_MICRO_UTC()));
+}
+
 } // namespace gluten

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ExpressionBuilder.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ExpressionBuilder.java
@@ -110,6 +110,14 @@ public class ExpressionBuilder {
     return new TimestampLiteralNode(vTimestamp, typeNode);
   }
 
+  public static TimeLiteralNode makeTimeLiteral(Long vTime) {
+    return new TimeLiteralNode(vTime);
+  }
+
+  public static TimeLiteralNode makeTimeLiteral(Long vTime, TypeNode typeNode) {
+    return new TimeLiteralNode(vTime, typeNode);
+  }
+
   public static StringLiteralNode makeStringLiteral(String vString) {
     return new StringLiteralNode(vString);
   }
@@ -176,6 +184,11 @@ public class ExpressionBuilder {
     }
     if (typeNode instanceof TimestampTypeNode) {
       return makeTimestampLiteral((Long) obj, typeNode);
+    }
+    if (typeNode instanceof TimeTypeNode) {
+      // Spark stores TimeType literals as nanoseconds since midnight. Substrait time literals
+      // and Velox TIME_MICRO_UTC use microseconds since midnight.
+      return makeTimeLiteral(((Long) obj) / 1000L, typeNode);
     }
     if (typeNode instanceof StringTypeNode) {
       return makeStringLiteral(obj.toString(), typeNode);

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/StructLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/StructLiteralNode.java
@@ -61,6 +61,9 @@ public class StructLiteralNode extends LiteralNodeWithValue<InternalRow> {
     if (type instanceof TimestampTypeNode) {
       return ExpressionBuilder.makeLiteral(value.getLong(index), type);
     }
+    if (type instanceof TimeTypeNode) {
+      return ExpressionBuilder.makeLiteral(value.getLong(index), type);
+    }
     if (type instanceof StringTypeNode) {
       return ExpressionBuilder.makeLiteral(value.getUTF8String(index), type);
     }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/TimeLiteralNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/TimeLiteralNode.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.substrait.expression;
+
+import org.apache.gluten.substrait.type.TimeTypeNode;
+import org.apache.gluten.substrait.type.TypeNode;
+
+import io.substrait.proto.Expression.Literal.Builder;
+
+public class TimeLiteralNode extends LiteralNodeWithValue<Long> {
+  public TimeLiteralNode(Long value) {
+    super(value, new TimeTypeNode(true));
+  }
+
+  public TimeLiteralNode(Long value, TypeNode typeNode) {
+    super(value, typeNode);
+  }
+
+  @Override
+  protected void updateLiteralBuilder(Builder literalBuilder, Long value) {
+    literalBuilder.setTime(value);
+  }
+}

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TimeTypeNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TimeTypeNode.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.substrait.type;
+
+import io.substrait.proto.Type;
+
+public class TimeTypeNode extends TypeNode {
+
+  public TimeTypeNode(Boolean nullable) {
+    super(nullable);
+  }
+
+  @Override
+  public Type toProtobuf() {
+    Type.Time.Builder timeBuilder = Type.Time.newBuilder();
+    if (nullable) {
+      timeBuilder.setNullability(Type.Nullability.NULLABILITY_NULLABLE);
+    } else {
+      timeBuilder.setNullability(Type.Nullability.NULLABILITY_REQUIRED);
+    }
+    Type.Builder builder = Type.newBuilder();
+    builder.setTime(timeBuilder.build());
+    return builder.build();
+  }
+}

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TypeBuilder.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/type/TypeBuilder.java
@@ -69,6 +69,10 @@ public class TypeBuilder {
     return new DateTypeNode(nullable);
   }
 
+  public static TypeNode makeTime(Boolean nullable) {
+    return new TimeTypeNode(nullable);
+  }
+
   public static TypeNode makeIntervalYear(Boolean nullable) {
     return new IntervalYearTypeNode(nullable);
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/HashAggregateExecBaseTransformer.scala
@@ -98,6 +98,7 @@ abstract class HashAggregateExecBaseTransformer(
 
   protected def checkType(dataType: DataType): Boolean = {
     dataType match {
+      case dt if ConverterUtils.isSupportedTimeType(dt) => true
       case BooleanType | StringType | TimestampType | DateType | BinaryType =>
         true
       case _: NumericType => true

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConverterUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ConverterUtils.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
+import org.apache.spark.util.SparkReflectionUtil
 
 import com.google.protobuf.CodedInputStream
 import io.substrait.proto.Type
@@ -33,10 +34,79 @@ import io.substrait.proto.Type
 import java.util.{ArrayList => JArrayList, List => JList, Locale}
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 case class ExpressionType(dataType: DataType, nullable: Boolean) {}
 
 object ConverterUtils extends Logging {
+  final private val SparkTimeTypeClassName = "org.apache.spark.sql.types.TimeType"
+  final private val SparkTimeTypeObjectClassName = SparkTimeTypeClassName + "$"
+  final private val TimeMicroPrecision = 6
+  final private val TimeCatalogPattern = "time(?:\\((\\d+)\\))?".r
+
+  private lazy val sparkTimeTypeClass: Option[Class[_]] = {
+    try {
+      Some(SparkReflectionUtil.classForName(SparkTimeTypeClassName))
+    } catch {
+      case _: ClassNotFoundException => None
+    }
+  }
+
+  def isTimeType(dataType: DataType): Boolean = {
+    val typeName = dataType.typeName.toLowerCase(Locale.ROOT)
+    val catalogString = dataType.catalogString.toLowerCase(Locale.ROOT)
+    sparkTimeTypeClass.exists(_.isInstance(dataType)) ||
+    typeName == "time" ||
+    catalogString == "time" ||
+    catalogString.startsWith("time(")
+  }
+
+  def isSupportedTimeType(dataType: DataType): Boolean = {
+    isTimeType(dataType) && timePrecision(dataType).forall(_ <= TimeMicroPrecision)
+  }
+
+  private def timePrecision(dataType: DataType): Option[Int] = {
+    if (!isTimeType(dataType)) {
+      return None
+    }
+    try {
+      Some(dataType.getClass.getMethod("precision").invoke(dataType).asInstanceOf[Int])
+    } catch {
+      case NonFatal(_) =>
+        dataType.catalogString.toLowerCase(Locale.ROOT) match {
+          case TimeCatalogPattern(precision) if precision != null =>
+            Some(precision.toInt)
+          case TimeCatalogPattern(_) =>
+            None
+          case _ =>
+            None
+        }
+    }
+  }
+
+  private def validateTimeType(dataType: DataType): Unit = {
+    timePrecision(dataType).foreach {
+      precision =>
+        if (precision > TimeMicroPrecision) {
+          throw new GlutenNotSupportException(
+            s"Type $dataType is not supported. Velox TIME_MICRO_UTC supports up to " +
+              s"$TimeMicroPrecision fractional digits.")
+        }
+    }
+  }
+
+  private def defaultTimeType(): DataType = {
+    try {
+      val module =
+        SparkReflectionUtil.classForName(SparkTimeTypeObjectClassName).getField("MODULE$").get(null)
+      module.getClass.getMethod("apply").invoke(module).asInstanceOf[DataType]
+    } catch {
+      case NonFatal(e) =>
+        throw new GlutenNotSupportException(
+          "Substrait TIME is only supported when Spark TimeType is available.",
+          e)
+    }
+  }
 
   /**
    * Get the source Attribute for the input Expression. It will traverse the Expression tree in a
@@ -162,6 +232,8 @@ object ConverterUtils extends Logging {
         (BinaryType, isNullable(substraitType.getBinary.getNullability))
       case Type.KindCase.TIMESTAMP_TZ =>
         (TimestampType, isNullable(substraitType.getTimestampTz.getNullability))
+      case Type.KindCase.TIME =>
+        (defaultTimeType(), isNullable(substraitType.getTime.getNullability))
       case Type.KindCase.DATE =>
         (DateType, isNullable(substraitType.getDate.getNullability))
       case Type.KindCase.DECIMAL =>
@@ -197,6 +269,9 @@ object ConverterUtils extends Logging {
 
   def getTypeNode(datatype: DataType, nullable: Boolean): TypeNode = {
     datatype match {
+      case dt if isTimeType(dt) =>
+        validateTimeType(dt)
+        TypeBuilder.makeTime(nullable)
       case BooleanType =>
         TypeBuilder.makeBoolean(nullable)
       case FloatType =>
@@ -271,6 +346,8 @@ object ConverterUtils extends Logging {
         BinaryType
       case _: DateTypeNode =>
         DateType
+      case _: TimeTypeNode =>
+        defaultTimeType()
       case _: IntervalYearTypeNode =>
         YearMonthIntervalType.DEFAULT
       case d: DecimalTypeNode =>
@@ -398,6 +475,7 @@ object ConverterUtils extends Logging {
       case FloatType => "fp32"
       case DoubleType => "fp64"
       case DateType => "date"
+      case dt if isTimeType(dt) => "time"
       case TimestampType => "ts"
       case StringType => "str"
       case BinaryType => "vbin"


### PR DESCRIPTION
What changes are proposed in this pull request?
This PR adds native Spark 4.1 TIME data type support in the Velox backend by mapping Substrait TIME to Velox TIME_MICRO_UTC and handling TIME literals end to end.

The change:

- adds Gluten Substrait TimeType and TimeLiteral nodes
- converts Spark 4.1 TimeType literals from Spark nanos to Substrait/Velox micros
- parses Substrait Type.Time as Velox TIME_MICRO_UTC in the C++ Substrait parser
- maps TIME_MICRO_UTC through Velox/Substrait signatures and Velox-to-Substrait type conversion
- converts Velox TIME_MICRO_UTC values back to Spark UnsafeRow nanos in columnar-to-row, including nested arrays, maps, and rows
- allows supported TIME precision through Velox validation and planning paths
- adds Java, Scala, and C++ coverage for time literals, type conversion, signatures, and columnar-to-row serialization

Why are the changes needed?
#11919 tracks Spark 4.1 TimeType support for the Velox backend. Spark 4.1 adds TimeType to DataTypeTestUtils.atomicTypes, so tests and planning paths that enumerate atomic types can hit TIME even when Gluten/Velox cannot yet parse or execute it. Mapping Substrait TIME to Velox TIME_MICRO_UTC gives Gluten a native representation for supported Spark TIME precision and unblocks literal/planning paths.

Does this PR introduce any user-facing change?
No public API change. It extends native Spark 4.1 TIME support in the Velox backend.

How was this patch tested?
Built and ran locally:

- Spark 4.1 Velox compile with Scala 2.13 and Java 21
- focused Spark 4.1 VeloxLiteralSuite Time Literal test
- C++ Velox backend build
- generic_benchmark smoke run

Commands:

- `git diff --cached --check`
- `mvn -Pbackends-velox,spark-4.1,scala-2.13,java-21 -pl backends-velox -am -DskipTests -Dcheckstyle.skip -Dspotless.check.skip compile`
- `./dev/run-scala-test.sh --force -Pjava-21,spark-4.1,scala-2.13,backends-velox,hadoop-3.4,spark-ut,delta -pl backends-velox -s org.apache.gluten.execution.VeloxLiteralSuite -t "Time Literal" -Dscalastyle.skip=true -Dcheckstyle.skip -Dspotless.check.skip`
- `cmake --build cpp/build --target velox -j 4`

Native C++ unit-test targets were not run locally because this checkout does not have the Velox vector test utility archive built (`libvelox_vector_test_lib.a`).

Performance
I ran targeted local benchmarks comparing clean upstream main against this patch.

Focused columnar-to-row benchmark:

| type | before median us | after median us | delta |
| --- | ---: | ---: | ---: |
| BIGINT | 1325.407 | 1329.853 | +0.335% |
| TIME_MICRO_UTC | 1331.705 | 1643.357 | +23.403% |

The TIME_MICRO_UTC delta is expected because this patch adds the required micros-to-nanos normalization for Spark UnsafeRow compatibility; the baseline treated TIME as a raw BIGINT-like value.

Broad generic_q5 smoke benchmark:

| metric | before | after | delta |
| --- | ---: | ---: | ---: |
| real median ms | 29.076 | 29.159 | +0.285% |
| CPU median ms | 28.993 | 28.991 | -0.006% |

Related issue: #11919
Tracked by #11910

Was this patch authored or co-authored using generative AI tooling?
Generated-by: IBM BOB