### PR TITLE
[VL][FOLLOWUP] Reduce Velox hash shuffle partition buffer memory by evicting large partitions after split

### DIFF
--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -440,7 +440,6 @@ arrow::Status VeloxHashShuffleWriter::doSplit(const facebook::velox::RowVector& 
 
   printPartitionBuffer();
 
-  setSplitState(SplitState::kInit);
   if (partitionBufferEvictThreshold_ > 0) {
     // After split, evict large partition buffers to free up memory for the next input RowVector.
     const auto partitionBytes = estimatePartitionBufferBytes();
@@ -450,6 +449,7 @@ arrow::Status VeloxHashShuffleWriter::doSplit(const facebook::velox::RowVector& 
       }
     }
   }
+  setSplitState(SplitState::kInit);
   return arrow::Status::OK();
 }
 

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -445,6 +445,7 @@ arrow::Status VeloxHashShuffleWriter::doSplit(const facebook::velox::RowVector& 
     const auto partitionBytes = estimatePartitionBufferBytes();
     for (uint32_t pid = 0; pid < partitionBytes.size(); ++pid) {
       if (partitionBufferBase_[pid] > 0 && partitionBytes[pid] >= partitionBufferEvictThreshold_) {
+        PartitionScopeGuard guard(partitionBufferInUse_, pid);
         RETURN_NOT_OK(evictPartitionBuffers(pid, false));
       }
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Bug fix for `VeloxHashShuffleWriter::doSplit`.

How does this issue happen :
* After set `splitState_ == kInit`, do `evictPartitionBuffers()` to evict large partitions.
* `evictPartitionBuffers(pid)` calls assembleBuffers, which slices / copies / serializes buffers and may allocate from the Velox memory pool. 
* The allocation can trigger memory arbitration, which calls back into `reclaimFixedSize`. 
* Because `evictState_` is still `kEvictable` and `evictPartitionBuffersAfterSpill()` is true, the arbitrator enters `evictPartitionBuffersMinSize`, which may select the same pid we are currently evicting. 
* The inner eviction resets `partitionBuffers_[*][pid]`, `partitionBinaryAddrs_[*][pid]`, and `partitionBufferBase_[pid]` while the outer call is still mid-assembly.

How to fix this issue:
* Do do `evictPartitionBuffers()` before set `splitState_ == kInit`
* Also add `PartitionScopeGuard` for the evicted partition to prevent buffer capacity or raw buffer pointer from becoming invalid if OOM is triggered during `assembleBuffers`

## How was this patch tested?

Use exists UT

## Was this patch authored or co-authored using generative AI tooling?
 
NO
