### PR TITLE
[GLUTEN-12185][CH] Guard missing prepared set in parquet index filter

### DIFF
--- a/cpp-ch/local-engine/Storages/Parquet/ColumnIndexFilter.cpp
+++ b/cpp-ch/local-engine/Storages/Parquet/ColumnIndexFilter.cpp
@@ -808,10 +808,10 @@ bool tryPrepareSetIndex(const DB::RPNBuilderFunctionTreeNode & func, DB::GlutenP
 {
     const auto right_arg = func.getArgumentAt(1);
     const auto future_set = right_arg.tryGetPreparedSet();
-    if (future_set->getTypes().size() != 1)
+    if (!future_set)
         return false;
 
-    if (!future_set)
+    if (future_set->getTypes().size() != 1)
         return false;
 
     const auto prepared_set = future_set->buildOrderedSetInplace(right_arg.getTreeContext().getQueryContext());


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Guard missing prepared set in parquet index filter

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
UTs

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
 co-authored using generative AI tooling

Related issue: #12185