### PR TITLE
[VL] Refactor defaultLeafPool usage

### DIFF
--- a/cpp/velox/benchmarks/PlanValidatorUtil.cc
+++ b/cpp/velox/benchmarks/PlanValidatorUtil.cc
@@ -44,8 +44,8 @@ int main(int argc, char** argv) {
   std::unordered_map<std::string, std::string> conf;
   conf.insert({kDebugModeEnabled, "true"});
   initVeloxBackend(conf);
-  auto pool = defaultLeafVeloxMemoryPool().get();
-  SubstraitToVeloxPlanValidator planValidator(pool);
+  auto pool = defaultLeafVeloxMemoryPool();
+  SubstraitToVeloxPlanValidator planValidator(pool.get());
 
   ::substrait::Plan subPlan;
   parseProtobuf(reinterpret_cast<uint8_t*>(plan.data()), plan.size(), &subPlan);

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -194,8 +194,8 @@ Java_org_apache_gluten_vectorized_PlanEvaluatorJniWrapper_nativeValidateWithFail
     }
   }
 
-  const auto pool = defaultLeafVeloxMemoryPool().get();
-  SubstraitToVeloxPlanValidator planValidator(pool);
+  auto pool = defaultLeafVeloxMemoryPool();
+  SubstraitToVeloxPlanValidator planValidator(pool.get());
   ::substrait::Plan subPlan;
   parseProtobuf(planData, planSize, &subPlan);
 
@@ -252,8 +252,8 @@ JNIEXPORT jboolean JNICALL Java_org_apache_gluten_vectorized_PlanEvaluatorJniWra
     env->DeleteLocalRef(mapping);
   }
 
-  auto pool = defaultLeafVeloxMemoryPool().get();
-  SubstraitToVeloxPlanValidator planValidator(pool);
+  auto pool = defaultLeafVeloxMemoryPool();
+  SubstraitToVeloxPlanValidator planValidator(pool.get());
   auto inputType = SubstraitParser::parseType(inputSubstraitType);
   if (inputType->kind() != TypeKind::ROW) {
     throw GlutenException("Input type is not a RowType.");

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1473,10 +1473,11 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::constructValuesNode(
   // It loads all data from the iterator at plan construction time
   VELOX_CHECK_LT(streamIdx, inputIters_.size(), "Could not find stream index {} in input iterator list.", streamIdx);
   const auto iter = std::move(inputIters_[streamIdx]);
+  auto pool = defaultLeafVeloxMemoryPool();
   std::vector<RowVectorPtr> rowVectors;
   while (iter->hasNext()) {
     auto batch = iter->next();
-    auto veloxBatch = VeloxColumnarBatch::from(defaultLeafVeloxMemoryPool().get(), batch);
+    auto veloxBatch = VeloxColumnarBatch::from(pool.get(), batch);
     rowVectors.emplace_back(veloxBatch->getRowVector());
   }
   auto node = std::make_shared<facebook::velox::core::ValuesNode>(nextPlanNodeId(), std::move(rowVectors));

--- a/cpp/velox/utils/VeloxArrowUtils.cc
+++ b/cpp/velox/utils/VeloxArrowUtils.cc
@@ -53,7 +53,8 @@ arrow::Result<std::shared_ptr<ColumnarBatch>> recordBatch2VeloxColumnarBatch(con
   ArrowArray arrowArray;
   ArrowSchema arrowSchema;
   RETURN_NOT_OK(arrow::ExportRecordBatch(rb, &arrowArray, &arrowSchema));
-  auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, gluten::defaultLeafVeloxMemoryPool().get());
+  auto pool = gluten::defaultLeafVeloxMemoryPool();
+  auto vp = velox::importFromArrowAsOwner(arrowSchema, arrowArray, pool.get());
   return std::make_shared<VeloxColumnarBatch>(std::dynamic_pointer_cast<velox::RowVector>(vp));
 }
 


### PR DESCRIPTION
…ry shared_ptr, calls .get() on it to extract the raw pointer, then immediately destroys the shared_ptr. This leaves a dangling raw pointer that can cause segfaults, especially in certain JDK distributions.

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
