### PR TITLE
[GLUTEN-12339][FLINK] Bind native callback target for Gluten operators

### DIFF
--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/api/operators/GlutenOperator.java
@@ -17,7 +17,6 @@
 package org.apache.gluten.streaming.api.operators;
 
 import org.apache.gluten.table.runtime.operators.GlutenMailboxHolder;
-import org.apache.gluten.table.runtime.operators.GlutenSessionResources;
 
 import io.github.zhztheplayer.velox4j.plan.StatefulPlanNode;
 import io.github.zhztheplayer.velox4j.type.RowType;
@@ -62,19 +61,6 @@ public interface GlutenOperator {
 
   default void scheduleDrainOnMailbox(Runnable drainAction) {
     mailboxHolder().get().scheduleDrain(drainAction);
-  }
-
-  /**
-   * Called from native Velox code to drain operator output. Drain is always scheduled on the Flink
-   * task mailbox thread.
-   */
-  static void processElementByJni(String operatorId) {
-    GlutenOperator operator =
-        GlutenSessionResources.getInstance().getOperator(operatorId).orElse(null);
-    if (operator == null) {
-      throw new IllegalArgumentException("Operator not found: " + operatorId);
-    }
-    operator.scheduleProcessElementOnMailbox();
   }
 
   /** Schedules native output drain on the mailbox thread. Implemented by concrete operators. */

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenCloseables.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenCloseables.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.table.runtime.operators;
+
+final class GlutenCloseables {
+
+  private GlutenCloseables() {}
+
+  static void runWithCleanup(CloseAction... actions) throws Exception {
+    Exception failure = null;
+    for (CloseAction action : actions) {
+      try {
+        action.close();
+      } catch (Exception e) {
+        if (failure == null) {
+          failure = e;
+        } else {
+          failure.addSuppressed(e);
+        }
+      }
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  interface CloseAction {
+    void close() throws Exception;
+  }
+}

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
@@ -31,6 +31,7 @@ import io.github.zhztheplayer.velox4j.plan.TableScanNode;
 import io.github.zhztheplayer.velox4j.query.Query;
 import io.github.zhztheplayer.velox4j.query.SerialTask;
 import io.github.zhztheplayer.velox4j.serde.Serde;
+import io.github.zhztheplayer.velox4j.stateful.NativeCallbackTarget;
 import io.github.zhztheplayer.velox4j.stateful.StatefulElement;
 import io.github.zhztheplayer.velox4j.stateful.StatefulRecord;
 import io.github.zhztheplayer.velox4j.stateful.StatefulWatermark;
@@ -49,7 +50,7 @@ import java.util.Map;
 
 /** Calculate operator in gluten, which will call Velox to run. */
 public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
-    implements OneInputStreamOperator<IN, OUT>, GlutenOperator {
+    implements OneInputStreamOperator<IN, OUT>, GlutenOperator, NativeCallbackTarget {
 
   private final StatefulPlanNode glutenPlan;
   private final String id;
@@ -143,6 +144,7 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
             VeloxQueryConfig.getConfig(getRuntimeContext()),
             VeloxConnectorConfig.getConfig(getRuntimeContext()));
     task = sessionResource.getSession().queryOps().execute(query);
+    task.bindNativeCallbackTarget(this);
     task.addSplit(
         id, new ExternalStreamConnectorSplit("connector-external-stream", inputQueue.id()));
     task.noMoreSplits(id);
@@ -184,6 +186,11 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
   @Override
   public void scheduleProcessElementOnMailbox() {
     scheduleDrainOnMailbox(this::drainTaskOutput);
+  }
+
+  @Override
+  public void onProcessElement() {
+    scheduleProcessElementOnMailbox();
   }
 
   @Override

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
@@ -245,7 +245,11 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
   @Override
   public void close() throws Exception {
     if (task != null) {
-      task.close();
+      try {
+        task.unbindNativeCallbackTarget();
+      } finally {
+        task.close();
+      }
     }
     if (inputQueue != null) {
       inputQueue.noMoreInput();

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
@@ -189,7 +189,7 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
   }
 
   @Override
-  public void onProcessElement() {
+  public void onProcessingTime(long timestamp) {
     scheduleProcessElementOnMailbox();
   }
 

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
@@ -120,7 +120,6 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
     }
     sessionResource = new GlutenSessionResource();
     GlutenSessionResources.getInstance().addSessionResource(id, sessionResource);
-    GlutenSessionResources.getInstance().addOperator(this.getClass().getSimpleName(), this);
     inputQueue = sessionResource.getSession().externalStreamOps().newBlockingQueue();
     // add a mock input as velox not allow the source is empty.
     if (inputType == null) {

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenOneInputOperator.java
@@ -63,6 +63,7 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
   private transient Query query;
   private transient ExternalStreams.BlockingQueue inputQueue;
   protected transient SerialTask task;
+  private transient volatile boolean closing;
   private final Class<IN> inClass;
   private final Class<OUT> outClass;
   private transient VectorInputBridge<IN> inputBridge;
@@ -151,6 +152,7 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
 
   @Override
   public void open() throws Exception {
+    closing = false;
     super.open();
     if (!mailboxHolder().get().isMailboxBound()) {
       ensureMailboxInitialized(getContainingTask());
@@ -184,21 +186,36 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
 
   @Override
   public void scheduleProcessElementOnMailbox() {
+    if (closing) {
+      return;
+    }
     scheduleDrainOnMailbox(this::drainTaskOutput);
   }
 
   @Override
   public void onProcessingTime(long timestamp) {
+    if (closing) {
+      return;
+    }
     scheduleProcessElementOnMailbox();
   }
 
   @Override
   public void processElementInternal() {
+    if (closing) {
+      return;
+    }
     drainOutput(this::drainTaskOutput);
   }
 
   private void drainTaskOutput() {
+    if (closing) {
+      return;
+    }
     while (true) {
+      if (closing) {
+        return;
+      }
       UpIterator.State state = task.advance();
       if (state == UpIterator.State.AVAILABLE) {
         final StatefulElement statefulElement = task.statefulGet();
@@ -244,20 +261,34 @@ public class GlutenOneInputOperator<IN, OUT> extends TableStreamOperator<OUT>
 
   @Override
   public void close() throws Exception {
-    if (task != null) {
-      try {
-        task.unbindNativeCallbackTarget();
-      } finally {
-        task.close();
-      }
-    }
-    if (inputQueue != null) {
-      inputQueue.noMoreInput();
-      inputQueue.close();
-    }
-    if (sessionResource != null) {
-      sessionResource.close();
-    }
+    closing = true;
+    GlutenCloseables.runWithCleanup(
+        () -> {
+          if (task != null) {
+            task.unbindNativeCallbackTarget();
+          }
+        },
+        () -> {
+          if (task != null) {
+            task.close();
+          }
+        },
+        () -> {
+          if (inputQueue != null) {
+            inputQueue.noMoreInput();
+          }
+        },
+        () -> {
+          if (inputQueue != null) {
+            inputQueue.close();
+          }
+        },
+        () -> {
+          if (sessionResource != null) {
+            sessionResource.close();
+          }
+        },
+        super::close);
   }
 
   @Override

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSessionResources.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSessionResources.java
@@ -16,8 +16,6 @@
  */
 package org.apache.gluten.table.runtime.operators;
 
-import org.apache.gluten.streaming.api.operators.GlutenOperator;
-
 import io.github.zhztheplayer.velox4j.Velox4j;
 import io.github.zhztheplayer.velox4j.memory.AllocationListener;
 import io.github.zhztheplayer.velox4j.memory.MemoryManager;
@@ -30,7 +28,6 @@ import org.apache.arrow.memory.RootAllocator;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 // Manage the session and resource for Velox.
 class GlutenSessionResource {
@@ -84,7 +81,6 @@ class GlutenSessionResource {
 public class GlutenSessionResources {
   private static final GlutenSessionResources instance = new GlutenSessionResources();
   private Map<String, GlutenSessionResource> sessionResources = new HashMap<>();
-  private Map<String, GlutenOperator> operators = new HashMap<>();
 
   private GlutenSessionResources() {}
 
@@ -104,14 +100,4 @@ public class GlutenSessionResources {
     return sessionResources.get(id).getSession();
   }
 
-  public void addOperator(String id, GlutenOperator operator) {
-    operators.put(id, operator);
-  }
-
-  public Optional<GlutenOperator> getOperator(String id) {
-    if (operators.containsKey(id)) {
-      return Optional.of(operators.get(id));
-    }
-    return Optional.empty();
-  }
 }

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSessionResources.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSessionResources.java
@@ -99,5 +99,4 @@ public class GlutenSessionResources {
   public Session getSession(String id) {
     return sessionResources.get(id).getSession();
   }
-
 }

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
@@ -292,7 +292,6 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
 
     sessionResource = new GlutenSessionResource();
     GlutenSessionResources.getInstance().addSessionResource(getId(), sessionResource);
-    GlutenSessionResources.getInstance().addOperator(getId(), this);
     leftInputQueue = sessionResource.getSession().externalStreamOps().newBlockingQueue();
     rightInputQueue = sessionResource.getSession().externalStreamOps().newBlockingQueue();
 

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
@@ -226,7 +226,11 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
       rightInputQueue.close();
     }
     if (task != null) {
-      task.close();
+      try {
+        task.unbindNativeCallbackTarget();
+      } finally {
+        task.close();
+      }
     }
     if (sessionResource != null) {
       sessionResource.close();

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
@@ -68,6 +68,7 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
   private ExternalStreams.BlockingQueue leftInputQueue;
   private ExternalStreams.BlockingQueue rightInputQueue;
   private SerialTask task;
+  private transient volatile boolean closing;
   private final Class<IN> inClass;
   private final Class<OUT> outClass;
   private VectorInputBridge<IN> inputBridge;
@@ -118,6 +119,7 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void open() throws Exception {
+    closing = false;
     super.open();
     if (!mailboxHolder().get().isMailboxBound()) {
       ensureMailboxInitialized(getContainingTask());
@@ -137,11 +139,17 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void scheduleProcessElementOnMailbox() {
+    if (closing) {
+      return;
+    }
     scheduleDrainOnMailbox(this::drainTaskOutput);
   }
 
   @Override
   public void onProcessingTime(long timestamp) {
+    if (closing) {
+      return;
+    }
     scheduleProcessElementOnMailbox();
   }
 
@@ -174,11 +182,20 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void processElementInternal() {
+    if (closing) {
+      return;
+    }
     drainOutput(this::drainTaskOutput);
   }
 
   private void drainTaskOutput() {
+    if (closing) {
+      return;
+    }
     while (true) {
+      if (closing) {
+        return;
+      }
       UpIterator.State state = task.advance();
       if (state == UpIterator.State.AVAILABLE) {
         final StatefulElement element = task.statefulGet();
@@ -219,22 +236,34 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
 
   @Override
   public void close() throws Exception {
-    if (leftInputQueue != null) {
-      leftInputQueue.close();
-    }
-    if (rightInputQueue != null) {
-      rightInputQueue.close();
-    }
-    if (task != null) {
-      try {
-        task.unbindNativeCallbackTarget();
-      } finally {
-        task.close();
-      }
-    }
-    if (sessionResource != null) {
-      sessionResource.close();
-    }
+    closing = true;
+    GlutenCloseables.runWithCleanup(
+        () -> {
+          if (leftInputQueue != null) {
+            leftInputQueue.close();
+          }
+        },
+        () -> {
+          if (rightInputQueue != null) {
+            rightInputQueue.close();
+          }
+        },
+        () -> {
+          if (task != null) {
+            task.unbindNativeCallbackTarget();
+          }
+        },
+        () -> {
+          if (task != null) {
+            task.close();
+          }
+        },
+        () -> {
+          if (sessionResource != null) {
+            sessionResource.close();
+          }
+        },
+        super::close);
   }
 
   @Override

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
@@ -28,6 +28,7 @@ import io.github.zhztheplayer.velox4j.iterator.UpIterator;
 import io.github.zhztheplayer.velox4j.plan.StatefulPlanNode;
 import io.github.zhztheplayer.velox4j.query.Query;
 import io.github.zhztheplayer.velox4j.query.SerialTask;
+import io.github.zhztheplayer.velox4j.stateful.NativeCallbackTarget;
 import io.github.zhztheplayer.velox4j.stateful.StatefulElement;
 import io.github.zhztheplayer.velox4j.stateful.StatefulRecord;
 import io.github.zhztheplayer.velox4j.stateful.StatefulWatermark;
@@ -50,7 +51,7 @@ import java.util.Map;
  * instead of flink RowData.
  */
 public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
-    implements TwoInputStreamOperator<IN, IN, OUT>, GlutenOperator {
+    implements TwoInputStreamOperator<IN, IN, OUT>, GlutenOperator, NativeCallbackTarget {
 
   private static final Logger LOG = LoggerFactory.getLogger(GlutenTwoInputOperator.class);
 
@@ -137,6 +138,11 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
   @Override
   public void scheduleProcessElementOnMailbox() {
     scheduleDrainOnMailbox(this::drainTaskOutput);
+  }
+
+  @Override
+  public void onProcessElement() {
+    scheduleProcessElementOnMailbox();
   }
 
   @Override
@@ -296,6 +302,7 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
             VeloxQueryConfig.getConfig(getRuntimeContext()),
             VeloxConnectorConfig.getConfig(getRuntimeContext()));
     task = sessionResource.getSession().queryOps().execute(query);
+    task.bindNativeCallbackTarget(this);
 
     ExternalStreamConnectorSplit leftSplit =
         new ExternalStreamConnectorSplit("connector-external-stream", leftInputQueue.id());

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenTwoInputOperator.java
@@ -141,7 +141,7 @@ public class GlutenTwoInputOperator<IN, OUT> extends AbstractStreamOperator<OUT>
   }
 
   @Override
-  public void onProcessElement() {
+  public void onProcessingTime(long timestamp) {
     scheduleProcessElementOnMailbox();
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

Adds native callback target binding for Gluten Flink operators so Velox processing-time callbacks can schedule output draining through the operator mailbox.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
UTs

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
co-authored using generative AI

Related issue: #12339

dependency
https://github.com/bigo-sg/velox4j/pull/33
https://github.com/bigo-sg/velox/pull/36
