### PR TITLE
[VL] Fix segfault on thread pool destruction

### DIFF
--- a/cpp/velox/compute/VeloxBackend.cc
+++ b/cpp/velox/compute/VeloxBackend.cc
@@ -195,8 +195,8 @@ void VeloxBackend::init(
       ioThreads >= 0,
       kVeloxIOThreads + " was set to negative number " + std::to_string(ioThreads) + ", this should not happen.");
   if (ioThreads > 0) {
-    ioExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
-        ioThreads, std::make_unique<folly::UnboundedBlockingQueue<folly::CPUThreadPoolExecutor::CPUTask>>());
+    ioExecutor_ =
+        std::make_unique<folly::CPUThreadPoolExecutor>(ioThreads, folly::CPUThreadPoolExecutor::makeLifoSemQueue());
   }
 
   initJolFilesystem();


### PR DESCRIPTION
```
---------------  T H R E A D  ---------------

Current thread (0x00007f58dc04de60):  JavaThread "Thread-11" daemon [_thread_in_native, id=12424, stack(0x00007f58e3ebe000,0x00007f58e46be000)]

Stack: [0x00007f58e3ebe000,0x00007f58e46be000],  sp=0x00007f58e46bca60,  free space=8186k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libvelox.so+0x7ed3bd4]  folly::detail::LifoSemBase<folly::SaturatingSemaphore<true, std::atomic>, std::atomic>::incrOrPop(unsigned int, bool)+0x114
C  [libvelox.so+0x7ed3084]  folly::detail::LifoSemBase<folly::SaturatingSemaphore<true, std::atomic>, std::atomic>::post()+0x22
C  [libvelox.so+0x7ef6d35]  folly::ThreadPoolExecutor::StoppedThreadQueue::add(std::shared_ptr<folly::ThreadPoolExecutor::Thread>&&)+0x5d
C  [libvelox.so+0x7eabf15]  folly::CPUThreadPoolExecutor::stopThread(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&)+0x139
C  [libvelox.so+0x7eac1c1]  folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)+0x23f
C  [libvelox.so+0x7efe952]  void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)+0x93
C  [libvelox.so+0x7efe277]  std::__invoke_result<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>::type std::__invoke<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)+0x4f
C  [libvelox.so+0x7efd919]  void std::_Bind<void (folly::ThreadPoolExecutor::*(folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>)+0x75
C  [libvelox.so+0x7efcc78]  void std::_Bind<void (folly::ThreadPoolExecutor::*(folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::operator()<, void>()+0x24
C  [libvelox.so+0x7efb9d8]  void folly::detail::function::call_<std::_Bind<void (folly::ThreadPoolExecutor::*(folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>, true, false, void>(, folly::detail::function::Data&)+0x20
```