### PR TITLE
[VL] Improve executor shutdown logic

### DIFF
--- a/cpp/velox/compute/VeloxRuntime.cc
+++ b/cpp/velox/compute/VeloxRuntime.cc
@@ -82,12 +82,20 @@ class HookedExecutor final : public folly::Executor {
         state_(std::make_shared<State>()) {}
 
   ~HookedExecutor() override {
+    shuttingDown_.store(true, std::memory_order_release);
     if (!join()) {
       LOG(WARNING) << "Timed out waiting for hooked executor " << name_ << " to finish after " << joinTimeout_.count()
                    << " ms.";
       if (debug_) {
         dumpOutstandingTasks();
       }
+    }
+    // We do NOT assume ownership of parent lifecycle,
+    // so we do NOT call join() blindly.
+    //
+    // Instead, we only try a "soft fence" by pushing a no-op barrier.
+    if (parent_) {
+      parent_->add([] {});
     }
   }
 
@@ -144,12 +152,18 @@ class HookedExecutor final : public folly::Executor {
  public:
   void add(folly::Func func) override {
     GLUTEN_CHECK(parent_ != nullptr, "Parent executor is null.");
+    if (UNLIKELY(shuttingDown_.load(std::memory_order_acquire))) {
+      return;
+    }
     state_->inFlight.fetch_add(1, std::memory_order_relaxed);
     parent_->add(wrap(std::move(func), 0));
   }
 
   void addWithPriority(folly::Func func, int8_t priority) override {
     GLUTEN_CHECK(parent_ != nullptr, "Parent executor is null.");
+    if (UNLIKELY(shuttingDown_.load(std::memory_order_acquire))) {
+      return;
+    }
     state_->inFlight.fetch_add(1, std::memory_order_relaxed);
     parent_->addWithPriority(wrap(std::move(func), priority), priority);
   }
@@ -194,6 +208,7 @@ class HookedExecutor final : public folly::Executor {
   bool debug_;
   std::chrono::milliseconds joinTimeout_;
   std::shared_ptr<State> state_;
+  std::atomic<bool> shuttingDown_{false};
 };
 
 std::unique_ptr<folly::Executor> makeHookedExecutor(


### PR DESCRIPTION


<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Adding a atomic bool to guard shutdown process, this can prevent to add more requests after shutdown

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
