### PR TITLE
[CORE] Optimize Iceberg schema field matching

### DIFF
--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.metric.SQLMetrics
 import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
 
-import org.apache.iceberg.{BaseTable, MetadataColumns, Schema, SnapshotSummary, TableProperties}
+import org.apache.iceberg.{BaseTable, MetadataColumns, SnapshotSummary, TableProperties}
 import org.apache.iceberg.avro.AvroSchemaUtil
 import org.apache.iceberg.spark.source.{GlutenIcebergSourceUtil, SparkTable}
 import org.apache.iceberg.spark.source.metrics.NumSplits
@@ -271,12 +271,12 @@ case class IcebergScanTransformer(
       case (iceberg: Types.StructType, currentType: Types.StructType, sparkStruct: StructType) =>
         sparkStruct.forall {
           sparkField =>
-            val currentField = new Schema(currentType.fields()).findField(sparkField.name)
+            val currentField = currentType.field(sparkField.name)
             // Find not exists column
             if (currentField == null) {
               false
             } else {
-              val field = new Schema(iceberg.fields()).findField(currentField.fieldId())
+              val field = iceberg.field(currentField.fieldId())
               // The field does not exist in old schema, add column case
               if (field == null) {
                 true


### PR DESCRIPTION
## What changes are proposed in this pull request?

Why this PR is needed?

In `IcebergScanTransformer.typesMatch()`, the struct type matching logic creates temporary Iceberg `Schema` objects for every Spark field:

```scala
new Schema(currentType.fields()).findField(...)
new Schema(iceberg.fields()).findField(...)
```

This repeatedly rebuilds Iceberg schema indexes while checking historical schemas, which can become expensive for wide schemas or tables with many schema versions. In production thread dumps, this shows up in `Schema` / `IndexByName` / `HashMap` initialization during Iceberg scan planning.
<img width="1792" height="1660" alt="image" src="https://github.com/user-attachments/assets/f61e1fff-73f0-446f-b975-85dfdeda335c" />


Changes in this PR:

This change uses `Types.StructType.field(name)` and `Types.StructType.field(id)` directly when matching nested struct fields.

`Types.StructType` already provides field lookup by name and id, so this avoids constructing temporary `Schema` objects inside the field loop while preserving the existing matching behavior:
- find the current field by Spark field name
- find the old schema field by Iceberg field id
- keep allowing added columns
- keep detecting renamed columns by comparing field names

## How was this patch tested?

Test with exist UT

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5