### PR TITLE
[GLUTEN-12172][CH] Fix group limit first array result offset

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -3050,27 +3050,22 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
       (CHConfig.runtimeSettings("enable_window_group_limit_to_aggregate"), "true"),
       (CHConfig.runtimeSettings("window.aggregate_topk_high_cardinality_threshold"), "2.0")
     ) {
-      spark.sql("drop table if exists test_win_top_first_offset")
-      spark.sql("create table test_win_top_first_offset (a string, b int) using parquet")
-      spark.sql("insert into test_win_top_first_offset values ('a', 2), ('a', 1)")
-
       compareResultsAgainstVanillaSpark(
         """
           |select * from (
           |  select a, b, row_number() over (partition by a order by b) as r
-          |  from test_win_top_first_offset
+          |  from (select * from values ('a', 2), ('a', 1) as t(a, b))
           |) where r <= 1
           |""".stripMargin,
         compareResult = true,
         df => {
-          val aggregateGroupLimit = collectWithSubqueries(df.queryExecution.executedPlan) {
+          val groupLimit = collectWithSubqueries(df.queryExecution.executedPlan) {
             case e: CHAggregateGroupLimitExecTransformer => e
+            case wgl: CHWindowGroupLimitExecTransformer => wgl
           }
-          assert(aggregateGroupLimit.nonEmpty)
+          assert(groupLimit.nonEmpty)
         }
       )
-
-      spark.sql("drop table if exists test_win_top_first_offset")
     }
   }
 

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -3045,6 +3045,35 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
 
   }
 
+  test("row number aggregate topk handles first array result offset") {
+    withSQLConf(
+      (CHConfig.runtimeSettings("enable_window_group_limit_to_aggregate"), "true"),
+      (CHConfig.runtimeSettings("window.aggregate_topk_high_cardinality_threshold"), "2.0")
+    ) {
+      spark.sql("drop table if exists test_win_top_first_offset")
+      spark.sql("create table test_win_top_first_offset (a string, b int) using parquet")
+      spark.sql("insert into test_win_top_first_offset values ('a', 2), ('a', 1)")
+
+      compareResultsAgainstVanillaSpark(
+        """
+          |select * from (
+          |  select a, b, row_number() over (partition by a order by b) as r
+          |  from test_win_top_first_offset
+          |) where r <= 1
+          |""".stripMargin,
+        compareResult = true,
+        df => {
+          val aggregateGroupLimit = collectWithSubqueries(df.queryExecution.executedPlan) {
+            case e: CHAggregateGroupLimitExecTransformer => e
+          }
+          assert(aggregateGroupLimit.nonEmpty)
+        }
+      )
+
+      spark.sql("drop table if exists test_win_top_first_offset")
+    }
+  }
+
   test("GLUTEN-7905 get topk of window by window") {
     withSQLConf(
       (CHConfig.runtimeSettings("enable_window_group_limit_to_aggregate"), "true"),

--- a/cpp-ch/local-engine/AggregateFunctions/GroupLimitFunctions.cpp
+++ b/cpp-ch/local-engine/AggregateFunctions/GroupLimitFunctions.cpp
@@ -142,7 +142,8 @@ public:
 
         sortAndLimit(max_elements, sort_orders);
 
-        result_array_offsets.push_back(result_array_offsets.back() + values.size());
+        const auto previous_offset = result_array_offsets.empty() ? 0 : result_array_offsets.back();
+        result_array_offsets.push_back(previous_offset + values.size());
 
         if (values.empty())
             return;


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

RowNumGroupArraySorted writes aggregate results into a newly created ColumnArray. For the first output row the array offsets vector can be empty, but insertResultInto read result_array_offsets.back() before appending the first offset. That is undefined behavior and can crash when aggregate top-k writes its first result.

Treat an empty offsets vector as having previous offset 0 before appending the next cumulative offset. Add a ClickHouse backend regression test that forces row_number top-k through the aggregate group limit path and validates the first array result row against vanilla Spark.

closed #12172

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

UTs

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
co-authored using generative AI tooling
