### PR TITLE
[VL] Simplify the logic in AppendBatchResizeForShuffleInputAndOutput

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -108,7 +108,7 @@ object VeloxRuleApi {
           offloads))
 
     // Legacy: Post-transform rules.
-    injector.injectPostTransform(_ => AppendBatchResizeForShuffleInputAndOutput())
+    injector.injectPostTransform(c => AppendBatchResizeForShuffleInputAndOutput(c.caller.isAqe()))
     injector.injectPostTransform(_ => GpuBufferBatchResizeForShuffleInputOutput())
     injector.injectPostTransform(_ => UnionTransformerRule())
     injector.injectPostTransform(_ => PartialFallbackRules())

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
@@ -28,11 +28,13 @@ import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
  * Try to append [[VeloxResizeBatchesExec]] for shuffle input and output to make the batch sizes in
  * good shape.
  */
-case class AppendBatchResizeForShuffleInputAndOutput() extends Rule[SparkPlan] {
+case class AppendBatchResizeForShuffleInputAndOutput(isAdaptiveContext: Boolean)
+  extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     if (VeloxConfig.get.enableColumnarCudf) {
       return plan
     }
+
     val resizeBatchesShuffleInputEnabled = VeloxConfig.get.veloxResizeBatchesShuffleInput
     val resizeBatchesShuffleOutputEnabled = VeloxConfig.get.veloxResizeBatchesShuffleOutput
     if (!resizeBatchesShuffleInputEnabled && !resizeBatchesShuffleOutputEnabled) {
@@ -41,65 +43,68 @@ case class AppendBatchResizeForShuffleInputAndOutput() extends Rule[SparkPlan] {
 
     val range = VeloxConfig.get.veloxResizeBatchesShuffleInputOutputRange
     val preferredBatchBytes = VeloxConfig.get.veloxPreferredBatchBytes
-    plan.transformUp {
+
+    val newPlan = if (resizeBatchesShuffleInputEnabled) {
+      addResizeBatchesForShuffleInput(plan, range.min, range.max, preferredBatchBytes)
+    } else {
+      plan
+    }
+
+    val resultPlan = if (resizeBatchesShuffleOutputEnabled) {
+      addResizeBatchesForShuffleOutput(newPlan, range.min, range.max, preferredBatchBytes)
+    } else {
+      newPlan
+    }
+
+    resultPlan
+  }
+
+  private def addResizeBatchesForShuffleInput(
+      plan: SparkPlan,
+      min: Int,
+      max: Int,
+      preferredBatchBytes: Long): SparkPlan = {
+    plan match {
       case shuffle: ColumnarShuffleExchangeExec
-          if resizeBatchesShuffleInputEnabled &&
-            shuffle.shuffleWriterType.requiresResizingShuffleInput =>
+          if shuffle.shuffleWriterType.requiresResizingShuffleInput =>
         val appendBatches =
-          VeloxResizeBatchesExec(shuffle.child, range.min, range.max, preferredBatchBytes)
+          VeloxResizeBatchesExec(shuffle.child, min, max, preferredBatchBytes)
         shuffle.withNewChildren(Seq(appendBatches))
-      case a @ AQEShuffleReadExec(
-            ShuffleQueryStageExec(_, shuffle: ColumnarShuffleExchangeExec, _),
-            _)
-          if resizeBatchesShuffleOutputEnabled &&
-            shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(a, range.min, range.max, preferredBatchBytes)
-      case a @ AQEShuffleReadExec(
-            ShuffleQueryStageExec(
-              _,
-              ReusedExchangeExec(_, shuffle: ColumnarShuffleExchangeExec),
-              _),
-            _)
-          if resizeBatchesShuffleOutputEnabled &&
-            shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(a, range.min, range.max, preferredBatchBytes)
-      // Since it's transformed in a bottom to up order, so we may first encounter
-      // ShuffeQueryStageExec, which is transformed to VeloxResizeBatchesExec(ShuffeQueryStageExec),
-      // then we see AQEShuffleReadExec
-      case a @ AQEShuffleReadExec(
-            VeloxResizeBatchesExec(
-              s @ ShuffleQueryStageExec(_, shuffle: ColumnarShuffleExchangeExec, _),
-              _,
-              _,
-              _),
-            _)
-          if resizeBatchesShuffleOutputEnabled &&
-            shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(a.copy(child = s), range.min, range.max, preferredBatchBytes)
-      case a @ AQEShuffleReadExec(
-            VeloxResizeBatchesExec(
-              s @ ShuffleQueryStageExec(
-                _,
-                ReusedExchangeExec(_, shuffle: ColumnarShuffleExchangeExec),
-                _),
-              _,
-              _,
-              _),
-            _)
-          if resizeBatchesShuffleOutputEnabled &&
-            shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(a.copy(child = s), range.min, range.max, preferredBatchBytes)
-      case s @ ShuffleQueryStageExec(_, shuffle: ColumnarShuffleExchangeExec, _)
-          if resizeBatchesShuffleOutputEnabled &&
-            shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(s, range.min, range.max, preferredBatchBytes)
-      case s @ ShuffleQueryStageExec(
-            _,
-            ReusedExchangeExec(_, shuffle: ColumnarShuffleExchangeExec),
-            _)
-          if resizeBatchesShuffleOutputEnabled &&
-            shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(s, range.min, range.max, preferredBatchBytes)
+      case other =>
+        other.withNewChildren(other.children.map(
+          p => addResizeBatchesForShuffleInput(p, min, max, preferredBatchBytes)))
+    }
+  }
+
+  private def addResizeBatchesForShuffleOutput(
+      plan: SparkPlan,
+      min: Int,
+      max: Int,
+      preferredBatchBytes: Long): SparkPlan = {
+    plan match {
+      case shuffle: ColumnarShuffleExchangeExec
+          if !isAdaptiveContext && shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
+        VeloxResizeBatchesExec(shuffle, min, max, preferredBatchBytes)
+      case reused @ ReusedExchangeExec(_, shuffle: ColumnarShuffleExchangeExec)
+          if !isAdaptiveContext && shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
+        VeloxResizeBatchesExec(reused, min, max, preferredBatchBytes)
+      case s: ShuffleQueryStageExec if requiresResizingShuffleOutput(s) =>
+        VeloxResizeBatchesExec(s, min, max, preferredBatchBytes)
+      case a @ AQEShuffleReadExec(s @ ShuffleQueryStageExec(_, _, _), _)
+          if requiresResizingShuffleOutput(s) =>
+        VeloxResizeBatchesExec(a, min, max, preferredBatchBytes)
+      case other =>
+        other.withNewChildren(other.children.map(
+          p => addResizeBatchesForShuffleOutput(p, min, max, preferredBatchBytes)))
+    }
+  }
+
+  private def requiresResizingShuffleOutput(s: ShuffleQueryStageExec): Boolean = {
+    s.shuffle match {
+      case c: ColumnarShuffleExchangeExec
+          if c.shuffleWriterType.requiresResizingShuffleOutput =>
+        true
+      case _ => false
     }
   }
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
@@ -84,8 +84,7 @@ case class AppendBatchResizeForShuffleInputAndOutput(isAdaptiveContext: Boolean)
           if requiresResizingShuffleOutput(s) =>
         VeloxResizeBatchesExec(a, min, max, preferredBatchBytes)
       case other =>
-        other.withNewChildren(other.children.map(
-          p => addResizeBatchesForShuffleOutput(p, min, max, preferredBatchBytes)))
+        other.mapChildren(addResizeBatchesForShuffleOutput(_, min, max, preferredBatchBytes))
     }
   }
 

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
@@ -22,7 +22,6 @@ import org.apache.gluten.execution.VeloxResizeBatchesExec
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarShuffleExchangeExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, ShuffleQueryStageExec}
-import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 
 /**
  * Try to append [[VeloxResizeBatchesExec]] for shuffle input and output to make the batch sizes in
@@ -65,12 +64,11 @@ case class AppendBatchResizeForShuffleInputAndOutput(isAdaptiveContext: Boolean)
       max: Int,
       preferredBatchBytes: Long): SparkPlan = {
     plan.transformUp {
-       case shuffle: ColumnarShuffleExchangeExec
-           if shuffle.shuffleWriterType.requiresResizingShuffleInput =>
-         val appendBatches =
-           VeloxResizeBatchesExec(shuffle.child, min, max, preferredBatchBytes)
-         shuffle.withNewChildren(Seq(appendBatches))
-       case other => other
+      case shuffle: ColumnarShuffleExchangeExec
+          if shuffle.shuffleWriterType.requiresResizingShuffleInput =>
+        val appendBatches =
+          VeloxResizeBatchesExec(shuffle.child, min, max, preferredBatchBytes)
+        shuffle.withNewChildren(Seq(appendBatches))
     }
   }
 
@@ -80,12 +78,6 @@ case class AppendBatchResizeForShuffleInputAndOutput(isAdaptiveContext: Boolean)
       max: Int,
       preferredBatchBytes: Long): SparkPlan = {
     plan match {
-      case shuffle: ColumnarShuffleExchangeExec
-          if !isAdaptiveContext && shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(shuffle, min, max, preferredBatchBytes)
-      case reused @ ReusedExchangeExec(_, shuffle: ColumnarShuffleExchangeExec)
-          if !isAdaptiveContext && shuffle.shuffleWriterType.requiresResizingShuffleOutput =>
-        VeloxResizeBatchesExec(reused, min, max, preferredBatchBytes)
       case s: ShuffleQueryStageExec if requiresResizingShuffleOutput(s) =>
         VeloxResizeBatchesExec(s, min, max, preferredBatchBytes)
       case a @ AQEShuffleReadExec(s @ ShuffleQueryStageExec(_, _, _), _)

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
@@ -49,7 +49,7 @@ case class AppendBatchResizeForShuffleInputAndOutput(isAdaptiveContext: Boolean)
       plan
     }
 
-    val resultPlan = if (resizeBatchesShuffleOutputEnabled) {
+    val resultPlan = if (isAdaptiveContext && resizeBatchesShuffleOutputEnabled) {
       addResizeBatchesForShuffleOutput(newPlan, range.min, range.max, preferredBatchBytes)
     } else {
       newPlan

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/AppendBatchResizeForShuffleInputAndOutput.scala
@@ -64,15 +64,13 @@ case class AppendBatchResizeForShuffleInputAndOutput(isAdaptiveContext: Boolean)
       min: Int,
       max: Int,
       preferredBatchBytes: Long): SparkPlan = {
-    plan match {
-      case shuffle: ColumnarShuffleExchangeExec
-          if shuffle.shuffleWriterType.requiresResizingShuffleInput =>
-        val appendBatches =
-          VeloxResizeBatchesExec(shuffle.child, min, max, preferredBatchBytes)
-        shuffle.withNewChildren(Seq(appendBatches))
-      case other =>
-        other.withNewChildren(other.children.map(
-          p => addResizeBatchesForShuffleInput(p, min, max, preferredBatchBytes)))
+    plan.transformUp {
+       case shuffle: ColumnarShuffleExchangeExec
+           if shuffle.shuffleWriterType.requiresResizingShuffleInput =>
+         val appendBatches =
+           VeloxResizeBatchesExec(shuffle.child, min, max, preferredBatchBytes)
+         shuffle.withNewChildren(Seq(appendBatches))
+       case other => other
     }
   }
 


### PR DESCRIPTION
The current logic in `AppendBatchResizeForShuffleInputAndOutput` is a bit convoluted and unclear. Refactor it by separating the logic into `addResizeBatchesForShuffleInput` and `addResizeBatchesForShuffleOutput`.

For `addResizeBatchesForShuffleInput`, simply wrap and replace the child of exchange.
For `addResizeBatchesForShuffleOutput`, when AQE is enabled, extract and wrap the exchange inside `ShuffleQueryStageExec`, or `AQEShuffleReadExec`