### PR TITLE
[GLUTEN-12225][CORE] Fix arrow.c shading: exclude memory/vector packages so public API stays unshaded

### DIFF
--- a/dev/check-arrow-c-shading.sh
+++ b/dev/check-arrow-c-shading.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Verify the bundled gluten-velox jar's Arrow C-Data classes have method
+# signatures referencing the *unshaded* org.apache.arrow.memory.BufferAllocator
+# and org.apache.arrow.vector.* types — not the gluten-shaded copies.
+#
+# Background: org.apache.arrow.c.* must NOT be relocated (its native JNI binds
+# to the original class names), but its public API methods accept/return
+# org.apache.arrow.memory.* and org.apache.arrow.vector.* types. Those types
+# must therefore also stay unshaded in the bundle, otherwise the bundled
+# ArrowArrayStream/ArrowSchema get re-bound to the shaded BufferAllocator at
+# compile time and any caller passing a vanilla Apache Arrow allocator hits
+# `NoSuchMethodError`. See gluten#12225.
+#
+# Usage:
+#   dev/check-arrow-c-shading.sh <path-to-gluten-velox-bundle.jar>
+#
+# Exit codes:
+#   0 — bundle is well-shaded (Arrow C-Data API uses public Apache Arrow types)
+#   1 — bundle is broken (Arrow C-Data API references gluten-shaded types)
+#   2 — usage / setup error
+
+set -euo pipefail
+
+JAR="${1:?usage: $0 <path-to-gluten-velox-bundle.jar>}"
+if [[ ! -f "$JAR" ]]; then
+  echo "error: jar not found: $JAR" >&2
+  exit 2
+fi
+
+if ! command -v javap >/dev/null; then
+  echo "error: javap not found on PATH" >&2
+  exit 2
+fi
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Classes whose public API touches the unshaded boundary.
+CLASSES=(
+  "org/apache/arrow/c/ArrowArrayStream"
+  "org/apache/arrow/c/ArrowSchema"
+  "org/apache/arrow/c/ArrowArray"
+  "org/apache/arrow/c/Data"
+)
+
+failures=0
+for cls in "${CLASSES[@]}"; do
+  if ! unzip -p "$JAR" "${cls}.class" > "$WORKDIR/$(basename "$cls").class" 2>/dev/null; then
+    echo "  SKIP $cls (not in bundle)"
+    continue
+  fi
+  signatures=$(javap -p "$WORKDIR/$(basename "$cls").class" 2>/dev/null || true)
+  # Any method signature mentioning the gluten-shaded Arrow path is the bug.
+  bad=$(echo "$signatures" | grep -E "org\.apache\.gluten\.shaded\.org\.apache\.arrow\.(memory|vector)\." || true)
+  if [[ -n "$bad" ]]; then
+    echo "  FAIL $cls — public API references gluten-shaded Arrow types:"
+    echo "$bad" | sed 's/^/    /'
+    failures=$((failures + 1))
+  else
+    echo "  OK   $cls"
+  fi
+done
+
+if (( failures > 0 )); then
+  echo
+  echo "Bundle has $failures Arrow C-Data class(es) with shaded API types."
+  echo "See gluten#12225 for context. Update package/pom.xml's"
+  echo "<relocation org.apache.arrow> excludes to also exclude"
+  echo "org.apache.arrow.memory.** and org.apache.arrow.vector.**."
+  exit 1
+fi
+
+echo
+echo "All Arrow C-Data classes use unshaded public Apache Arrow API. ✓"

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -315,10 +315,10 @@
               (gluten#12225).
             -->
             <id>verify-arrow-c-shading</id>
-            <phase>verify</phase>
             <goals>
               <goal>exec</goal>
             </goals>
+            <phase>verify</phase>
             <configuration>
               <executable>${project.basedir}/../dev/check-arrow-c-shading.sh</executable>
               <arguments>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -121,10 +121,22 @@
                 <relocation>
                   <pattern>org.apache.arrow</pattern>
                   <shadedPattern>${gluten.shade.packageName}.org.apache.arrow</shadedPattern>
-                  <!--arrow's C and dataset wrapper refers to the original class path, so we should not relocate here-->
+                  <!--
+                    arrow's C and dataset wrappers refer to the original class
+                    path, so they must not be relocated. Their public APIs also
+                    take and return org.apache.arrow.memory.* and
+                    org.apache.arrow.vector.* types, so those packages must also
+                    stay unshaded — otherwise the bundled (unshaded)
+                    ArrowArrayStream/ArrowSchema get compiled against the
+                    relocated BufferAllocator/VectorSchemaRoot, producing
+                    `NoSuchMethodError` for any caller passing a vanilla
+                    Apache Arrow allocator. See #12225.
+                  -->
                   <excludes>
                     <exclude>org.apache.arrow.c.*</exclude>
                     <exclude>org.apache.arrow.c.jni.*</exclude>
+                    <exclude>org.apache.arrow.memory.**</exclude>
+                    <exclude>org.apache.arrow.vector.**</exclude>
                     <exclude>org.apache.arrow.dataset.**</exclude>
                   </excludes>
                 </relocation>
@@ -283,6 +295,35 @@
                 </banDuplicateClasses>
               </rules>
               <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <!--
+              Verify that the bundled Arrow C-Data classes have public method
+              signatures referencing the unshaded Apache Arrow API
+              (org.apache.arrow.memory.*, org.apache.arrow.vector.*) and not
+              the gluten-shaded copies. Catches a regression where shading
+              relocates classes that the unshaded org.apache.arrow.c.* API
+              transitively depends on, producing a bundle whose public Arrow
+              C-Data API is incompatible with vanilla Apache Arrow callers
+              (gluten#12225).
+            -->
+            <id>verify-arrow-c-shading</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${project.basedir}/../dev/check-arrow-c-shading.sh</executable>
+              <arguments>
+                <argument>${project.build.directory}/${project.build.finalName}.jar</argument>
+              </arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extend `package/pom.xml`'s `org.apache.arrow` relocation excludes to also keep `org.apache.arrow.memory.**` and `org.apache.arrow.vector.**` unshaded.

The bundled Arrow C-Data classes (`org.apache.arrow.c.*`) are correctly excluded from relocation because their native JNI binds to the original class names. However, their public API signatures take and return `org.apache.arrow.memory.*` and `org.apache.arrow.vector.*` types — which were being relocated. The result: the bundled `ArrowArrayStream` / `ArrowSchema` / `ArrowArray` / `Data` classes get compiled against the shaded `BufferAllocator` / `VectorSchemaRoot`, so any caller passing a vanilla Apache Arrow allocator hits `NoSuchMethodError`.

This affects any Spark workload that combines gluten with another library using Arrow C-Data (Iceberg's Arrow vector layer, Lance Java's writer, Snowflake JDBC's Arrow result decoder, etc.) when gluten's bundle wins classloader resolution against vanilla Arrow.

## How was this patch tested?

Adds `dev/check-arrow-c-shading.sh` which runs `javap` on the produced bundle jar and asserts that public method signatures reference unshaded Arrow types. Wired into `package/pom.xml`'s `verify` phase via `exec-maven-plugin` so regressions are caught in CI.

Tested against the upstream `gluten-velox-bundle-spark3.5_2.12-linux_amd64-1.6.0.jar`:

```
$ dev/check-arrow-c-shading.sh /path/to/gluten-velox-bundle-spark3.5_2.12-linux_amd64-1.6.0.jar
  FAIL org/apache/arrow/c/ArrowArrayStream — public API references gluten-shaded Arrow types:
      public static org.apache.arrow.c.ArrowArrayStream allocateNew(
        org.apache.gluten.shaded.org.apache.arrow.memory.BufferAllocator);
  FAIL org/apache/arrow/c/ArrowSchema — public API references gluten-shaded Arrow types:
      public static org.apache.arrow.c.ArrowSchema allocateNew(
        org.apache.gluten.shaded.org.apache.arrow.memory.BufferAllocator);
  FAIL org/apache/arrow/c/ArrowArray — public API references gluten-shaded Arrow types:
      public static org.apache.arrow.c.ArrowArray allocateNew(
        org.apache.gluten.shaded.org.apache.arrow.memory.BufferAllocator);
  FAIL org/apache/arrow/c/Data — public API references gluten-shaded Arrow types:
      [16 methods touching shaded org.apache.arrow.memory/vector types]

Bundle has 4 Arrow C-Data class(es) with shaded API types.
exit code: 1
```

After applying the relocation exclude change, a freshly-built bundle should pass the same check (script exits 0). The repro from #12225 (3 lines calling `ArrowArrayStream.allocateNew(new RootAllocator(...))` ) goes from `NoSuchMethodError` to `OK`.

## Closes

#12225