### PR TITLE
feat(velox): Route Concat expression through Velox backend

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -97,6 +97,38 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
       newExpr)
   }
 
+  override def genConcatTransformer(
+      substraitExprName: String,
+      children: Seq[ExpressionTransformer],
+      original: Concat): ExpressionTransformer = {
+    // Zero-argument concat: Spark returns '' for StringType and empty byte array for
+    // BinaryType. Velox requires at least one argument, so fall back to Spark.
+    if (original.children.isEmpty) {
+      throw new GlutenNotSupportException("Native concat with zero arguments is not supported")
+    }
+
+    original.dataType match {
+      // Velox's array concat uses defaultNullBehavior=true (returns NULL if ANY input is NULL),
+      // but Spark 3.4+ (SPARK-41296) skips NULL array inputs and only returns NULL when ALL
+      // inputs are NULL. Fall back to Spark for ArrayType until null-skipping is implemented.
+      case _: ArrayType =>
+        throw new GlutenNotSupportException(
+          "Native array concat is not supported: Velox null semantics differ from Spark 3.4+")
+      case StringType | BinaryType =>
+      case other =>
+        throw new GlutenNotSupportException(
+          s"Native concat is not supported for type: ${other.simpleString}")
+    }
+
+    // Single-argument concat is a no-op (returns the argument as-is). Velox requires
+    // at least 2 arguments for concat, so return the child expression directly.
+    if (original.children.size == 1) {
+      return children.head
+    }
+
+    GenericExpressionTransformer(substraitExprName, children, original)
+  }
+
   override def genAtLeastNNonNullsTransformer(
       substraitExprName: String,
       children: Seq[ExpressionTransformer],

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxStringFunctionsSuite.scala
@@ -17,10 +17,8 @@
 package org.apache.gluten.execution
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
 import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, NullPropagation}
-import org.apache.spark.sql.classic.ClassicColumn
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types.StringType
 
 class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
@@ -38,7 +36,7 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
     createTPCHNotNullTables()
     spark
       .table("lineitem")
-      .select(col("*"), ClassicColumn(Alias(Literal(null, StringType), NULL_STR_COL)()))
+      .select(col("*"), lit(null).cast(StringType).as(NULL_STR_COL))
       .createOrReplaceTempView(LINEITEM_TABLE)
   }
 
@@ -73,6 +71,67 @@ class VeloxStringFunctionsSuite extends VeloxWholeStageTransformerSuite {
         s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
     runQueryAndCompare(
       s"select l_orderkey, concat(l_comment, 'hello', 'world') " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
+    // Single-argument concat is identity
+    runQueryAndCompare(
+      s"select l_orderkey, concat(l_comment) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
+    // Verify null-in-null-out: concat with a NULL input returns NULL
+    runQueryAndCompare(
+      s"select l_orderkey, concat(l_comment, $NULL_STR_COL) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
+    runQueryAndCompare(
+      s"select l_orderkey, concat($NULL_STR_COL, 'hello', l_comment) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
+    // All-NULL inputs should return NULL (not empty string)
+    runQueryAndCompare(
+      s"select l_orderkey, concat($NULL_STR_COL, $NULL_STR_COL) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
+  }
+
+  test("concat falls back for zero arguments") {
+    // Zero-argument concat returns '' in Spark; should fall back gracefully
+    runQueryAndCompare(
+      s"select l_orderkey, concat() " +
+        s"from $LINEITEM_TABLE limit $LENGTH") {
+      df =>
+        val plan = df.queryExecution.executedPlan
+        // Zero-arg concat should be constant-folded or fall back; either way
+        // it should not appear as a native concat expression
+        val nativeProjects = plan.collect { case p: ProjectExecTransformer => p }
+        assert(
+          nativeProjects.isEmpty ||
+            !nativeProjects.exists(_.projectList.exists(
+              _.find(_.isInstanceOf[org.apache.spark.sql.catalyst.expressions.Concat]).isDefined)),
+          "zero-arg concat should not go native"
+        )
+    }
+  }
+
+  test("concat falls back for ArrayType") {
+    // Array concat has different null semantics in Spark 3.4+; should fall back
+    runQueryAndCompare(
+      s"select l_orderkey, concat(array(1, 2), array(3, 4)) " +
+        s"from $LINEITEM_TABLE limit $LENGTH") {
+      df =>
+        val plan = df.queryExecution.executedPlan
+        val nativeProjects = plan.collect { case p: ProjectExecTransformer => p }
+        assert(
+          nativeProjects.isEmpty ||
+            !nativeProjects.exists(_.projectList.exists(
+              _.find(_.isInstanceOf[org.apache.spark.sql.catalyst.expressions.Concat]).isDefined)),
+          "array concat should not go native"
+        )
+    }
+  }
+
+  test("concat with BinaryType") {
+    // BinaryType concat should work natively with null-in-null-out semantics
+    runQueryAndCompare(
+      s"select l_orderkey, concat(cast(l_comment as binary), cast('hello' as binary)) " +
+        s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
+    runQueryAndCompare(
+      s"select l_orderkey, concat(cast(l_comment as binary), cast(null as binary)) " +
         s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/SparkPlanExecApi.scala
@@ -228,6 +228,19 @@ trait SparkPlanExecApi {
     GenericExpressionTransformer(substraitExprName, Seq(left, right), original)
   }
 
+  /**
+   * Transform Spark's Concat expression to Substrait.
+   *
+   * Handles StringType, BinaryType, and ArrayType inputs. Backends may override to customize
+   * behavior if their native concat semantics differ from Spark's.
+   */
+  def genConcatTransformer(
+      substraitExprName: String,
+      children: Seq[ExpressionTransformer],
+      original: Concat): ExpressionTransformer = {
+    GenericExpressionTransformer(substraitExprName, children, original)
+  }
+
   def genAtLeastNNonNullsTransformer(
       substraitExprName: String,
       children: Seq[ExpressionTransformer],

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -922,6 +922,12 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           substraitExprName,
           replaceWithExpressionTransformer0(errorMessage, attributeSeq, expressionsMap),
           re)
+      case c: Concat =>
+        BackendsApiManager.getSparkPlanExecApiInstance.genConcatTransformer(
+          substraitExprName,
+          c.children.map(replaceWithExpressionTransformer0(_, attributeSeq, expressionsMap)),
+          c
+        )
       case expr =>
         GenericExpressionTransformer(
           substraitExprName,


### PR DESCRIPTION
## Context
Spark's `Concat` expression supports `StringType`, `BinaryType`, and `ArrayType` inputs. Currently in Gluten, `Concat` falls through the generic expression transformer without any type-specific handling. This PR adds explicit routing with proper edge case handling for the Velox backend.

## What
Add `genConcatTransformer` to `SparkPlanExecApi` and override it in `VeloxSparkPlanExecApi` with:

- **StringType / BinaryType**: Offloaded to Velox. Velox's `concat` uses `defaultNullBehavior=true` (returns NULL when any input is NULL), matching Spark's null-in-null-out semantics.
- **ArrayType**: Falls back to Spark. Velox returns NULL if ANY input is NULL, but Spark 3.4+ (SPARK-41296) skips NULL array inputs and only returns NULL when ALL inputs are NULL.
- **Zero arguments**: Falls back to Spark (Velox requires at least 1 argument).
- **Single argument**: Returns the child expression directly (identity optimization; Velox requires at least 2 arguments for concat).

## Changes
- `SparkPlanExecApi.scala`: Add `genConcatTransformer` with default `GenericExpressionTransformer` implementation
- `ExpressionConverter.scala`: Add explicit `case c: Concat =>` routing to backend API
- `VeloxSparkPlanExecApi.scala`: Override with type checks and edge case handling
- `VeloxStringFunctionsSuite.scala`: Enhanced tests for null handling, single-arg identity, zero-arg fallback, ArrayType fallback, and BinaryType support