### PR TITLE
[GLUTEN-12235][VL] Fix hash shuffle spill ordering when evicting partition buffers

### DIFF
--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -716,6 +716,11 @@ arrow::Status LocalPartitionWriter::hashEvict(
   rawPartitionLengths_[partitionId] += inMemoryPayload->rawSize();
 
   if (evictType == Evict::kSpill) {
+    // Spill merge scans payloads by partition id, so split the file when hash eviction wraps around.
+    if (lastEvictPid_ != -1 && partitionId < lastEvictPid_) {
+      lastEvictPid_ = -1;
+      RETURN_NOT_OK(finishSpill());
+    }
     RETURN_NOT_OK(requestSpill(false));
 
     auto shouldCompress = codec_ != nullptr && inMemoryPayload->numRows() >= options_->compressionThreshold;
@@ -725,6 +730,7 @@ arrow::Status LocalPartitionWriter::hashEvict(
             shouldCompress ? Payload::kToBeCompressed : Payload::kUncompressed, payloadPool_.get(), codec_.get()));
 
     RETURN_NOT_OK(spiller_->spill(partitionId, std::move(payload)));
+    lastEvictPid_ = partitionId;
     return arrow::Status::OK();
   }
 

--- a/cpp/core/shuffle/LocalPartitionWriter.cc
+++ b/cpp/core/shuffle/LocalPartitionWriter.cc
@@ -716,11 +716,6 @@ arrow::Status LocalPartitionWriter::hashEvict(
   rawPartitionLengths_[partitionId] += inMemoryPayload->rawSize();
 
   if (evictType == Evict::kSpill) {
-    // Spill merge scans payloads by partition id, so split the file when hash eviction wraps around.
-    if (lastEvictPid_ != -1 && partitionId < lastEvictPid_) {
-      lastEvictPid_ = -1;
-      RETURN_NOT_OK(finishSpill());
-    }
     RETURN_NOT_OK(requestSpill(false));
 
     auto shouldCompress = codec_ != nullptr && inMemoryPayload->numRows() >= options_->compressionThreshold;
@@ -730,7 +725,6 @@ arrow::Status LocalPartitionWriter::hashEvict(
             shouldCompress ? Payload::kToBeCompressed : Payload::kUncompressed, payloadPool_.get(), codec_.get()));
 
     RETURN_NOT_OK(spiller_->spill(partitionId, std::move(payload)));
-    lastEvictPid_ = partitionId;
     return arrow::Status::OK();
   }
 

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -1505,7 +1505,6 @@ arrow::Result<int64_t> VeloxHashShuffleWriter::evictPartitionBuffersMinSize(int6
   // shrinking is not enough. In this case partitionBufferSize_ == partitionBufferBase_
   VELOX_CHECK(!partitionBufferInUse_);
   int64_t beforeEvict = partitionBufferPool_->bytes_allocated();
-  int64_t evicted = 0;
   std::vector<std::pair<uint32_t, uint32_t>> pidToSize;
   for (auto pid = 0; pid < numPartitions_; ++pid) {
     if (partitionBufferSize_[pid] == 0) {
@@ -1514,22 +1513,34 @@ arrow::Result<int64_t> VeloxHashShuffleWriter::evictPartitionBuffersMinSize(int6
     pidToSize.emplace_back(pid, partitionBufferSize_[pid]);
   }
   std::sort(pidToSize.begin(), pidToSize.end(), [&](const auto& a, const auto& b) { return a.second > b.second; });
-  if (!pidToSize.empty()) {
-    for (auto& item : pidToSize) {
-      auto pid = item.first;
-      ARROW_ASSIGN_OR_RAISE(auto buffers, assembleBuffers(pid, false));
-      auto* types = partitionWriter_->enableTypeAwareCompress() ? &tacBufferTypes_ : nullptr;
-      auto payload = std::make_unique<InMemoryPayload>(
-          item.second, &isValidityBuffer_, schema_, std::move(buffers), hasComplexType_, types);
-      metrics_.totalBytesToEvict += payload->rawSize();
-      RETURN_NOT_OK(partitionWriter_->hashEvict(pid, std::move(payload), Evict::kSpill, false, writtenBytes_));
-      evicted = beforeEvict - partitionBufferPool_->bytes_allocated();
-      if (evicted >= size) {
-        break;
-      }
+
+  struct PartitionPayload {
+    uint32_t pid;
+    std::unique_ptr<InMemoryPayload> payload;
+  };
+  std::vector<PartitionPayload> selectedPayloads;
+  int64_t selectedBytes = 0;
+  for (auto& item : pidToSize) {
+    auto pid = item.first;
+    ARROW_ASSIGN_OR_RAISE(auto buffers, assembleBuffers(pid, false));
+    auto* types = partitionWriter_->enableTypeAwareCompress() ? &tacBufferTypes_ : nullptr;
+    auto payload = std::make_unique<InMemoryPayload>(
+        item.second, &isValidityBuffer_, schema_, std::move(buffers), hasComplexType_, types);
+    selectedBytes += payload->rawCapacity();
+    selectedPayloads.push_back({pid, std::move(payload)});
+    if (selectedBytes >= size) {
+      break;
     }
   }
-  return evicted;
+
+  std::sort(selectedPayloads.begin(), selectedPayloads.end(), [](const auto& a, const auto& b) {
+    return a.pid < b.pid;
+  });
+  for (auto& item : selectedPayloads) {
+    metrics_.totalBytesToEvict += item.payload->rawSize();
+    RETURN_NOT_OK(partitionWriter_->hashEvict(item.pid, std::move(item.payload), Evict::kSpill, false, writtenBytes_));
+  }
+  return beforeEvict - partitionBufferPool_->bytes_allocated();
 }
 
 bool VeloxHashShuffleWriter::shrinkPartitionBuffersAfterSpill() const {

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -1505,39 +1505,35 @@ arrow::Result<int64_t> VeloxHashShuffleWriter::evictPartitionBuffersMinSize(int6
   // shrinking is not enough. In this case partitionBufferSize_ == partitionBufferBase_
   VELOX_CHECK(!partitionBufferInUse_);
   int64_t beforeEvict = partitionBufferPool_->bytes_allocated();
-  std::vector<std::pair<uint32_t, uint32_t>> pidToSize;
+  const auto partitionBytes = estimatePartitionBufferBytes();
+  std::vector<std::pair<uint32_t, int64_t>> pidToSize;
   for (auto pid = 0; pid < numPartitions_; ++pid) {
     if (partitionBufferSize_[pid] == 0) {
       continue;
     }
-    pidToSize.emplace_back(pid, partitionBufferSize_[pid]);
+    pidToSize.emplace_back(pid, partitionBytes[pid]);
   }
   std::sort(pidToSize.begin(), pidToSize.end(), [&](const auto& a, const auto& b) { return a.second > b.second; });
 
-  struct PartitionPayload {
-    uint32_t pid;
-    std::unique_ptr<InMemoryPayload> payload;
-  };
-  std::vector<PartitionPayload> selectedPayloads;
+  std::vector<uint32_t> selectedPids;
   int64_t selectedBytes = 0;
   for (auto& item : pidToSize) {
-    auto pid = item.first;
-    ARROW_ASSIGN_OR_RAISE(auto buffers, assembleBuffers(pid, false));
-    auto* types = partitionWriter_->enableTypeAwareCompress() ? &tacBufferTypes_ : nullptr;
-    auto payload = std::make_unique<InMemoryPayload>(
-        item.second, &isValidityBuffer_, schema_, std::move(buffers), hasComplexType_, types);
-    selectedBytes += payload->rawCapacity();
-    selectedPayloads.push_back({pid, std::move(payload)});
+    selectedPids.push_back(item.first);
+    selectedBytes += item.second;
     if (selectedBytes >= size) {
       break;
     }
   }
 
-  std::sort(
-      selectedPayloads.begin(), selectedPayloads.end(), [](const auto& a, const auto& b) { return a.pid < b.pid; });
-  for (auto& item : selectedPayloads) {
-    metrics_.totalBytesToEvict += item.payload->rawSize();
-    RETURN_NOT_OK(partitionWriter_->hashEvict(item.pid, std::move(item.payload), Evict::kSpill, false, writtenBytes_));
+  std::sort(selectedPids.begin(), selectedPids.end());
+  for (auto pid : selectedPids) {
+    auto numRows = partitionBufferBase_[pid];
+    ARROW_ASSIGN_OR_RAISE(auto buffers, assembleBuffers(pid, false));
+    auto* types = partitionWriter_->enableTypeAwareCompress() ? &tacBufferTypes_ : nullptr;
+    auto payload = std::make_unique<InMemoryPayload>(
+        numRows, &isValidityBuffer_, schema_, std::move(buffers), hasComplexType_, types);
+    metrics_.totalBytesToEvict += payload->rawSize();
+    RETURN_NOT_OK(partitionWriter_->hashEvict(pid, std::move(payload), Evict::kSpill, false, writtenBytes_));
   }
   return beforeEvict - partitionBufferPool_->bytes_allocated();
 }

--- a/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
+++ b/cpp/velox/shuffle/VeloxHashShuffleWriter.cc
@@ -1533,9 +1533,8 @@ arrow::Result<int64_t> VeloxHashShuffleWriter::evictPartitionBuffersMinSize(int6
     }
   }
 
-  std::sort(selectedPayloads.begin(), selectedPayloads.end(), [](const auto& a, const auto& b) {
-    return a.pid < b.pid;
-  });
+  std::sort(
+      selectedPayloads.begin(), selectedPayloads.end(), [](const auto& a, const auto& b) { return a.pid < b.pid; });
   for (auto& item : selectedPayloads) {
     metrics_.totalBytesToEvict += item.payload->rawSize();
     RETURN_NOT_OK(partitionWriter_->hashEvict(item.pid, std::move(item.payload), Evict::kSpill, false, writtenBytes_));

--- a/cpp/velox/tests/VeloxShuffleWriterSpillTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterSpillTest.cc
@@ -208,8 +208,8 @@ TEST_F(VeloxHashShuffleWriterSpillTest, spillPartitionBuffersInPidOrder) {
   auto shuffleWriter =
       createHashShuffleWriter(8, shuffleWriterOptions, nullptr, arrow::Compression::type::UNCOMPRESSED);
 
-  // pid 4 gets a larger partition buffer than pid 1. Size-based eviction chooses pid 4 first, so the local
-  // partition writer must split spills before writing pid 1.
+  // pid 4 gets a larger partition buffer than pid 1. Size-based eviction chooses pid 4 first, but the selected
+  // payloads must still be written to local spill files in pid order.
   auto input = makeRowVector({
       makeFlatVector<int32_t>({4, 4, 4, 4, 4, 4, 4, 4, 1}),
       makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8}),

--- a/cpp/velox/tests/VeloxShuffleWriterSpillTest.cc
+++ b/cpp/velox/tests/VeloxShuffleWriterSpillTest.cc
@@ -201,6 +201,30 @@ TEST_F(VeloxHashShuffleWriterSpillTest, kInit) {
   ASSERT_NOT_OK(shuffleWriter->stop());
 }
 
+TEST_F(VeloxHashShuffleWriterSpillTest, spillPartitionBuffersInPidOrder) {
+  auto shuffleWriterOptions = std::make_shared<HashShuffleWriterOptions>();
+  shuffleWriterOptions->partitioning = Partitioning::kRange;
+  shuffleWriterOptions->splitBufferSize = 4;
+  auto shuffleWriter =
+      createHashShuffleWriter(8, shuffleWriterOptions, nullptr, arrow::Compression::type::UNCOMPRESSED);
+
+  // pid 4 gets a larger partition buffer than pid 1. Size-based eviction chooses pid 4 first, so the local
+  // partition writer must split spills before writing pid 1.
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>({4, 4, 4, 4, 4, 4, 4, 4, 1}),
+      makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8}),
+  });
+
+  ASSERT_NOT_OK(splitRowVector(*shuffleWriter, input));
+
+  int64_t evicted;
+  ASSERT_NOT_OK(shuffleWriter->reclaimFixedSize(shuffleWriter->partitionBufferSize(), &evicted));
+  ASSERT_GT(evicted, 0);
+  ASSERT_EQ(shuffleWriter->partitionBufferSize(), 0);
+
+  ASSERT_NOT_OK(shuffleWriter->stop());
+}
+
 TEST_F(VeloxHashShuffleWriterSpillTest, kInitSingle) {
   auto shuffleWriterOptions = std::make_shared<HashShuffleWriterOptions>();
   shuffleWriterOptions->partitioning = Partitioning::kSingle;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Hash shuffle may write partition-buffer spill payloads to the same local spill file out of partition-id order.

After #10009, VeloxHashShuffleWriter::evictPartitionBuffersMinSize() sorts partition buffers by size before spilling, so the write order can become pid 4 -> pid 1. However, LocalPartitionWriter::mergeSpills() later merges spill files by scanning pids in ascending order, and Spill::nextPayload(pid) only consumes the queue head. If a lower pid appears after a higher pid in the same spill file, it can remain unmerged and fail during clearResource() with:
```
Native shuffle write: ShuffleWriter stop failed - Invalid:
Merging from spill N is not exhausted. pid: X
```
This pr keep the size-based eviction selection, but separate selection order from write order.

This change first selects partition IDs by estimated partition-buffer bytes until enough memory is selected for eviction, then sorts the selected IDs by pid before assembling and writing each payload to the local partition writer. This preserves the existing large-buffer-first eviction behavior while ensuring local spill files are written in the order required by the merge logic.

Materializing and evicting one selected partition at a time also avoids holding all selected InMemoryPayloads simultaneously, reducing peak memory usage during eviction.

The earlier fallback that split spill files in LocalPartitionWriter on pid wraparound is removed, since the hash writer now preserves pid order before writing.

## How was this patch tested?

UT. A regression test covers the case where a higher pid has a larger partition buffer than a lower pid.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: codex GPT-5.5


Related issue: #12235