### PR TITLE
[GLUTEN-10215][VL] Delta write: Preserve partition columns when required

### DIFF
--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -564,6 +564,14 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
           }
       }.toArray
 
+    private val reservePartitionColumns: Boolean =
+      description.partitionColumns.exists {
+        pcol =>
+          description.dataColumns.exists {
+            dcol => dcol.name == pcol.name && dcol.exprId == pcol.exprId
+          }
+      }
+
     private def beforeWrite(record: InternalRow): Unit = {
       val nextPartitionValues = if (isPartitioned) Some(getPartitionValues(record)) else None
       val nextBucketId = if (isBucketed) Some(getBucketId(record)) else None
@@ -662,7 +670,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
           .splitBlockByPartitionAndBucket(
             terminalRow.batch(),
             partitionColIndice,
-            isBucketed)
+            isBucketed,
+            reservePartitionColumns)
         try {
           val iter = blockStripes.iterator()
           while (iter.hasNext) {

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.files
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.backendsapi.velox.VeloxBatchType
+import org.apache.gluten.columnarbatch.VeloxColumnarBatches
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.execution.datasource.GlutenFormatFactory
@@ -45,6 +46,7 @@ import org.apache.spark.sql.execution.datasources.FileFormatWriter._
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 import org.apache.hadoop.conf.Configuration
@@ -590,42 +592,85 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       record match {
         case carrierRow: BatchCarrierRow =>
           carrierRow match {
-            case placeholderRow: PlaceholderRow =>
+            case _: PlaceholderRow =>
             // Do nothing.
             case terminalRow: TerminalRow =>
-              val numRows = terminalRow.batch().numRows()
-              if (numRows > 0) {
-                val blockStripes = GlutenFormatFactory.rowSplitter
-                  .splitBlockByPartitionAndBucket(
-                    terminalRow.batch(),
-                    partitionColIndice,
-                    isBucketed)
-                val iter = blockStripes.iterator()
-                while (iter.hasNext) {
-                  val blockStripe = iter.next()
-                  val headingRow = blockStripe.getHeadingRow
-                  beforeWrite(headingRow)
-                  val currentColumnBatch = blockStripe.getColumnarBatch
-                  val numRowsOfCurrentColumnarBatch = currentColumnBatch.numRows()
-                  assert(numRowsOfCurrentColumnarBatch > 0)
-                  val currentTerminalRow = terminalRow.withNewBatch(currentColumnBatch)
-                  currentWriter.write(currentTerminalRow)
-                  statsTrackers.foreach {
-                    tracker =>
-                      tracker.newRow(currentWriter.path, currentTerminalRow)
-                      for (_ <- 0 until numRowsOfCurrentColumnarBatch - 1) {
-                        tracker.newRow(currentWriter.path, new PlaceholderRow())
-                      }
-                  }
-                  currentColumnBatch.close()
-                }
-                blockStripes.release()
-                recordsInFile += numRows
-              }
+              writePartitionedBatch(terminalRow)
           }
         case _ =>
           beforeWrite(record)
           writeRecord(record)
+      }
+    }
+
+    private def writeCurrentBatch(terminalRow: TerminalRow, rowCount: Int): Unit = {
+      assert(rowCount > 0)
+      currentWriter.write(terminalRow)
+      statsTrackers.foreach(_.newRow(currentWriter.path, terminalRow))
+      recordsInFile += rowCount
+    }
+
+    private def writeCurrentBatchWithMaxRecords(
+        terminalRow: TerminalRow,
+        columnBatch: ColumnarBatch): Unit = {
+      val numRows = columnBatch.numRows()
+      var offset = 0
+      while (offset < numRows) {
+        val rowsRemaining = numRows - offset
+        val rowsToWrite = if (description.maxRecordsPerFile > 0) {
+          if (recordsInFile >= description.maxRecordsPerFile) {
+            renewCurrentWriterIfTooManyRecords(currentPartitionValues, currentBucketId)
+          }
+          math.min(rowsRemaining.toLong, description.maxRecordsPerFile - recordsInFile).toInt
+        } else {
+          rowsRemaining
+        }
+
+        assert(rowsToWrite > 0)
+        val batchToWrite =
+          if (offset == 0 && rowsToWrite == numRows) {
+            columnBatch
+          } else {
+            VeloxColumnarBatches.slice(columnBatch, offset, rowsToWrite)
+          }
+        try {
+          writeCurrentBatch(terminalRow.withNewBatch(batchToWrite), rowsToWrite)
+        } finally {
+          if (batchToWrite ne columnBatch) {
+            batchToWrite.close()
+          }
+        }
+        offset += rowsToWrite
+      }
+    }
+
+    private def writePartitionStripe(terminalRow: TerminalRow, blockStripe: BlockStripe): Unit = {
+      beforeWrite(blockStripe.getHeadingRow)
+      val currentColumnBatch = blockStripe.getColumnarBatch
+      try {
+        assert(currentColumnBatch.numRows() > 0)
+        writeCurrentBatchWithMaxRecords(terminalRow, currentColumnBatch)
+      } finally {
+        currentColumnBatch.close()
+      }
+    }
+
+    private def writePartitionedBatch(terminalRow: TerminalRow): Unit = {
+      val numRows = terminalRow.batch().numRows()
+      if (numRows > 0) {
+        val blockStripes = GlutenFormatFactory.rowSplitter
+          .splitBlockByPartitionAndBucket(
+            terminalRow.batch(),
+            partitionColIndice,
+            isBucketed)
+        try {
+          val iter = blockStripes.iterator()
+          while (iter.hasNext) {
+            writePartitionStripe(terminalRow, iter.next())
+          }
+        } finally {
+          blockStripes.release()
+        }
       }
     }
   }

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -152,6 +152,7 @@ object GlutenDeltaJobStatsTracker extends Logging {
     }
     private val statsAttrs = aggregates.flatMap(_.aggregateFunction.aggBufferAttributes)
     private val statsResultAttrs = aggregates.flatMap(_.aggregateFunction.inputAggBufferAttributes)
+    private val dataColIndices = dataCols.indices.toArray
     private val veloxAggTask: ColumnarBatchOutIterator = {
       val inputNode = StatisticsInputNode(Seq(dummyKeyAttr), dataCols)
       val aggOp = SortAggregateExec(
@@ -261,6 +262,16 @@ object GlutenDeltaJobStatsTracker extends Logging {
         case t: TerminalRow =>
           val valueBatch = t.batch()
           val numRows = valueBatch.numRows()
+          val statsValueBatch = if (valueBatch.numCols() == dataCols.size) {
+            valueBatch
+          } else {
+            assert(
+              valueBatch.numCols() > dataCols.size,
+              s"Delta stats input has ${valueBatch.numCols()} columns, " +
+                s"but the stats schema needs ${dataCols.size} columns."
+            )
+            ColumnarBatches.select(BackendsApiManager.getBackendName, valueBatch, dataColIndices)
+          }
           val dummyKeyVec = ArrowWritableColumnVector
             .allocateColumns(numRows, new StructType().add(dummyKeyAttr.name, IntegerType))
             .head
@@ -269,10 +280,15 @@ object GlutenDeltaJobStatsTracker extends Logging {
             ColumnarBatches.offload(
               ArrowBufferAllocators.contextInstance(),
               new ColumnarBatch(Array[ColumnVector](dummyKeyVec), numRows)))
-          val compositeBatch = VeloxColumnarBatches.compose(dummyKeyBatch, valueBatch)
-          dummyKeyBatch.close()
-          valueBatch.close()
-          inputBatchQueue.put(Some(compositeBatch))
+          try {
+            val compositeBatch = VeloxColumnarBatches.compose(dummyKeyBatch, statsValueBatch)
+            inputBatchQueue.put(Some(compositeBatch))
+          } finally {
+            dummyKeyBatch.close()
+            if (statsValueBatch ne valueBatch) {
+              statsValueBatch.close()
+            }
+          }
       }
     }
 

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.files
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.backendsapi.velox.VeloxBatchType
+import org.apache.gluten.columnarbatch.VeloxColumnarBatches
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.execution.datasource.GlutenFormatFactory
@@ -46,6 +47,7 @@ import org.apache.spark.sql.execution.datasources.FileFormatWriter._
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 import org.apache.hadoop.conf.Configuration
@@ -583,40 +585,82 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       record match {
         case carrierRow: BatchCarrierRow =>
           carrierRow match {
-            case placeholderRow: PlaceholderRow =>
+            case _: PlaceholderRow =>
             // Do nothing.
             case terminalRow: TerminalRow =>
-              val numRows = terminalRow.batch().numRows()
-              if (numRows > 0) {
-                val blockStripes = GlutenFormatFactory.rowSplitter
-                  .splitBlockByPartitionAndBucket(terminalRow.batch(), partitionColIndice,
-                    isBucketed)
-                val iter = blockStripes.iterator()
-                while (iter.hasNext) {
-                  val blockStripe = iter.next()
-                  val headingRow = blockStripe.getHeadingRow
-                  beforeWrite(headingRow)
-                  val currentColumnBatch = blockStripe.getColumnarBatch
-                  val numRowsOfCurrentColumnarBatch = currentColumnBatch.numRows()
-                  assert(numRowsOfCurrentColumnarBatch > 0)
-                  val currentTerminalRow = terminalRow.withNewBatch(currentColumnBatch)
-                  currentWriter.write(currentTerminalRow)
-                  statsTrackers.foreach {
-                    tracker =>
-                      tracker.newRow(currentWriter.path, currentTerminalRow)
-                      for (_ <- 0 until numRowsOfCurrentColumnarBatch - 1) {
-                        tracker.newRow(currentWriter.path, new PlaceholderRow())
-                      }
-                  }
-                  currentColumnBatch.close()
-                }
-                blockStripes.release()
-                recordsInFile += numRows
-              }
+              writePartitionedBatch(terminalRow)
           }
         case _ =>
           beforeWrite(record)
           writeRecord(record)
+      }
+    }
+
+    private def writeCurrentBatch(terminalRow: TerminalRow, rowCount: Int): Unit = {
+      assert(rowCount > 0)
+      currentWriter.write(terminalRow)
+      statsTrackers.foreach(_.newRow(currentWriter.path, terminalRow))
+      recordsInFile += rowCount
+    }
+
+    private def writeCurrentBatchWithMaxRecords(
+        terminalRow: TerminalRow,
+        columnBatch: ColumnarBatch): Unit = {
+      val numRows = columnBatch.numRows()
+      var offset = 0
+      while (offset < numRows) {
+        val rowsRemaining = numRows - offset
+        val rowsToWrite = if (description.maxRecordsPerFile > 0) {
+          if (recordsInFile >= description.maxRecordsPerFile) {
+            renewCurrentWriterIfTooManyRecords(currentPartitionValues, currentBucketId)
+          }
+          math.min(rowsRemaining.toLong, description.maxRecordsPerFile - recordsInFile).toInt
+        } else {
+          rowsRemaining
+        }
+
+        assert(rowsToWrite > 0)
+        val batchToWrite =
+          if (offset == 0 && rowsToWrite == numRows) {
+            columnBatch
+          } else {
+            VeloxColumnarBatches.slice(columnBatch, offset, rowsToWrite)
+          }
+        try {
+          writeCurrentBatch(terminalRow.withNewBatch(batchToWrite), rowsToWrite)
+        } finally {
+          if (batchToWrite ne columnBatch) {
+            batchToWrite.close()
+          }
+        }
+        offset += rowsToWrite
+      }
+    }
+
+    private def writePartitionStripe(terminalRow: TerminalRow, blockStripe: BlockStripe): Unit = {
+      beforeWrite(blockStripe.getHeadingRow)
+      val currentColumnBatch = blockStripe.getColumnarBatch
+      try {
+        assert(currentColumnBatch.numRows() > 0)
+        writeCurrentBatchWithMaxRecords(terminalRow, currentColumnBatch)
+      } finally {
+        currentColumnBatch.close()
+      }
+    }
+
+    private def writePartitionedBatch(terminalRow: TerminalRow): Unit = {
+      val numRows = terminalRow.batch().numRows()
+      if (numRows > 0) {
+        val blockStripes = GlutenFormatFactory.rowSplitter
+          .splitBlockByPartitionAndBucket(terminalRow.batch(), partitionColIndice, isBucketed)
+        try {
+          val iter = blockStripes.iterator()
+          while (iter.hasNext) {
+            writePartitionStripe(terminalRow, iter.next())
+          }
+        } finally {
+          blockStripes.release()
+        }
       }
     }
   }

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -559,6 +559,14 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
           }
       }.toArray
 
+    private val reservePartitionColumns: Boolean =
+      description.partitionColumns.exists {
+        pcol =>
+          description.dataColumns.exists {
+            dcol => dcol.name == pcol.name && dcol.exprId == pcol.exprId
+          }
+      }
+
     private def beforeWrite(record: InternalRow): Unit = {
       val nextPartitionValues = if (isPartitioned) Some(getPartitionValues(record)) else None
       val nextBucketId = if (isBucketed) Some(getBucketId(record)) else None
@@ -652,7 +660,11 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       val numRows = terminalRow.batch().numRows()
       if (numRows > 0) {
         val blockStripes = GlutenFormatFactory.rowSplitter
-          .splitBlockByPartitionAndBucket(terminalRow.batch(), partitionColIndice, isBucketed)
+          .splitBlockByPartitionAndBucket(
+            terminalRow.batch(),
+            partitionColIndice,
+            isBucketed,
+            reservePartitionColumns)
         try {
           val iter = blockStripes.iterator()
           while (iter.hasNext) {

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -156,6 +156,7 @@ object GlutenDeltaJobStatsTracker extends Logging {
     }
     private val statsAttrs = aggregates.flatMap(_.aggregateFunction.aggBufferAttributes)
     private val statsResultAttrs = aggregates.flatMap(_.aggregateFunction.inputAggBufferAttributes)
+    private val dataColIndices = dataCols.indices.toArray
     private val veloxAggTask: ColumnarBatchOutIterator = {
       val inputNode = StatisticsInputNode(Seq(dummyKeyAttr), dataCols)
       val aggOp = SortAggregateExec(
@@ -265,6 +266,16 @@ object GlutenDeltaJobStatsTracker extends Logging {
         case t: TerminalRow =>
           val valueBatch = t.batch()
           val numRows = valueBatch.numRows()
+          val statsValueBatch = if (valueBatch.numCols() == dataCols.size) {
+            valueBatch
+          } else {
+            assert(
+              valueBatch.numCols() > dataCols.size,
+              s"Delta stats input has ${valueBatch.numCols()} columns, " +
+                s"but the stats schema needs ${dataCols.size} columns."
+            )
+            ColumnarBatches.select(BackendsApiManager.getBackendName, valueBatch, dataColIndices)
+          }
           val dummyKeyVec = ArrowWritableColumnVector
             .allocateColumns(numRows, new StructType().add(dummyKeyAttr.name, IntegerType))
             .head
@@ -273,10 +284,15 @@ object GlutenDeltaJobStatsTracker extends Logging {
             ColumnarBatches.offload(
               ArrowBufferAllocators.contextInstance(),
               new ColumnarBatch(Array[ColumnVector](dummyKeyVec), numRows)))
-          val compositeBatch = VeloxColumnarBatches.compose(dummyKeyBatch, valueBatch)
-          dummyKeyBatch.close()
-          valueBatch.close()
-          inputBatchQueue.put(Some(compositeBatch))
+          try {
+            val compositeBatch = VeloxColumnarBatches.compose(dummyKeyBatch, statsValueBatch)
+            inputBatchQueue.put(Some(compositeBatch))
+          } finally {
+            dummyKeyBatch.close()
+            if (statsValueBatch ne valueBatch) {
+              statsValueBatch.close()
+            }
+          }
       }
     }
 

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteSuite.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteSuite.scala
@@ -434,6 +434,42 @@ class DeltaNativeWriteSuite extends DeltaSQLCommandTest {
     }
   }
 
+  test("native delta Iceberg-compatible partitioned write should collect stats") {
+    withNativeWriteOffloadConf(collectStats = true) {
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            val input = spark
+              .range(0, 12, 1, 3)
+              .selectExpr("id", "cast(id % 3 as int) as part")
+
+            val plans = collectExecutedPlans {
+              input.write
+                .format("delta")
+                .option(DeltaConfigs.COLUMN_MAPPING_MODE.key, "name")
+                .option(DeltaConfigs.ICEBERG_COMPAT_V1_ENABLED.key, "true")
+                .partitionBy("part")
+                .mode("overwrite")
+                .save(path)
+            }
+
+            assertContainsNativeWriteCommand(
+              plans,
+              "Iceberg-compatible partitioned DataFrameWriter.save(overwrite) with stats")
+            assert(spark.read.format("delta").load(path).collect().toSet == input.collect().toSet)
+
+            val snapshot = DeltaLog.forTable(spark, path).update()
+            assert(IcebergCompatV1.isEnabled(snapshot.metadata))
+            val addFiles = snapshot.allFiles.collect()
+            assert(addFiles.nonEmpty, "Expected Delta write to add files")
+            val stats = addFiles.map(add => readStatsJson(add.stats))
+            assert(stats.map(numRecords).sum == 12)
+        }
+      }
+    }
+  }
+
   test("native delta optimize command should be offloaded") {
     withNativeWriteOffloadConf {
       withTempDir {

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteSuite.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteSuite.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.ExecutedCommandExec
@@ -45,14 +46,22 @@ class DeltaNativeWriteSuite extends DeltaSQLCommandTest {
     .exists(_.toLowerCase(java.util.Locale.ROOT).contains("mac"))
 
   private def withNativeWriteOffloadConf[T](f: => T): T = {
+    withNativeWriteOffloadConf(collectStats = false)(f)
+  }
+
+  private def withNativeWriteOffloadConf[T](collectStats: Boolean)(f: => T): T = {
     val confs = Seq(
       SQLConf.ANSI_ENABLED.key -> "false",
       SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
       GlutenConfig.GLUTEN_ANSI_FALLBACK_ENABLED.key -> "false",
-      DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false"
+      DeltaSQLConf.DELTA_COLLECT_STATS.key -> collectStats.toString
     ) ++
       (if (isMac) {
-         Seq(GlutenConfig.NATIVE_VALIDATION_ENABLED.key -> "false")
+         Seq(
+           GlutenConfig.NATIVE_VALIDATION_ENABLED.key -> "false",
+           GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key -> "false",
+           GlutenConfig.COLUMNAR_BATCHSCAN_ENABLED.key -> "false"
+         )
        } else {
          Seq.empty
        })
@@ -71,14 +80,27 @@ class DeltaNativeWriteSuite extends DeltaSQLCommandTest {
         s"${GlutenConfig.GLUTEN_ANSI_FALLBACK_ENABLED.key} should be false in native write tests"
       )
       assert(
-        !spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_COLLECT_STATS),
-        s"${DeltaSQLConf.DELTA_COLLECT_STATS.key} should be false in native write tests")
+        spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_COLLECT_STATS) == collectStats,
+        s"${DeltaSQLConf.DELTA_COLLECT_STATS.key} should be $collectStats in native write tests"
+      )
       if (isMac) {
         assert(
           !spark.sessionState.conf
             .getConfString(GlutenConfig.NATIVE_VALIDATION_ENABLED.key)
             .toBoolean,
           s"${GlutenConfig.NATIVE_VALIDATION_ENABLED.key} should be false on macOS"
+        )
+        assert(
+          !spark.sessionState.conf
+            .getConfString(GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key)
+            .toBoolean,
+          s"${GlutenConfig.COLUMNAR_FILESCAN_ENABLED.key} should be false on macOS"
+        )
+        assert(
+          !spark.sessionState.conf
+            .getConfString(GlutenConfig.COLUMNAR_BATCHSCAN_ENABLED.key)
+            .toBoolean,
+          s"${GlutenConfig.COLUMNAR_BATCHSCAN_ENABLED.key} should be false on macOS"
         )
       }
       f
@@ -205,6 +227,18 @@ class DeltaNativeWriteSuite extends DeltaSQLCommandTest {
           metrics.partitionsOptimized == expected,
           s"Expected $expected optimized partitions for $context, got " +
             metrics.partitionsOptimized)
+    }
+  }
+
+  private def readStatsJson(stats: String): Map[String, Any] = {
+    assert(stats != null && stats.nonEmpty, "Expected Delta AddFile stats to be recorded")
+    JsonUtils.fromJson[Map[String, Any]](stats)
+  }
+
+  private def numRecords(stats: Map[String, Any]): Long = {
+    stats("numRecords") match {
+      case number: Number => number.longValue()
+      case other => other.toString.toLong
     }
   }
 
@@ -342,6 +376,60 @@ class DeltaNativeWriteSuite extends DeltaSQLCommandTest {
             result.select("id", "value", "part").collect().toSet == Set(
               Row(1, "a", 0),
               Row(2, "b", 1)))
+      }
+    }
+  }
+
+  test("native delta optimized partitioned write should collect stats and honor file layout") {
+    withNativeWriteOffloadConf(collectStats = true) {
+      withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            val maxRecordsPerFile = 4L
+            val input = spark
+              .range(0, 40, 1, 4)
+              .selectExpr(
+                "id",
+                "concat('v', cast(id as string)) as value",
+                "cast(id % 4 as int) as part")
+
+            val plans = collectExecutedPlans {
+              input.write
+                .format("delta")
+                .partitionBy("part")
+                .option("maxRecordsPerFile", maxRecordsPerFile.toString)
+                .mode("overwrite")
+                .save(path)
+            }
+
+            assertContainsNativeWriteCommand(
+              plans,
+              "optimized partitioned DataFrameWriter.save(overwrite) with stats")
+            assert(spark.read.format("delta").load(path).collect().toSet == input.collect().toSet)
+
+            val addFiles = DeltaLog.forTable(spark, path).update().allFiles.collect()
+            assert(addFiles.nonEmpty, "Expected Delta write to add files")
+            val fileStats = addFiles.map(add => add -> readStatsJson(add.stats))
+            assert(fileStats.map { case (_, stat) => numRecords(stat) }.sum == 40)
+            fileStats.foreach {
+              case (_, stat) =>
+                val fileNumRecords = numRecords(stat)
+                assert(
+                  fileNumRecords <= maxRecordsPerFile,
+                  s"Expected at most $maxRecordsPerFile rows per file, got $fileNumRecords")
+                assert(stat.contains("minValues"), s"Missing minValues in stats: $stat")
+                assert(stat.contains("maxValues"), s"Missing maxValues in stats: $stat")
+                assert(stat.contains("nullCount"), s"Missing nullCount in stats: $stat")
+            }
+            val recordsByPartition = fileStats
+              .groupBy { case (add, _) => add.partitionValues("part") }
+              .map {
+                case (partition, files) =>
+                  partition -> files.map { case (_, stat) => numRecords(stat) }.sum
+              }
+            assert(recordsByPartition == Map("0" -> 10L, "1" -> 10L, "2" -> 10L, "3" -> 10L))
+        }
       }
     }
   }

--- a/backends-velox/src/main/java/org/apache/gluten/datasource/VeloxDataSourceJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/datasource/VeloxDataSourceJniWrapper.java
@@ -54,5 +54,8 @@ public class VeloxDataSourceJniWrapper implements RuntimeAware {
   public native void writeBatch(long dsHandle, long batchHandle);
 
   public native BlockStripes splitBlockByPartitionAndBucket(
-      long blockAddress, int[] partitionColIndice, boolean hasBucket);
+      long blockAddress,
+      int[] partitionColIndice,
+      boolean hasBucket,
+      boolean reservePartitionColumns);
 }

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -119,6 +119,10 @@ class VeloxRowSplitter extends GlutenRowSplitter {
     val datasourceJniWrapper = VeloxDataSourceJniWrapper.create(runtime)
     new VeloxBlockStripes(
       datasourceJniWrapper
-        .splitBlockByPartitionAndBucket(handler, partitionColIndice, hasBucket))
+        .splitBlockByPartitionAndBucket(
+          handler,
+          partitionColIndice,
+          hasBucket,
+          reservePartitionColumns))
   }
 }

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -583,7 +583,8 @@ Java_org_apache_gluten_datasource_VeloxDataSourceJniWrapper_splitBlockByPartitio
     jobject wrapper,
     jlong batchHandle,
     jintArray partitionColIndices,
-    jboolean hasBucket) {
+    jboolean hasBucket,
+    jboolean reservePartitionColumns) {
   JNI_METHOD_START
 
   GLUTEN_CHECK(!hasBucket, "Bucketing not supported by splitBlockByPartitionAndBucket");
@@ -600,12 +601,15 @@ Java_org_apache_gluten_datasource_VeloxDataSourceJniWrapper_splitBlockByPartitio
     partitionColIndicesVec.emplace_back(partitionColumnIndex);
   }
 
-  std::vector<int32_t> dataColIndicesVec;
+  std::vector<int32_t> outputColIndicesVec;
   for (int i = 0; i < batch->numColumns(); ++i) {
     if (std::find(partitionColIndicesVec.begin(), partitionColIndicesVec.end(), i) == partitionColIndicesVec.end()) {
-      // The column is not a partition column. Add it to the data column vector.
-      dataColIndicesVec.emplace_back(i);
+      // Write data columns first, matching Spark's dynamic partition writer output schema.
+      outputColIndicesVec.emplace_back(i);
     }
+  }
+  if (reservePartitionColumns) {
+    outputColIndicesVec.insert(outputColIndicesVec.end(), partitionColIndicesVec.begin(), partitionColIndicesVec.end());
   }
 
   auto pool = dynamic_cast<VeloxMemoryManager*>(ctx->memoryManager())->getLeafMemoryPool();
@@ -656,9 +660,8 @@ Java_org_apache_gluten_datasource_VeloxDataSourceJniWrapper_splitBlockByPartitio
         : exec::wrap(partitionSize, partitionRows[partitionId], inputRowVector);
 
     const std::shared_ptr<VeloxColumnarBatch> partitionBatch = std::make_shared<VeloxColumnarBatch>(rowVector);
-    const std::shared_ptr<VeloxColumnarBatch> partitionBatchWithoutPartitionColumns =
-        partitionBatch->select(pool.get(), dataColIndicesVec);
-    partitionBatchHandles[partitionId] = ctx->saveObject(partitionBatchWithoutPartitionColumns);
+    const std::shared_ptr<VeloxColumnarBatch> outputBatch = partitionBatch->select(pool.get(), outputColIndicesVec);
+    partitionBatchHandles[partitionId] = ctx->saveObject(outputBatch);
     const auto headingRow = partitionBatch->toUnsafeRow(0);
     const auto headingRowBytes = headingRow.data();
     const auto headingRowNumBytes = headingRow.size();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch preserves partition columns in native partition split output only when Delta's write contract includes those partition columns in `dataColumns`.

The change:
- Detects whether Delta expects partition columns in the writer data columns.
- Passes that contract to the Velox partition splitter.
- Keeps native stats aggregation scoped to Delta data columns when the written batch includes extra partition columns.
- Adds Delta 4.0 coverage for Iceberg-compatible partitioned native writes with stats enabled.

This is the second split from #12016. It is stacked on #12016 and should be reviewed after that PR merges.

### Why are the changes needed?

Some Delta write modes keep partition columns in the writer batch. The native splitter should preserve those columns only for those modes, while the Delta stats tracker must still compute AddFile stats over Delta data columns only.

### Does this PR introduce any user-facing change?

No public API change. This improves correctness for native Delta partitioned writes.

### How was this patch tested?

Built locally and ran:

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home \
./dev/run-scala-test.sh --force \
  -Pjava-17,spark-4.0,scala-2.13,backends-velox,hadoop-3.3,spark-ut,delta \
  -pl backends-velox \
  -s org.apache.spark.sql.delta.DeltaNativeWriteSuite \
  -t "native delta Iceberg-compatible partitioned write should collect stats"
```

Result: 1 test passed, 0 failures.

Also ran the partitioned optimized write layout regression test on the stacked branch, Spark 4.0 `backends-velox` test compilation, C++ `gluten`/`velox` native build, and `git diff --check`.

Related issue: #10215
