### PR TITLE
[GLUTEN-12266][FLINK] Fix UnsatisfiedLinkError when IN predicate uses strin…

### DIFF
--- a/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/RexNodeConverter.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/RexNodeConverter.java
@@ -23,6 +23,7 @@ import org.apache.gluten.util.LogicalTypeConverter;
 import io.github.zhztheplayer.velox4j.expression.ConstantTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.FieldAccessTypedExpr;
 import io.github.zhztheplayer.velox4j.expression.TypedExpr;
+import io.github.zhztheplayer.velox4j.type.ArrayType;
 import io.github.zhztheplayer.velox4j.type.Type;
 import io.github.zhztheplayer.velox4j.variant.ArrayValue;
 import io.github.zhztheplayer.velox4j.variant.BigIntValue;
@@ -144,7 +145,7 @@ public class RexNodeConverter {
       values.add(toVariant(range.lowerEndpoint(), relDataType.getSqlTypeName()));
     }
     Variant arrayValue = new ArrayValue(values);
-    return ConstantTypedExpr.create(arrayValue);
+    return new ConstantTypedExpr(ArrayType.create(toType(relDataType)), arrayValue, null);
   }
 
   public static List<TypedExpr> toTypedExpr(Range range, RelDataType relDataType) {
@@ -164,6 +165,9 @@ public class RexNodeConverter {
       case INTEGER:
         return new IntegerValue(((BigDecimal) comparable).intValue());
       case VARCHAR:
+        if (comparable instanceof NlsString) {
+          return new VarCharValue(((NlsString) comparable).getValue());
+        }
         return new VarCharValue(comparable.toString());
       case CHAR:
         return new VarCharValue(((NlsString) comparable).getValue());


### PR DESCRIPTION
related issue: #12266 

## What changes are proposed in this pull request?

Fix two bugs in `RexNodeConverter.java` that break IN predicate with string values in Gluten-Flink planner.

`ConstantTypedExpr.create(Variant)` calls `StaticJniApi.variantInferType()` via JNI to infer type, but the planner runs in SQL client process where native library is not loaded, causing `UnsatisfiedLinkError`. The type is already available from `relDataType`, so we use the 3-arg constructor to pass it directly.

`NlsString.toString()` returns SQL display format (e.g. `"_UTF-16LE'apple'"`) instead of raw string, causing the serialized IN list to contain malformed values that never match. Fix by checking `instanceof NlsString` and calling `getValue()`.

Note: A companion fix in velox4j is also needed for `REGEXP_EXTRACT` returning empty string instead of NULL on no match. See [bigo-sg/velox4j #31](https://github.com/bigo-sg/velox4j/pull/31).

## How was this patch tested?

Manual test. Tested by running Nexmark Q21 on Gluten-Flink with 10000 events. Previously crashed at submission with `UnsatisfiedLinkError`. After this fix, the query submits successfully and produces correct results (8754 output rows matching Flink native execution).

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
