### PR TITLE
[VL] Subdivide SplitRV CPU/wall timer into 4 sub-stages

### DIFF
--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -494,6 +494,7 @@ arrow::Status VeloxHashShuffleWriter::splitRowVector(const facebook::velox::RowV
 }
 
 arrow::Status VeloxHashShuffleWriter::splitFixedWidthValueBuffer(const facebook::velox::RowVector& rv) {
+  SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingSplitFixedWidth]);
   for (auto col = 0; col < fixedWidthColumnCount_; ++col) {
     auto colIdx = simpleColumnIndices_[col];
     auto& column = rv.childAt(colIdx);
@@ -636,6 +637,7 @@ void VeloxHashShuffleWriter::splitBoolType(const uint8_t* srcAddr, const std::ve
 }
 
 arrow::Status VeloxHashShuffleWriter::splitValidityBuffer(const facebook::velox::RowVector& rv) {
+  SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingSplitValidity]);
   for (size_t col = 0; col < simpleColumnIndices_.size(); ++col) {
     auto colIdx = simpleColumnIndices_[col];
     auto& column = rv.childAt(colIdx);
@@ -727,6 +729,7 @@ arrow::Status VeloxHashShuffleWriter::splitBinaryType(
 }
 
 arrow::Status VeloxHashShuffleWriter::splitBinaryArray(const facebook::velox::RowVector& rv) {
+  SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingSplitBinary]);
   for (auto col = fixedWidthColumnCount_; col < simpleColumnIndices_.size(); ++col) {
     auto binaryIdx = col - fixedWidthColumnCount_;
     auto& dstAddrs = partitionBinaryAddrs_[binaryIdx];
@@ -738,6 +741,7 @@ arrow::Status VeloxHashShuffleWriter::splitBinaryArray(const facebook::velox::Ro
 }
 
 arrow::Status VeloxHashShuffleWriter::splitComplexType(const facebook::velox::RowVector& rv) {
+  SCOPED_TIMER(cpuWallTimingList_[CpuWallTimingSplitComplex]);
   if (complexColumnIndices_.size() == 0) {
     return arrow::Status::OK();
   }

--- a/cpp/velox/shuffle/VeloxShuffleWriter.h
+++ b/cpp/velox/shuffle/VeloxShuffleWriter.h
@@ -113,6 +113,85 @@ class VeloxShuffleWriter : public ShuffleWriter {
     return partitionBufferPool_->max_memory() + veloxPool_->peakBytes();
   }
 
+  // stat
+  enum CpuWallTimingType {
+    CpuWallTimingBegin = 0,
+    CpuWallTimingCompute = CpuWallTimingBegin,
+    CpuWallTimingBuildPartition,
+    CpuWallTimingEvictPartition,
+    CpuWallTimingHasNull,
+    CpuWallTimingCalculateBufferSize,
+    CpuWallTimingAllocateBuffer,
+    CpuWallTimingCreateRbFromBuffer,
+    CpuWallTimingMakeRB,
+    CpuWallTimingCacheRB,
+    CpuWallTimingFlattenRV,
+    // Outer SplitRV bucket wraps `splitRowVector()` end-to-end. The four
+    // entries below subdivide its body so reviewers / profilers can tell
+    // which inner split path dominates when SplitRV does. Inner buckets
+    // overlap the outer in time (the outer continues to run while each
+    // inner is active); the outer minus the sum-of-inners is therefore
+    // the time spent in `splitRowVector()` outside the four sub-paths
+    // (mostly the post-split `partitionBufferBase_` update loop).
+    CpuWallTimingSplitRV,
+    CpuWallTimingSplitFixedWidth,
+    CpuWallTimingSplitValidity,
+    CpuWallTimingSplitBinary,
+    CpuWallTimingSplitComplex,
+    CpuWallTimingIteratePartitions,
+    CpuWallTimingStop,
+    CpuWallTimingEnd,
+    CpuWallTimingNum = CpuWallTimingEnd - CpuWallTimingBegin
+  };
+
+  static std::string CpuWallTimingName(CpuWallTimingType type) {
+    switch (type) {
+      case CpuWallTimingCompute:
+        return "CpuWallTimingCompute";
+      case CpuWallTimingBuildPartition:
+        return "CpuWallTimingBuildPartition";
+      case CpuWallTimingEvictPartition:
+        return "CpuWallTimingEvictPartition";
+      case CpuWallTimingHasNull:
+        return "CpuWallTimingHasNull";
+      case CpuWallTimingCalculateBufferSize:
+        return "CpuWallTimingCalculateBufferSize";
+      case CpuWallTimingAllocateBuffer:
+        return "CpuWallTimingAllocateBuffer";
+      case CpuWallTimingCreateRbFromBuffer:
+        return "CpuWallTimingCreateRbFromBuffer";
+      case CpuWallTimingMakeRB:
+        return "CpuWallTimingMakeRB";
+      case CpuWallTimingCacheRB:
+        return "CpuWallTimingCacheRB";
+      case CpuWallTimingFlattenRV:
+        return "CpuWallTimingFlattenRV";
+      case CpuWallTimingSplitRV:
+        return "CpuWallTimingSplitRV";
+      case CpuWallTimingSplitFixedWidth:
+        return "CpuWallTimingSplitFixedWidth";
+      case CpuWallTimingSplitValidity:
+        return "CpuWallTimingSplitValidity";
+      case CpuWallTimingSplitBinary:
+        return "CpuWallTimingSplitBinary";
+      case CpuWallTimingSplitComplex:
+        return "CpuWallTimingSplitComplex";
+      case CpuWallTimingIteratePartitions:
+        return "CpuWallTimingIteratePartitions";
+      case CpuWallTimingStop:
+        return "CpuWallTimingStop";
+      default:
+        return "CpuWallTimingUnknown";
+    }
+  }
+
+  // Read-only access to a single per-stage timer. Useful for tests and for
+  // anyone wanting to drive the existing `cpuWallTimingList_` data through a
+  // channel other than the `VELOX_SHUFFLE_WRITER_LOG_FLAG` compile-time log.
+  const facebook::velox::CpuWallTiming& cpuWallTiming(CpuWallTimingType type) const {
+    return cpuWallTimingList_[type];
+  }
+
  protected:
   VeloxShuffleWriter(
       uint32_t numPartitions,
@@ -146,59 +225,6 @@ class VeloxShuffleWriter : public ShuffleWriter {
   int32_t maxBatchSize_{0};
 
   enum EvictState { kEvictable, kUnevictable };
-
-  // stat
-  enum CpuWallTimingType {
-    CpuWallTimingBegin = 0,
-    CpuWallTimingCompute = CpuWallTimingBegin,
-    CpuWallTimingBuildPartition,
-    CpuWallTimingEvictPartition,
-    CpuWallTimingHasNull,
-    CpuWallTimingCalculateBufferSize,
-    CpuWallTimingAllocateBuffer,
-    CpuWallTimingCreateRbFromBuffer,
-    CpuWallTimingMakeRB,
-    CpuWallTimingCacheRB,
-    CpuWallTimingFlattenRV,
-    CpuWallTimingSplitRV,
-    CpuWallTimingIteratePartitions,
-    CpuWallTimingStop,
-    CpuWallTimingEnd,
-    CpuWallTimingNum = CpuWallTimingEnd - CpuWallTimingBegin
-  };
-
-  static std::string CpuWallTimingName(CpuWallTimingType type) {
-    switch (type) {
-      case CpuWallTimingCompute:
-        return "CpuWallTimingCompute";
-      case CpuWallTimingBuildPartition:
-        return "CpuWallTimingBuildPartition";
-      case CpuWallTimingEvictPartition:
-        return "CpuWallTimingEvictPartition";
-      case CpuWallTimingHasNull:
-        return "CpuWallTimingHasNull";
-      case CpuWallTimingCalculateBufferSize:
-        return "CpuWallTimingCalculateBufferSize";
-      case CpuWallTimingAllocateBuffer:
-        return "CpuWallTimingAllocateBuffer";
-      case CpuWallTimingCreateRbFromBuffer:
-        return "CpuWallTimingCreateRbFromBuffer";
-      case CpuWallTimingMakeRB:
-        return "CpuWallTimingMakeRB";
-      case CpuWallTimingCacheRB:
-        return "CpuWallTimingCacheRB";
-      case CpuWallTimingFlattenRV:
-        return "CpuWallTimingFlattenRV";
-      case CpuWallTimingSplitRV:
-        return "CpuWallTimingSplitRV";
-      case CpuWallTimingIteratePartitions:
-        return "CpuWallTimingIteratePartitions";
-      case CpuWallTimingStop:
-        return "CpuWallTimingStop";
-      default:
-        return "CpuWallTimingUnknown";
-    }
-  }
 
   facebook::velox::CpuWallTiming cpuWallTimingList_[CpuWallTimingNum];
 

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -103,6 +103,9 @@ add_velox_test(velox_shuffle_writer_test SOURCES VeloxShuffleWriterTest.cc)
 add_velox_test(velox_hash_shuffle_writer_input_encoding_test SOURCES
                VeloxHashShuffleWriterInputEncodingTest.cc)
 
+add_velox_test(velox_hash_shuffle_writer_split_rv_substages_test SOURCES
+               VeloxHashShuffleWriterSplitRvSubStagesTest.cc)
+
 add_velox_test(velox_shuffle_writer_spill_test SOURCES
                VeloxShuffleWriterSpillTest.cc)
 

--- a/cpp/velox/tests/VeloxHashShuffleWriterSplitRvSubStagesTest.cc
+++ b/cpp/velox/tests/VeloxHashShuffleWriterSplitRvSubStagesTest.cc
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "shuffle/VeloxHashShuffleWriter.h"
+
+#include "VeloxShuffleWriterTestBase.h"
+#include "utils/Macros.h"
+#include "utils/TestUtils.h"
+
+namespace gluten {
+
+namespace {
+
+std::shared_ptr<PartitionWriter> makeLocalPartitionWriter(
+    uint32_t numPartitions,
+    const std::string& dataFile,
+    const std::vector<std::string>& localDirs) {
+  GLUTEN_ASSIGN_OR_THROW(auto codec, arrow::util::Codec::Create(arrow::Compression::LZ4_FRAME));
+  auto options = std::make_shared<LocalPartitionWriterOptions>();
+  return std::make_shared<LocalPartitionWriter>(
+      numPartitions, std::move(codec), getDefaultMemoryManager(), options, dataFile, localDirs);
+}
+
+} // namespace
+
+class HashShuffleWriterSplitRvSubStagesTest : public ::testing::Test, public VeloxShuffleWriterTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    setUpVeloxBackend();
+  }
+
+  static void TearDownTestSuite() {
+    tearDownVeloxBackend();
+  }
+
+  void SetUp() override {
+    VeloxShuffleWriterTestBase::setUpTestData();
+  }
+
+  std::shared_ptr<VeloxShuffleWriter> createWriter(uint32_t numPartitions) {
+    auto options = std::make_shared<HashShuffleWriterOptions>();
+    options->partitioning = Partitioning::kHash;
+    options->splitBufferSize = 4096;
+
+    auto partitionWriter = makeLocalPartitionWriter(numPartitions, dataFile_, localDirs_);
+
+    GLUTEN_ASSIGN_OR_THROW(
+        auto writer,
+        VeloxShuffleWriter::create(
+            ShuffleWriterType::kHashShuffle, numPartitions, partitionWriter, options, getDefaultMemoryManager()));
+    return writer;
+  }
+
+  arrow::Status writeBatch(VeloxShuffleWriter& writer, facebook::velox::RowVectorPtr rv) {
+    std::shared_ptr<ColumnarBatch> cb = std::make_shared<VeloxColumnarBatch>(rv);
+    return writer.write(cb, ShuffleWriter::kMinMemLimit);
+  }
+};
+
+// Verifies that the human-readable names for the 4 new sub-stages match the
+// enum identifiers exactly (this is what shows up in the
+// `VELOX_SHUFFLE_WRITER_LOG_FLAG` log line, so the strings are part of the
+// stable observable surface).
+TEST_F(HashShuffleWriterSplitRvSubStagesTest, enumNames) {
+  EXPECT_EQ(
+      VeloxShuffleWriter::CpuWallTimingName(VeloxShuffleWriter::CpuWallTimingSplitFixedWidth),
+      "CpuWallTimingSplitFixedWidth");
+  EXPECT_EQ(
+      VeloxShuffleWriter::CpuWallTimingName(VeloxShuffleWriter::CpuWallTimingSplitValidity),
+      "CpuWallTimingSplitValidity");
+  EXPECT_EQ(
+      VeloxShuffleWriter::CpuWallTimingName(VeloxShuffleWriter::CpuWallTimingSplitBinary), "CpuWallTimingSplitBinary");
+  EXPECT_EQ(
+      VeloxShuffleWriter::CpuWallTimingName(VeloxShuffleWriter::CpuWallTimingSplitComplex),
+      "CpuWallTimingSplitComplex");
+}
+
+// A batch with one fixed-width data column should tick the fixed-width
+// sub-stage and visit (but not necessarily do meaningful work in) the other
+// three. We assert `count >= 1` rather than `>0 ns wall` because the
+// SCOPED_TIMER timing resolution can round empty paths to 0 ns; the count
+// is the reliable signal that the timer was reached.
+TEST_F(HashShuffleWriterSplitRvSubStagesTest, fixedWidthBumpsItsBucket) {
+  auto writer = createWriter(2);
+  auto rv = makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 0, 1}), // partition key
+      makeFlatVector<int64_t>({100, 200, 300, 400}),
+  });
+  ASSERT_NOT_OK(writeBatch(*writer, rv));
+
+  EXPECT_EQ(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitFixedWidth).count, 1);
+  EXPECT_EQ(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitValidity).count, 1);
+  EXPECT_EQ(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitBinary).count, 1);
+  EXPECT_EQ(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitComplex).count, 1);
+}
+
+// A batch with a VARCHAR column should tick the binary sub-stage with
+// nonzero wall time (there's real work copying string data per partition).
+TEST_F(HashShuffleWriterSplitRvSubStagesTest, binaryBumpsItsBucket) {
+  auto writer = createWriter(2);
+  auto rv = makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 0, 1}), // partition key
+      makeFlatVector<facebook::velox::StringView>({"alpha", "beta", "gamma", "delta"}),
+  });
+  ASSERT_NOT_OK(writeBatch(*writer, rv));
+
+  EXPECT_EQ(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitBinary).count, 1);
+  EXPECT_GT(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitBinary).wallNanos, 0);
+}
+
+// A batch with a complex (ARRAY) column should tick the complex sub-stage
+// with nonzero wall time (Presto serializer round-trip per partition).
+TEST_F(HashShuffleWriterSplitRvSubStagesTest, complexBumpsItsBucket) {
+  auto writer = createWriter(2);
+  auto rv = makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 0, 1}), // partition key
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6},
+          {7, 8, 9, 10},
+      }),
+  });
+  ASSERT_NOT_OK(writeBatch(*writer, rv));
+
+  EXPECT_EQ(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitComplex).count, 1);
+  EXPECT_GT(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitComplex).wallNanos, 0);
+}
+
+// Sanity: the outer SplitRV bucket continues to tick once per batch — the
+// new sub-stage timers do not replace it, they refine it.
+TEST_F(HashShuffleWriterSplitRvSubStagesTest, outerSplitRvStillCounted) {
+  auto writer = createWriter(2);
+  auto rv = makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 0, 1}),
+      makeFlatVector<int64_t>({100, 200, 300, 400}),
+  });
+  ASSERT_NOT_OK(writeBatch(*writer, rv));
+  ASSERT_NOT_OK(writeBatch(*writer, rv));
+
+  EXPECT_EQ(writer->cpuWallTiming(VeloxShuffleWriter::CpuWallTimingSplitRV).count, 2);
+}
+
+} // namespace gluten
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Companion follow-up to #12083 (which made `cpuWallTimingList_` actually record real numbers) and #12107 (which added a per-batch input-encoding counter). The existing `CpuWallTimingSplitRV` bucket wraps the entire `splitRowVector()` call, so when it dominates wall time in a `VELOX_SHUFFLE_WRITER_LOG_FLAG=1` profile, there's no way to tell which of the four sub-paths is responsible: fixed-width scatter, validity copy, binary split, or complex (Presto-serialized) split.

This PR subdivides `SplitRV` into four new buckets, one per helper inside `splitRowVector()`:

| New enum                              | Helper                            |
|---------------------------------------|-----------------------------------|
| `CpuWallTimingSplitFixedWidth`        | `splitFixedWidthValueBuffer()`    |
| `CpuWallTimingSplitValidity`          | `splitValidityBuffer()`           |
| `CpuWallTimingSplitBinary`            | `splitBinaryArray()`              |
| `CpuWallTimingSplitComplex`           | `splitComplexType()`              |

The outer `SplitRV` bucket is unchanged: it continues to count once per call, and its wall/cpu measurement now happens to overlap the four inner buckets (the outer timer is still ticking while each inner one is). The outer **minus** the sum-of-inners is therefore the time spent in `splitRowVector()` outside the four sub-paths (mostly the post-split `partitionBufferBase_` update loop). This is the same parent/child pattern most profiling tools use for nested timers, and it's documented in a comment next to the enum.

The `CpuWallTimingType` enum, the `CpuWallTimingName()` helper, and a new single-value accessor `cpuWallTiming(CpuWallTimingType)` are hoisted from `protected` to `public` so the data is accessible from tests. The underlying `cpuWallTimingList_` storage stays `protected`.

## How was this patch tested?

This PR adds `cpp/velox/tests/VeloxHashShuffleWriterSplitRvSubStagesTest.cc` (second commit) with five gtest cases:

- `enumNames`: validates the strings emitted under `VELOX_SHUFFLE_WRITER_LOG_FLAG` for the 4 new enum entries (these strings are stable observable surface).
- `fixedWidthBumpsItsBucket`: single fixed-width batch; asserts each of the 4 inner buckets has `count == 1` (every helper inside `splitRowVector()` is called once per batch regardless of column-type mix, since the new sub-stage `SCOPED_TIMER` calls live at function entry).
- `binaryBumpsItsBucket`: VARCHAR batch; asserts the binary sub-stage's `wallNanos > 0`, confirming real work is being measured (not just function-entry overhead).
- `complexBumpsItsBucket`: ARRAY batch; same `wallNanos > 0` assertion against the complex sub-stage (Presto-serialized round-trip per partition).
- `outerSplitRvStillCounted`: sanity check, two batches in and outer `SplitRV` bucket has `count == 2`. Confirms the new inner timers refine, not replace, the existing outer timer.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI (Claude Opus 4.7 1M context)