### PR TITLE
[VL] Bump FasterXML Jackson to 2.18.6 for Spark 3.5 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <scala.recompile.mode>all</scala.recompile.mode>
     <scala.release.version>${java.version}</scala.release.version>
     <!-- For unit tests -->
-    <fasterxml.version>2.15.0</fasterxml.version>
+    <fasterxml.version>2.18.6</fasterxml.version>
     <junit.version>4.13.1</junit.version>
     <!-- Maven version for build/mvn wrapper script -->
     <maven.version>3.9.16</maven.version>
@@ -1184,6 +1184,7 @@
         <delta.package.name>delta-core</delta.package.name>
         <delta.version>2.3.0</delta.version>
         <delta.binary.version>23</delta.binary.version>
+        <fasterxml.version>2.15.0</fasterxml.version>
         <antlr4.version>4.8</antlr4.version>
         <hadoop.version>3.3.2</hadoop.version>
         <hudi.version>0.15.0</hudi.version>
@@ -1210,6 +1211,7 @@
         <delta.package.name>delta-core</delta.package.name>
         <delta.version>2.4.0</delta.version>
         <delta.binary.version>24</delta.binary.version>
+        <fasterxml.version>2.15.0</fasterxml.version>
         <antlr4.version>4.9.3</antlr4.version>
         <hadoop.version>3.3.4</hadoop.version>
         <hudi.version>0.15.0</hudi.version>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
bump fasterxml.jackson.core to  2.18.6 to fix the security warning

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
