### PR TITLE
[Velox][Build][MIRROR] Skip sudo on macOS when staging Velox Arrow patches

### DIFF
--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -141,8 +141,12 @@ function apply_provided_velox_patch {
 }
 
 function apply_compilation_fixes {
-  sudo cp ${CURRENT_DIR}/modify_arrow.patch ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/
-  sudo cp ${CURRENT_DIR}/modify_arrow_dataset_scan_option.patch ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/
+  local SUDO_CMD=""
+  if [ "$OS" == "Linux" ]; then
+    SUDO_CMD="sudo"
+  fi
+  $SUDO_CMD cp ${CURRENT_DIR}/modify_arrow.patch ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/
+  $SUDO_CMD cp ${CURRENT_DIR}/modify_arrow_dataset_scan_option.patch ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/
 
   git add ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/modify_arrow.patch # to avoid the file from being deleted by git clean -dffx :/
   git add ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/modify_arrow_dataset_scan_option.patch # to avoid the file from being deleted by git clean -dffx :/


### PR DESCRIPTION
## What changes are proposed in this pull request?

`apply_compilation_fixes` in `ep/build-velox/src/get-velox.sh` always
calls `sudo cp` when staging the two Arrow patch files into
`$VELOX_HOME/CMake/resolve_dependency_modules/arrow/`. On macOS the
target directory is user-owned, so the `sudo` triggers an interactive
password prompt on every build with no functional benefit.

Introduce a `SUDO_CMD` variable that resolves to `sudo` on Linux and
an empty string elsewhere; behavior on Linux is unchanged.

## How was this patch tested?

- macOS 14 arm64: `dev/builddeps-veloxbe.sh` no longer prompts for a
  password when re-running `apply_compilation_fixes`. The two patch
  files land in `$VELOX_HOME/CMake/resolve_dependency_modules/arrow/`
  with the user's own ownership.
- Linux x86_64: `SUDO_CMD=sudo`, identical to the previous behavior.

## Was this patch authored or co-authored using generative AI tooling?

co-auth: Claude (Sonnet/Opus) via Claude Code 1.x
