### PR TITLE
[GLUTEN-12169][CH] Fix str_to_map nullable input null-map access

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/GlutenFunctionValidateSuite.scala
@@ -489,6 +489,20 @@ class GlutenFunctionValidateSuite extends GlutenClickHouseWholeStageTransformerS
     runQueryAndCompare(sql1)(checkGlutenPlan[ProjectExecTransformer])
   }
 
+  test("test str2map with nullable string input") {
+    val sql =
+      """
+        |select id, str_to_map(str, ',', ':')
+        |from (
+        |  select id,
+        |    if(id = 1, cast(null as string), concat('k:', cast(id as string))) as str
+        |  from range(4)
+        |)
+        |order by id
+        |""".stripMargin
+    runQueryAndCompare(sql)(checkGlutenPlan[ProjectExecTransformer])
+  }
+
   test("test parse_url") {
     val sql1 =
       """

--- a/cpp-ch/local-engine/Functions/SparkFunctionStrToMap.cpp
+++ b/cpp-ch/local-engine/Functions/SparkFunctionStrToMap.cpp
@@ -240,7 +240,7 @@ public:
 
         for (size_t i = 0, n = offsets.size(); i < n; ++i)
         {
-            if (null_map && (*null_map)[n] != 0)
+            if (null_map && (*null_map)[i] != 0)
                 col_map->insertDefault();
             else
             {


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

SparkFunctionStrToMap iterates rows with index i, but the nullable string path checked null_map[n], where n is offsets.size(). For any non-empty nullable input this reads one element past the null map and can produce an incorrect null decision, undefined behavior, or a crash.

Use the current row index when reading the nullable null map. Add a ClickHouse backend regression test that evaluates str_to_map over a nullable string expression containing both null and non-null rows, then compares the result with vanilla Spark.

closed #12169

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
UT
## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
co-authored using generative AI tooling