### PR TITLE
[VL] Make Velox memory manager capacity ratio configurable

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -42,6 +42,9 @@ const std::string kIgnoreMissingFiles = "spark.sql.files.ignoreMissingFiles";
 
 const std::string kSparkOverheadMemory = "spark.gluten.memoryOverhead.size.in.bytes";
 
+const std::string kMemoryManagerCapacityRatio = "spark.gluten.memory.manager.capacity.ratio";
+const double kMemoryManagerCapacityRatioDefault = 0.75;
+
 const std::string kSparkOffHeapMemory = "spark.gluten.memory.offHeap.size.in.bytes";
 
 const std::string kSparkTaskOffHeapMemory = "spark.gluten.memory.task.offHeap.size.in.bytes";

--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -228,9 +228,19 @@ void VeloxBackend::init(
   auto sparkOverhead = backendConf_->get<int64_t>(kSparkOverheadMemory);
   int64_t memoryManagerCapacity;
   if (sparkOverhead.has_value()) {
-    // 0.75 * total overhead memory is used for Velox global memory manager.
-    // FIXME: Make this configurable.
-    memoryManagerCapacity = sparkOverhead.value() * 0.75;
+    // Get configurable ratio for Velox global memory manager capacity
+    auto capacityRatio = backendConf_->get<double>(kMemoryManagerCapacityRatio);
+    double ratio = capacityRatio.has_value() ? capacityRatio.value() : kMemoryManagerCapacityRatioDefault;
+
+    if (ratio <= 0.0 || ratio > 1.0) {
+      LOG(WARNING) << "Invalid memory manager capacity ratio: " << ratio
+                   << ". Using default: " << kMemoryManagerCapacityRatioDefault;
+      ratio = kMemoryManagerCapacityRatioDefault;
+    }
+
+    memoryManagerCapacity = static_cast<int64_t>(sparkOverhead.value() * ratio);
+    LOG(INFO) << "Using memory manager capacity ratio: " << ratio << " (overhead: " << sparkOverhead.value()
+              << ", capacity: " << memoryManagerCapacity << ")";
   } else {
     memoryManagerCapacity = facebook::velox::memory::kMaxMemory;
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -1251,6 +1251,18 @@ object GlutenConfig extends ConfigRegistry {
       .booleanConf
       .createWithDefault(false)
 
+  val MEMORY_MANAGER_CAPACITY_RATIO =
+    buildConf("spark.gluten.memory.manager.capacity.ratio")
+      .internal()
+      .doc(
+        "Ratio of spark.gluten.memoryOverhead.size.in.bytes to allocate for Velox global " +
+          "memory manager. The memory manager is used during spill operations.")
+      .doubleConf
+      .checkValue(
+        ratio => ratio > 0.0 && ratio <= 1.0,
+        "Memory manager capacity ratio must be between 0.0 and 1.0")
+      .createWithDefault(0.75)
+
   val TRANSFORM_PLAN_LOG_LEVEL =
     buildConf("spark.gluten.sql.transform.logLevel")
       .internal()

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/config/GlutenRuntimeConfigSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/config/GlutenRuntimeConfigSuite.scala
@@ -47,4 +47,19 @@ class GlutenRuntimeConfigSuite extends GlutenQueryTest with SharedSparkSession {
       conf.set(key, original)
     }
   }
+
+  test("Memory manager capacity ratio config validation") {
+
+    assert(GlutenConfig.MEMORY_MANAGER_CAPACITY_RATIO.defaultValue.get == 0.75)
+
+    withSQLConf(GlutenConfig.MEMORY_MANAGER_CAPACITY_RATIO.key -> "0.8") {
+      assert(GlutenConfig.get.getConf(GlutenConfig.MEMORY_MANAGER_CAPACITY_RATIO) == 0.8)
+    }
+
+    intercept[IllegalArgumentException] {
+      withSQLConf(GlutenConfig.MEMORY_MANAGER_CAPACITY_RATIO.key -> "1.5") {
+        GlutenConfig.get.getConf(GlutenConfig.MEMORY_MANAGER_CAPACITY_RATIO)
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->
This PR makes the Velox memory manager capacity ratio configurable, Previously, the memory manager capacity was hardcoded to use 75% (0.75) of the Spark overhead memory. This PR introduces a new configuration parameter `spark.gluten.memory.manager.capacity.ratio` that allows users to tune this ratio based on their workload characteristics.

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
New test case added for validation

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No