### PR TITLE
[VL] Compute real nullCount for flat-encoded unsupported types in cached-batch partition stats

### DIFF
--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/ColumnarCachedBatchE2ESuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/ColumnarCachedBatchE2ESuite.scala
@@ -488,4 +488,25 @@ class ColumnarCachedBatchE2ESuite
       }
     }
   }
+
+  test("V2 stats: IsNull on VARBINARY null-bearing partition is not pruned") {
+    withSQLConf(
+      GlutenConfig.COLUMNAR_TABLE_CACHE_PARTITION_STATS_ENABLED.key -> "true") {
+      val df = spark.range(N)
+        .select(
+          when(col("id") === lit(750L), lit(null).cast("binary"))
+            .otherwise(col("id").cast("string").cast("binary"))
+            .as("bin"))
+        .repartitionByRange(P, col("bin"))
+        .cache()
+      try {
+        df.count()
+        assert(
+          df.filter(col("bin").isNull).count() == 1L,
+          "VARBINARY null-bearing partition was silently pruned by IsNull")
+      } finally {
+        df.unpersist(blocking = true)
+      }
+    }
+  }
 }

--- a/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
+++ b/cpp/velox/operators/serializer/VeloxColumnarBatchSerializer.cc
@@ -369,6 +369,8 @@ std::vector<ColumnStats> VeloxColumnarBatchSerializer::computeStats(RowVectorPtr
         break;
       }
       default:
+        // Mirror non-flat path: real nullCount needed for JVM IsNull pruning.
+        nullCnt = countNullsAny(child.get());
         // Unsupported type -> hasLowerBound=hasUpperBound=false -> JVM buildFilter pass-through.
         break;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`VeloxColumnarBatchSerializer::computeStats` did not accrue `nullCount` in the
`default:` arm of the flat-encoding TypeKind switch. For flat-encoded
unsupported TypeKinds (`VARBINARY`, `OPAQUE`, `UNKNOWN`) with V2 partition
stats enabled, `stats.nullCount` was 0 regardless of real null count, so
Spark `IsNull` predicate pruning silently dropped null-bearing partitions.

Mirror the non-flat path's `countNullsAny` call. Wire format unchanged
(the `nullCount` slot has always been emitted, just zero for the affected
types). No `SQLConf` change.

## How was this patch tested?

New e2e test in `ColumnarCachedBatchE2ESuite`. Pre-fix: `0 did not equal 1`.
Post-fix: pass.

## (Optional) Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-4.7
