### PR TITLE
[CORE] Unbundle Arrow memory + vector from gluten-velox-bundle (Draft)

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -79,6 +79,24 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+    <!--
+      arrow-memory-core / arrow-vector are scope=provided in gluten-arrow so
+      they are not bundled. Re-declare them at provided scope here so the
+      compile classpath still resolves them. At runtime they come from
+      Spark's distribution.
+    -->
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-core</artifactId>
+      <version>${arrow.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>${arrow.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>

--- a/dev/build-arrow.sh
+++ b/dev/build-arrow.sh
@@ -31,7 +31,6 @@ function prepare_arrow_build() {
   #wget_and_untar https://archive.apache.org/dist/arrow/arrow-${VELOX_ARROW_BUILD_VERSION}/apache-arrow-${VELOX_ARROW_BUILD_VERSION}.tar.gz arrow_ep
   cd arrow_ep
   patch -p1 < $CURRENT_DIR/../ep/build-velox/src/modify_arrow.patch
-  patch -p1 < $CURRENT_DIR/../ep/build-velox/src/modify_arrow_dataset_scan_option.patch
   patch -p1 < $CURRENT_DIR/../ep/build-velox/src/cmake-compatibility.patch
   patch -p1 < $CURRENT_DIR/../ep/build-velox/src/support_ibm_power.patch
   popd
@@ -97,8 +96,6 @@ function build_arrow_java() {
     export CMAKE_BUILD_PARALLEL_LEVEL=$NPROC
 
     pushd $ARROW_PREFIX/java
-    # Because arrow-bom module need the -DprocessAllModules
-    ${MVN_CMD} versions:set -DnewVersion=15.0.0-gluten -DprocessAllModules
 
     ${MVN_CMD} clean install -pl bom,maven/module-info-compiler-maven-plugin,vector -am \
           -DskipTests -Drat.skip -Dmaven.gitcommitid.skip -Dcheckstyle.skip -Dassembly.skipAssembly

--- a/gluten-arrow/pom.xml
+++ b/gluten-arrow/pom.xml
@@ -88,13 +88,13 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>${arrow-memory.artifact}</artifactId>
-      <version>${arrow-gluten.version}</version>
+      <version>${arrow.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>
-      <version>${arrow-gluten.version}</version>
+      <version>${arrow.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
-      <version>${arrow-gluten.version}</version>
+      <version>${arrow.version}</version>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-c-data</artifactId>
-      <version>${arrow-gluten.version}</version>
+      <version>${arrow.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-dataset</artifactId>
-      <version>${arrow-gluten.version}</version>
+      <version>${arrow.version}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/gluten-arrow/pom.xml
+++ b/gluten-arrow/pom.xml
@@ -85,17 +85,24 @@
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!--
+      Arrow memory + vector come from Spark's distribution (declared in Spark
+      4.x's pom; bundled in $SPARK_HOME/jars/ for Spark 3.x). gluten compiles
+      against the same arrow.version it expects at runtime, but the artifacts
+      are scope=provided so they are NOT bundled into gluten-velox-bundle —
+      avoiding the #12225 class-shadowing problem entirely.
+    -->
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>${arrow-memory.artifact}</artifactId>
       <version>${arrow.version}</version>
-      <scope>runtime</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory-core</artifactId>
       <version>${arrow.version}</version>
-      <scope>compile</scope>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>
@@ -111,6 +118,7 @@
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
       <version>${arrow.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -118,28 +118,15 @@
                     <include>com.google.gson.**</include>
                   </includes>
                 </relocation>
-                <relocation>
-                  <pattern>org.apache.arrow</pattern>
-                  <shadedPattern>${gluten.shade.packageName}.org.apache.arrow</shadedPattern>
-                  <!--
-                    arrow's C and dataset wrappers refer to the original class
-                    path, so they must not be relocated. Their public APIs also
-                    take and return org.apache.arrow.memory.* and
-                    org.apache.arrow.vector.* types, so those packages must also
-                    stay unshaded — otherwise the bundled (unshaded)
-                    ArrowArrayStream/ArrowSchema get compiled against the
-                    relocated BufferAllocator/VectorSchemaRoot, producing
-                    `NoSuchMethodError` for any caller passing a vanilla
-                    Apache Arrow allocator. See #12225.
-                  -->
-                  <excludes>
-                    <exclude>org.apache.arrow.c.*</exclude>
-                    <exclude>org.apache.arrow.c.jni.*</exclude>
-                    <exclude>org.apache.arrow.memory.**</exclude>
-                    <exclude>org.apache.arrow.vector.**</exclude>
-                    <exclude>org.apache.arrow.dataset.**</exclude>
-                  </excludes>
-                </relocation>
+                <!--
+                  org.apache.arrow.memory.* and org.apache.arrow.vector.* are
+                  now scope=provided in gluten-arrow/pom.xml — they come from
+                  Spark's distribution at runtime, so there is nothing to
+                  relocate. arrow-c-data and arrow-dataset are still bundled
+                  but never relocated (their JNI binds to the original class
+                  names), so no shade-relocation entry is needed for Arrow.
+                  See #12225 / #12226 for the historical context.
+                -->
                 <relocation>
                   <pattern>com.google.flatbuffers</pattern>
                   <shadedPattern>${gluten.shade.packageName}.com.google.flatbuffers</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
     <celeborn.version>0.6.3</celeborn.version>
     <uniffle.version>0.10.0</uniffle.version>
     <arrow.version>15.0.0</arrow.version>
-    <arrow-gluten.version>15.0.0-gluten</arrow-gluten.version>
     <arrow-memory.artifact>arrow-memory-unsafe</arrow-memory.artifact>
     <hadoop.version>2.7.4</hadoop.version>
     <antlr4.version>4.9.3</antlr4.version>
@@ -1285,7 +1284,6 @@
         <log4j.version>2.24.3</log4j.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <arrow.version>18.1.0</arrow.version>
-        <arrow-gluten.version>18.1.0</arrow-gluten.version>
         <scala.compiler.version>4.9.2</scala.compiler.version>
       </properties>
       <dependencies>
@@ -1365,7 +1363,6 @@
         <log4j.version>2.24.3</log4j.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <arrow.version>18.1.0</arrow.version>
-        <arrow-gluten.version>18.1.0</arrow-gluten.version>
         <scala.compiler.version>4.9.5</scala.compiler.version>
       </properties>
       <dependencies>


### PR DESCRIPTION
**Draft.** Stacked on #12244. The diff below is what the unbundle looks like in pom-form; cross-distro testing (vanilla 3.5, DBR 16.4, Cloudera, 4.0/4.1) is still TODO and gates merge.

## What changes were proposed in this pull request?

Stop bundling \`arrow-memory-*\` and \`arrow-vector\` in \`gluten-velox-bundle\`. Mark them as \`scope=provided\` in \`gluten-arrow/pom.xml\` and rely on Spark's own Arrow distribution at runtime (\`\$SPARK_HOME/jars/\` for Spark 3.x; declared in Spark 4.x's pom).

\`arrow-c-data\` and \`arrow-dataset\` stay bundled — Spark does not ship those.

## Why

Follow-up from #12226 discussion. The bundled-and-shaded-Arrow approach is the source of #12225 (and similar #7423): when gluten's bundle wins classloader resolution, its class signatures collide with the user's vanilla Arrow. #12226 fixed the immediate \`NoSuchMethodError\` by un-shading; but as @zhztheplayer noted, "Memory and vector APIs should be stable across minor versions" is a real risk worth eliminating: the cleanest fix is to not ship them at all.

Effects:
* gluten-velox-bundle no longer contains any \`org.apache.arrow.memory.*\` or \`org.apache.arrow.vector.*\` classes. Class-shadowing from #12225 disappears by construction.
* The \`org.apache.arrow\` shade-relocation block in \`package/pom.xml\` is removed (nothing to relocate, since memory/vector aren't bundled and c-data/dataset were already excluded).
* \`arrow-c-data\` / \`arrow-dataset\` remain bundled. With no relocation, their public API signatures bind to vanilla \`BufferAllocator\` / \`VectorSchemaRoot\` — exactly what every other Arrow C-Data caller on the classpath expects.
* \`backends-velox/pom.xml\` re-declares \`arrow-memory-core\` and \`arrow-vector\` at \`provided\` scope so its compile classpath still resolves them after the gluten-arrow scope flip. \`gluten-ut/*\` and \`backends-clickhouse\` already declare them locally.

## Open questions / why this is a Draft

1. **\`arrow.version\` pin per Spark distro.** \`<arrow.version>15.0.0</arrow.version>\` matches vanilla Spark 3.5.x. DBR 16.4 ships Spark 3.5 with Arrow 12.0.1 — gluten compiled against 15 might \`NoSuchMethodError\` on DBR. Need to either (a) downgrade to LCD 12.0.1 for the Spark-3.5 profile, or (b) add a DBR-specific profile, or (c) declare gluten as DBR-incompatible. Cloudera flavors need similar verification.
2. **Cross-distro test matrix.** Want to actually run the gluten test suite against vanilla 3.5, DBR 16.4, Cloudera CDS, and 4.0/4.1 before merging. CI here only covers vanilla.
3. **Velox C++ side still uses bundled Arrow.** The cpp side links its own Arrow (the C++ patches in \`ep/build-velox/src/modify_arrow.patch\`); this PR only changes JVM-side bundling. The JVM ↔ C++ exchange happens via Arrow C-Data's stable ABI, so the JVM-side Arrow version doesn't need to match the C++-side one. Worth noting in case anyone assumes they should track.
4. \`dev/check-arrow-c-shading.sh\` from #12226 still passes — bundle still has \`org/apache/arrow/c/*\` and their signatures now reference unshaded \`memory.*\` / \`vector.*\` types (which resolve from Spark's bundled Arrow at runtime).

## How was this patch tested?

Local build only. CI green needed before un-drafting.

## Closes / refs

* Follow-up from #12226 discussion (zhztheplayer + FelixYBW asked for this direction).
* Subsumes the immediate need for #12226's \`dev/check-arrow-c-shading.sh\` if the bundle fully stops containing memory/vector classes — but the script remains useful as a regression guard for the c-data classes still in the bundle.

Stacked on:
* #12244 — drop the \`15.0.0-gluten\` Arrow version rename