### PR TITLE
[VL] Tighten cache-stats wire-edge bound checks

### DIFF
--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -401,6 +401,18 @@ object CachedColumnarBatchKryoSerializer {
     require(
       numCols >= 0 && numCols <= Int.MaxValue / 5,
       s"corrupt statsBlob: numCols=$numCols out of valid range")
+    if (schema != null) {
+      // Asymmetric: numCols > schema.length would IOB on schema(col) dispatch in
+      // serializeStats/deserializeStats; that's a real corrupt-frame signal. The
+      // numCols < schema.length direction is intentionally allowed -- the public
+      // API is loose enough that callers (incl. the unit-test fixtures) pass an
+      // EXPANDED 5-field-per-source-col schema where schema.length == numCols * 5.
+      // Only the first numCols entries are ever consumed for type dispatch.
+      require(
+        numCols <= schema.length,
+        s"corrupt statsBlob: numCols=$numCols > schema.length=${schema.length}; " +
+          "likely cpp/JVM wire mismatch or truncated frame")
+    }
     val row = new GenericInternalRow(numCols * 5)
     var col = 0
     while (col < numCols) {

--- a/backends-velox/src/test/scala/org/apache/spark/sql/execution/ColumnarCachedBatchFramedBytesSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/spark/sql/execution/ColumnarCachedBatchFramedBytesSuite.scala
@@ -409,4 +409,64 @@ class ColumnarCachedBatchFramedBytesSuite extends AnyFunSuite {
     assert(statsBlob(4) === 0.toByte, "supported byte must be 0 (no-bounds branch)")
   }
 
+  // ---------------------------------------------------------------------------
+  // deserializeStats numCols-vs-schema.length invariant (asymmetric).
+  // Only the > direction is a corrupt-frame signal; the < direction is allowed
+  // because callers may pass an EXPANDED 5-field-per-source-col schema (see
+  // ColumnarCachedBatchIntFamilyMarshalSuite for the canonical pattern).
+  // 1 RED test (numCols > schema.length) + 2 sentinels (numCols < and schema=null).
+  // ---------------------------------------------------------------------------
+
+  test("deserializeStats: numCols < schema.length is allowed (loose-schema API)") {
+    // Callers (e.g. IntFamilyMarshalSuite) routinely pass an expanded schema
+    // where schema.length = numCols * 5. The first numCols entries drive type
+    // dispatch; the rest are silently ignored. Sentinel guards against future
+    // tightening that would break the existing test fleet.
+    val schema = StructType(Seq(
+      StructField("a", LongType),
+      StructField("b", LongType),
+      StructField("c", LongType),
+      StructField("d", LongType),
+      StructField("e", LongType)))
+    val baos = new java.io.ByteArrayOutputStream()
+    writeU32LE(baos, 1) // numCols on wire = 1; schema.length = 5; legal.
+    baos.write(0.toByte)
+    for (_ <- 0 until 4) baos.write(0.toByte) // nullCount
+    for (_ <- 0 until 4) baos.write(0.toByte) // count
+    for (_ <- 0 until 8) baos.write(0.toByte) // sizeInBytes
+    val row = CachedColumnarBatchKryoSerializer.deserializeStats(baos.toByteArray, schema)
+    assert(row != null)
+    assert(row.numFields == 5, "1 col * 5 slots = 5; schema.length is NOT the row width")
+  }
+
+  test("deserializeStats: numCols > schema.length is rejected with wire-mismatch IAE") {
+    val schema = StructType(Seq(StructField("a", LongType)))
+    val baos = new java.io.ByteArrayOutputStream()
+    writeU32LE(baos, 2) // numCols on wire = 2; schema.length = 1; IOB-bound.
+    // two fake col headers (1B + 4B + 4B + 8B = 17B each); the new check
+    // fires before they are consumed, so contents are immaterial.
+    for (_ <- 0 until 17 * 2) baos.write(0.toByte)
+    val blob = baos.toByteArray
+    val ex = intercept[IllegalArgumentException] {
+      CachedColumnarBatchKryoSerializer.deserializeStats(blob, schema)
+    }
+    assert(ex.getMessage.contains("numCols=2"), s"got: ${ex.getMessage}")
+    assert(ex.getMessage.contains("schema.length=1"), s"got: ${ex.getMessage}")
+    assert(ex.getMessage.toLowerCase(Locale.ROOT).contains("wire mismatch"))
+  }
+
+  test("deserializeStats: schema=null path unaffected by the new invariant") {
+    // V1-wire backcompat: schema=null, numCols read from wire only.
+    val baos = new java.io.ByteArrayOutputStream()
+    writeU32LE(baos, 1)
+    baos.write(0.toByte) // supported=0
+    for (_ <- 0 until 4) baos.write(0.toByte) // nullCount
+    for (_ <- 0 until 4) baos.write(0.toByte) // count
+    for (_ <- 0 until 8) baos.write(0.toByte) // sizeInBytes
+    val blob = baos.toByteArray
+    val row = CachedColumnarBatchKryoSerializer.deserializeStats(blob, null)
+    assert(row != null)
+    assert(row.numFields == 5)
+  }
+
 }

--- a/cpp/core/jni/JniWrapper.cc
+++ b/cpp/core/jni/JniWrapper.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <filesystem>
+#include <limits>
 
 #include "compute/Runtime.h"
 #include "config/GlutenConfig.h"
@@ -1316,6 +1317,14 @@ Java_org_apache_gluten_vectorized_ColumnarBatchSerializerJniWrapper_serializeWit
   auto serializer = ctx->createColumnarBatchSerializer(nullptr);
   std::vector<uint8_t> framed = serializer->framedSerializeWithStats(batch);
 
+  // Outer-layer size defense (inner layer = bytesLen <= UINT32_MAX in
+  // framedSerializeWithStats). jsize is signed int32; > INT32_MAX wraps
+  // negative -> NewByteArray would throw NegativeArraySizeException.
+  // Fail fast here so JNI_METHOD_END surfaces it as GlutenException.
+  GLUTEN_CHECK(
+      framed.size() <= static_cast<size_t>(std::numeric_limits<jsize>::max()),
+      "serializeWithStats: framed payload (" + std::to_string(framed.size()) + " bytes) exceeds Java byte[] limit (" +
+          std::to_string(std::numeric_limits<jsize>::max()) + ")");
   jbyteArray out = env->NewByteArray(static_cast<jsize>(framed.size()));
   if (!framed.empty()) {
     env->SetByteArrayRegion(out, 0, static_cast<jsize>(framed.size()), reinterpret_cast<jbyte*>(framed.data()));


### PR DESCRIPTION
## What changes are proposed in this pull request?

Two defensive bound checks at the wire-edges of the cache-stats
serialization path:

1. **cpp JNI `serializeWithStats`**: `GLUTEN_CHECK` that the framed
   payload fits in `jsize` (signed int32, ~2 GiB) before
   `NewByteArray`. A payload in the (2 GiB, 4 GiB] window (allowed by
   the inner `bytesLen <= UINT32_MAX` check) would currently wrap to
   a negative `jsize` and surface as `NegativeArraySizeException`
   with no actionable diagnostic. Fail fast as `GlutenException` with
   byte count + limit.

2. **JVM `deserializeStats`**: when `schema != null`, require
   `numCols <= schema.length`. The `>` direction would IOB on
   `schema(col)` during type dispatch (a real corrupt-frame signal).
   The `<` direction is intentionally allowed -- existing fixtures
   like `ColumnarCachedBatchIntFamilyMarshalSuite` pass an EXPANDED
   5-field-per-source-col schema where `schema.length == numCols * 5`
   and only the first `numCols` entries drive dispatch. The new
   guard catches corrupt frames at the wire boundary instead of
   letting an undersized row propagate into a downstream
   `ArrayIndexOutOfBoundsException`. The pre-existing
   `0 <= numCols <= Int.MaxValue/5` bound is preserved.

Both fixes are defense-in-depth -- no production caller triggers
either path today. Recovery on the JVM side is via the existing
`NonFatal` corrupt-frame catch in `ColumnarCachedBatchSerializer.serialize`
(no change), which falls back to legacy `serialize()` for the batch.

## How was this patch tested?

- `ColumnarCachedBatchFramedBytesSuite`: 3 new JVM tests covering
  `numCols > schema.length` rejection, `numCols < schema.length`
  loose-schema sentinel, and the `schema=null` V1-wire backcompat
  sentinel.
- `ColumnarCachedBatch*Suite` family (9 suites, 69 tests): all
  pass against a fresh local `libgluten.so` / `libvelox.so` built
  from this branch. Local preflight (cpp + JVM compile + format +
  lint) clean.
- No cpp gtest for the `jsize` guard: exercising the bound would
  require materializing a >2 GiB framed payload, which risks OOM on
  CI runners with 8-16 GiB total. The guard itself is a one-liner
  immediately before `NewByteArray`.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7
