### PR TITLE
[MINOR][DOC] Add AGENTS.md with guidelines for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# Agent Guidelines for Apache Gluten
+
+## Developer Documentation
+
+- [New to Gluten](docs/developers/NewToGluten.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Build Guide (Velox backend)](docs/get-started/Velox.md)
+- [Build Guide (ClickHouse backend)](docs/get-started/ClickHouse.md)
+- [C++ Coding Style](docs/developers/CppCodingStyle.md)
+
+## Build Order (Important)
+
+The Java/Scala build depends on native shared libraries produced by the C++ build.
+Always build the native backend before running Maven. Modifying `gluten-core` without
+rebuilding the native backend produces a build that compiles but fails at runtime.
+
+```bash
+# Velox backend — build native first, then Maven
+./dev/builddeps-veloxbe.sh
+mvn package -Pbackends-velox -DskipTests
+
+# ClickHouse backend — build native first, then Maven
+./dev/builddeps-clickhousebe.sh
+mvn package -Pbackends-clickhouse -DskipTests
+```
+
+## Before Committing
+
+Before committing any changes, you MUST run the following checks and fix any issues.
+
+### Java/Scala
+
+```bash
+./dev/format-scala-code.sh
+```
+
+### C/C++ (Velox backend)
+
+```bash
+# requires clang-format-15
+./dev/format-cpp-code.sh
+```
+
+### License Headers
+
+```bash
+# Requires the `regex` Python package: pip install regex
+./dev/check.py header main --fix
+```
+
+Do not commit code that fails CI checks.
+
+## PR Title Convention
+
+Use `[GLUTEN-<issue ID>]` when a GitHub issue exists ("if necessary" per CONTRIBUTING.md —
+omit the issue tag entirely for minor changes with no associated issue).
+
+| Scope | Title format |
+|---|---|
+| Velox backend only | `[GLUTEN-<issue ID>][VL] description` |
+| ClickHouse backend only | `[GLUTEN-<issue ID>][CH] description` |
+| Common/core code | `[GLUTEN-<issue ID>][CORE] description` |
+| Docs/minor | `[GLUTEN-<issue ID>][DOC]` or `[MINOR] description` |
+
+Examples from CONTRIBUTING.md:
+- `[GLUTEN-1234][VL] Fix null handling in velox aggregation`
+- `[MINOR][DOC] Update configuration docs`
+
+## Testing
+
+Add at least one unit test (under `gluten-ut/`) for any fix or feature not covered by
+existing Spark UTs.
+
+```bash
+# Java/Scala unit tests
+mvn test -pl gluten-ut
+
+# Velox backend (build with tests enabled)
+./dev/builddeps-veloxbe.sh --build_tests=ON
+
+# ClickHouse backend CI — re-trigger by posting on the PR page:
+# Run Gluten Clickhouse CI
+```
+
+## AI Tooling Disclosure
+
+The PR template requires answering: "Was this patch authored or co-authored using
+generative AI tooling?"
+
+- If yes: `Generated-by: <tool name and version>` (e.g. `Generated-by: Claude claude-sonnet-4-6`)
+- If no: write `No`
+
+See [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html).


### PR DESCRIPTION
  ---
  What changes are proposed in this pull request?

  Adds AGENTS.md — a top-level file that provides guidelines for AI coding agents (e.g. Claude Code, Cursor, Copilot)
  working in this repository.

  The file covers:
  - Pointers to key developer documentation (build guides, contributing guide, C++ style guide)
  - Build order requirements (native backend must be built before Maven, with concrete commands for both Velox and
  ClickHouse backends)
  - Pre-commit checklist: Scala formatting, C++ formatting, and license header checks
  - PR title convention summarizing the [GLUTEN-<id>][BACKEND] pattern with a quick reference table
  - Testing instructions for Java/Scala unit tests and both native backends
  - AI tooling disclosure reminder as required by the ASF Generative Tooling Guidance

  This follows the emerging convention (google/A2A, anthropics/claude-code) of providing an AGENTS.md file so AI
  assistants can orient themselves to a project's conventions without reading the full contributor docs.

  How was this patch tested?

  Documentation-only change. No code was modified. Manually verified that all referenced scripts and docs exist in the
  repository.

  Was this patch authored or co-authored using generative AI tooling?

  Generated-by: Claude claude-sonnet-4-6