### PR TITLE
[INFRA] Use hadoop 2.10.2 for uniffle test

### DIFF
--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -574,10 +574,10 @@ jobs:
         run: |
           export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
           if [ ! -e "/opt/apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz" ]; then
-            ${WGET_CMD} https://www.apache.org/dyn/closer.lua/uniffle/${{ matrix.uniffle }}/apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz?action=download -P /opt
+            ${WGET_CMD} https://www.apache.org/dyn/closer.lua/uniffle/${{ matrix.uniffle }}/apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz?action=download -O /opt/apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz
           fi
           if [ ! -e "/opt/hadoop-${{ matrix.hadoop }}.tar.gz" ]; then
-            ${WGET_CMD} https://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-${{ matrix.hadoop }}/hadoop-${{ matrix.hadoop }}.tar.gz?action=download -P /opt
+            ${WGET_CMD} https://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-${{ matrix.hadoop }}/hadoop-${{ matrix.hadoop }}.tar.gz?action=download -O /opt/hadoop-${{ matrix.hadoop }}.tar.gz
           fi
           cd /opt && rm -rf shims && \
           mkdir /opt/uniffle && tar xzf apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz -C /opt/uniffle --strip-components=1 && \

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -555,7 +555,7 @@ jobs:
       matrix:
         spark: [ "spark-3.3" ]
         uniffle: [ "0.10.0" ]
-        hadoop: [ "2.8.5" ]
+        hadoop: [ "2.10.2" ]
     runs-on: ubuntu-22.04
     container: apache/gluten:centos-8-jdk8
     steps:
@@ -574,10 +574,10 @@ jobs:
         run: |
           export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
           if [ ! -e "/opt/apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz" ]; then
-            ${WGET_CMD} https://archive.apache.org/dist/uniffle/${{ matrix.uniffle }}/apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz -P /opt
+            ${WGET_CMD} https://www.apache.org/dyn/closer.lua/uniffle/${{ matrix.uniffle }}/apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz?action=download -P /opt
           fi
           if [ ! -e "/opt/hadoop-${{ matrix.hadoop }}.tar.gz" ]; then
-            ${WGET_CMD} https://archive.apache.org/dist/hadoop/common/hadoop-${{ matrix.hadoop }}/hadoop-${{ matrix.hadoop }}.tar.gz -P /opt
+            ${WGET_CMD} https://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-${{ matrix.hadoop }}/hadoop-${{ matrix.hadoop }}.tar.gz?action=download -P /opt
           fi
           cd /opt && rm -rf shims && \
           mkdir /opt/uniffle && tar xzf apache-uniffle-${{ matrix.uniffle }}-bin.tar.gz -C /opt/uniffle --strip-components=1 && \

--- a/dev/docker/Dockerfile.centos8-dynamic-build
+++ b/dev/docker/Dockerfile.centos8-dynamic-build
@@ -37,7 +37,7 @@ RUN set -ex; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.5.4/apache-celeborn-0.5.4-bin.tgz?action=download -O /opt/apache-celeborn-0.5.4-bin.tgz; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.6.3/apache-celeborn-0.6.3-bin.tgz?action=download -O /opt/apache-celeborn-0.6.3-bin.tgz; \
     wget -nv ${mirror_host}/uniffle/0.10.0/apache-uniffle-0.10.0-bin.tar.gz?action=download -O /opt/apache-uniffle-0.10.0-bin.tar.gz; \
-    wget -nv ${mirror_host}/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz?action=download -O /opt/hadoop-2.8.5.tar.gz; \
+    wget -nv ${mirror_host}/hadoop/common/hadoop-2.10.2/hadoop-2.10.2.tar.gz?action=download -O /opt/hadoop-2.10.2.tar.gz; \
     git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten/.github/workflows/util/; \
     ./install-spark-resources.sh 3.3; \

--- a/dev/docker/Dockerfile.centos9-dynamic-build
+++ b/dev/docker/Dockerfile.centos9-dynamic-build
@@ -35,7 +35,6 @@ RUN set -ex; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.5.4/apache-celeborn-0.5.4-bin.tgz?action=download -O /opt/apache-celeborn-0.5.4-bin.tgz; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.6.3/apache-celeborn-0.6.3-bin.tgz?action=download -O /opt/apache-celeborn-0.6.3-bin.tgz; \
     wget -nv ${mirror_host}/uniffle/0.10.0/apache-uniffle-0.10.0-bin.tar.gz?action=download -O /opt/apache-uniffle-0.10.0-bin.tar.gz; \
-    wget -nv ${mirror_host}/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz?action=download -O /opt/hadoop-2.8.5.tar.gz; \
     git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten/.github/workflows/util/; \
     ./install-spark-resources.sh 3.3; \

--- a/dev/docker/Dockerfile.centos9-dynamic-build
+++ b/dev/docker/Dockerfile.centos9-dynamic-build
@@ -34,7 +34,6 @@ RUN set -ex; \
     mirror_host="https://www.apache.org/dyn/closer.lua"; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.5.4/apache-celeborn-0.5.4-bin.tgz?action=download -O /opt/apache-celeborn-0.5.4-bin.tgz; \
     wget -nv ${mirror_host}/celeborn/celeborn-0.6.3/apache-celeborn-0.6.3-bin.tgz?action=download -O /opt/apache-celeborn-0.6.3-bin.tgz; \
-    wget -nv ${mirror_host}/uniffle/0.10.0/apache-uniffle-0.10.0-bin.tar.gz?action=download -O /opt/apache-uniffle-0.10.0-bin.tar.gz; \
     git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten/.github/workflows/util/; \
     ./install-spark-resources.sh 3.3; \


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Upgrade the hadoop home version from 2.8.5 to 2.10.2 for  `tpc-test-centos8-uniffle`.

The 2.8.5 archive is in `archive.apache.org`, the download is much slow and is easy to cause the `Build and Push Docker Image` failed, details in https://github.com/apache/gluten/actions/workflows/docker_image.yml.

```bash
111.8 + wget -nv 'https://www.apache.org/dyn/closer.lua/hadoop/common/hadoop-2.8.5/hadoop-2.8.5.tar.gz?action=download' -O /opt/hadoop-2.8.5.tar.gz
247.6 failed: Connection timed out.
247.6 failed: Network is unreachable.
```

## How was this patch tested?
Pass CI.

## Was this patch authored or co-authored using generative AI tooling?
No.
