### PR TITLE
[VL] Fix gflags mode in folly on Centos9

### DIFF
--- a/.github/workflows/velox_backend_arm.yml
+++ b/.github/workflows/velox_backend_arm.yml
@@ -150,7 +150,6 @@ jobs:
       - name: Build Gluten native libraries
         run: |
           df -a
-          sed -i "s|gflags_static|gflags_shared|g" /usr/local/lib/cmake/folly/folly-targets.cmake # TODO: remove after upgrading folly to 2024.09.30 or later which has fixed the gflags linkage issue
           bash dev/ci-velox-buildshared-centos-9.sh
           ccache -s
       - name: Run CPP unit test

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -1181,7 +1181,6 @@ jobs:
       - name: Build Gluten native libraries
         run: |
           df -a
-          sed -i "s|gflags_static|gflags_shared|g" /usr/local/lib/cmake/folly/folly-targets.cmake # TODO remove after image update
           bash dev/ci-velox-buildshared-centos-9.sh
           ccache -s
       - name: Run CPP unit test

--- a/dev/docker/Dockerfile.centos8-dynamic-build
+++ b/dev/docker/Dockerfile.centos8-dynamic-build
@@ -51,6 +51,7 @@ RUN set -ex; \
     fi; \
     cd /opt/gluten; \
     source /opt/rh/gcc-toolset-11/enable; \
+    export VELOX_BUILD_SHARED=ON; \
     ./dev/builddeps-veloxbe.sh --run_setup_script=ON build_arrow; \
     ./build/mvn dependency:go-offline -Pbackends-velox -Piceberg -Pdelta -Pspark-3.5 -DskipTests; \
     dnf clean all; \

--- a/dev/docker/Dockerfile.centos9-dynamic-build
+++ b/dev/docker/Dockerfile.centos9-dynamic-build
@@ -47,6 +47,7 @@ RUN set -ex; \
     fi; \
     cd /opt/gluten; \
     source /opt/rh/gcc-toolset-12/enable; \
+    export VELOX_BUILD_SHARED=ON; \
     ./dev/builddeps-veloxbe.sh --run_setup_script=ON build_arrow; \
     ./build/mvn dependency:go-offline -Pbackends-velox -Piceberg -Pdelta -Pspark-3.5 -DskipTests; \
     dnf clean all; \

--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -69,7 +69,6 @@ function process_setup_ubuntu {
 }
 
 function process_setup_centos9 {
-  sed -i "s|-DGFLAGS_SHARED=FALSE|-DGFLAGS_SHARED=TRUE|g" scripts/setup-common.sh
   echo "Using setup script from Velox"
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Remove the workaround for folly gflags mode on centos9 image introduced in https://github.com/apache/gluten/pull/12223

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
pass GHA

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
