### PR TITLE
[CORE] Fix UnsupportedOperationException in input_file_name() with broadcast join build-side LocalRelation

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -1077,6 +1077,50 @@ abstract class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  test("input_file_name() with BHJ build-side LocalRelation must return real path") {
+    withTempPath {
+      path =>
+        Seq(("event_a", 1001L, "param1"))
+          .toDF("event", "device_id", "params")
+          .write
+          .parquet(path.getCanonicalPath)
+        spark.read.parquet(path.getCanonicalPath).createOrReplaceTempView("event_log")
+
+        withSQLConf(
+          "spark.sql.autoBroadcastJoinThreshold" -> "10MB",
+          "spark.sql.adaptive.enabled" -> "true"
+        ) {
+          val sql =
+            """
+              |SELECT  a.event,
+              |        a.params,
+              |        a.device_id,
+              |        input_file_name() AS fname
+              |FROM    event_log a
+              |JOIN
+              |        (
+              |            SELECT  'event_a' AS envent,
+              |                    1001 AS device_id
+              |        ) b
+              |ON      a.event     = b.envent
+              |AND     a.device_id = b.device_id
+              |""".stripMargin
+
+          compareResultsAgainstVanillaSpark(sql, true, { _ => })
+
+          val df = spark.sql(sql)
+          val rows = df.collect()
+          assert(rows.nonEmpty, "Join should match at least one row")
+          rows.foreach {
+            r =>
+              val fname = r.getAs[String]("fname")
+              assert(fname != null && fname.nonEmpty)
+              assert(fname.contains(path.getName))
+          }
+        }
+    }
+  }
+
   testWithMinSparkVersion("array insert", "3.4") {
     withTempPath {
       path =>

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PushDownInputFileExpression.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/PushDownInputFileExpression.scala
@@ -21,7 +21,8 @@ import org.apache.gluten.execution.{BatchScanExecTransformerBase, FileSourceScan
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, NamedExpression}
 import org.apache.spark.sql.catalyst.optimizer.CollapseProjectShim
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{DeserializeToObjectExec, LeafExecNode, ProjectExec, SerializeFromObjectExec, SparkPlan, UnionExec}
+import org.apache.spark.sql.execution.{DeserializeToObjectExec, FileSourceScanExec, LeafExecNode, ProjectExec, SerializeFromObjectExec, SparkPlan, UnionExec}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
 
 import java.util.Locale
@@ -87,7 +88,8 @@ object PushDownInputFileExpression {
 
   object PreOffload extends Rule[SparkPlan] {
     override def apply(plan: SparkPlan): SparkPlan = plan.transformUp {
-      case ProjectExec(projectList, child) if projectList.exists(containsInputFileRelatedExpr) =>
+      case ProjectExec(projectList, child)
+          if projectList.exists(containsInputFileRelatedExpr) && hasInputFileRelatedSource(child) =>
         val replacedExprs = mutable.Map[String, Alias]()
         val newProjectList = projectList.map {
           expr => rewriteExpr(expr, replacedExprs).asInstanceOf[NamedExpression]
@@ -104,8 +106,10 @@ object PushDownInputFileExpression {
           // For BatchScanExecTransformerBase (includes Iceberg scans), add fallback tag
           // to prevent offloading when input_file expressions are present
           addFallbackTag(ProjectExec(p.output ++ replacedExprs.values, p))
-        case p: LeafExecNode =>
+        case p: LeafExecNode if shouldAddInputFileExpr(p) =>
           addFallbackTag(ProjectExec(p.output ++ replacedExprs.values, p))
+        case p: LeafExecNode =>
+          p
         // Output of SerializeFromObjectExec's child and output of DeserializeToObjectExec must be
         // a single-field row.
         case p @ (_: SerializeFromObjectExec | _: DeserializeToObjectExec) =>
@@ -127,6 +131,23 @@ object PushDownInputFileExpression {
           u.copy(children = newFirstChild +: newOtherChildren)
         case p => p.withNewChildren(p.children.map(child => addMetadataCol(child, replacedExprs)))
       }
+
+    private def hasInputFileRelatedSource(plan: SparkPlan): Boolean = {
+      plan match {
+        case _: BatchScanExecTransformerBase => true
+        case p: LeafExecNode => shouldAddInputFileExpr(p)
+        case _ => plan.children.exists(hasInputFileRelatedSource)
+      }
+    }
+
+    private def shouldAddInputFileExpr(plan: SparkPlan): Boolean = {
+      plan match {
+        case _: FileSourceScanExec => true
+        case _: BatchScanExec => true
+        case p if HiveTableScanExecTransformer.isHiveTableScan(p) => true
+        case _ => false
+      }
+    }
   }
 
   object PostOffload extends Rule[SparkPlan] {


### PR DESCRIPTION
## Problem

The newly added ut failed: 
```
java.lang.UnsupportedOperationException: WholeStageCodegen (3) does not implement doExecuteBroadcast
  at org.apache.spark.sql.errors.QueryExecutionErrors$.doExecuteBroadcastNotImplementedError(QueryExecutionErrors.scala:1942)
  at org.apache.spark.sql.execution.SparkPlan.doExecuteBroadcast(SparkPlan.scala:312)
  ...
  at org.apache.gluten.execution.RowToVeloxColumnarExec.doExecuteBroadcast(RowToVeloxColumnarExec.scala:76)
  at org.apache.spark.sql.execution.ColumnarInputAdapter.doExecuteBroadcast(ColumnarCollapseTransformStages.scala:207)
  at org.apache.spark.sql.execution.InputIteratorTransformer.doExecuteBroadcast(ColumnarCollapseTransformStages.scala:72)
  ...
  at org.apache.gluten.execution.VeloxBroadcastNestedLoopJoinExecTransformer.columnarInputRDDs(VeloxBroadcastNestedLoopJoinExecTransformer.scala:47)
```

## Root cause

`PushDownInputFileExpression.PreOffload` originally injects `Project [..., input_file_name() AS attr#N]` above **every** `LeafExecNode` (with a fallback tag).

When the broadcast build side is a non-file leaf (e.g. `LocalTableScanExec` from a constant subquery), the rule still wraps that leaf with a fallback `ProjectExec`. This forces vanilla Spark to wrap the subtree in `WholeStageCodegen` for the broadcast side. Down the road, `VeloxBroadcastNestedLoopJoinExecTransformer.columnarInputRDDs` → `InputIteratorTransformer.doExecuteBroadcast` → `RowToVeloxColumnarExec.doExecuteBroadcast` → `child.executeBroadcast` ends up calling `WholeStageCodegenExec.doExecuteBroadcast`, which is not implemented, hence `UnsupportedOperationException`.

In short: the rule was injecting `input_file_name()` on leaves that *cannot* produce a real file name in the first place (they have no `InputFileBlockHolder` context), and the resulting fallback Project changes the operator shape on the broadcast side so the broadcast pipeline can no longer be executed.

## Fix

Limit the rewrite to leaves that can actually populate `InputFileBlockHolder`:

- `FileSourceScanExec`
- v2 `BatchScanExec`
- Hive table scan (`HiveTableScanExecTransformer.isHiveTableScan`)
- `BatchScanExecTransformerBase` (already special-cased in community for Iceberg etc.)

In addition, the `ProjectExec` match in `PreOffload` now requires that the subtree actually contains at least one such file-aware source via the new `hasInputFileRelatedSource` helper. Other leaves (`LocalTableScanExec`, `RangeExec`, `RDDScanExec`, ...) are left untouched, so the broadcast build side keeps its original shape and the `doExecuteBroadcast` path no longer terminates at `WholeStageCodegen`.

As a nice side effect, this also avoids producing a fake empty `input_file_name` attribute on non-file leaves, which previously could collide with a real file scan's ExprId on the other side of the join and silently return an empty file name.

## Test

Added `input_file_name() with BHJ build-side LocalRelation must return real path` in `backends-velox` `ScalarFunctionsValidateSuite`, which reproduces the failing scenario (parquet table broadcast-joined with a literal subquery, projecting `input_file_name()`) and asserts:

- The query runs without `UnsupportedOperationException`.
- Result matches vanilla Spark via `compareResultsAgainstVanillaSpark`.
- Each row's `fname` is non-empty and contains the real parquet path.

The existing `test("input_file_name")` (file/Hive scan paths) is unchanged because those scans remain in the whitelist.
