### PR TITLE
[DOC] Mark map_from_entries as supported in Velox backend

### DIFF
--- a/docs/velox-backend-scalar-function-support.md
+++ b/docs/velox-backend-scalar-function-support.md
@@ -212,7 +212,7 @@
 | map_contains_key  | MapContainsKey      | S        |                                                                             |
 | map_entries       | MapEntries          | S        |                                                                             |
 | map_from_arrays   | MapFromArrays       |          |                                                                             |
-| map_from_entries  | MapFromEntries      |          |                                                                             |
+| map_from_entries  | MapFromEntries      | S        | Converts array of struct(key, value) pairs to map                           |
 | map_keys          | MapKeys             | S        |                                                                             |
 | map_values        | MapValues           | S        |                                                                             |
 | str_to_map        | StringToMap         | PS       | Only spark.sql.mapKeyDedupPolicy = EXCEPTION is supported for Velox backend |


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Update documentation to reflect that `map_from_entries` function is now supported in Velox backend. This change was added as part of https://github.com/apache/gluten/pull/8731

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
Doc Changes Only

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No