### PR TITLE
[VL] Fix ClassCastException in Delta stats for non-offloadable aggregations

### DIFF
--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -137,12 +137,11 @@ object GlutenDeltaJobStatsTracker extends Logging {
         statsResultAttrs,
         StatisticsInputNode(dataCols))
       val projOp = ProjectExec(statsResultAttrs, aggOp)
-      val offloads = Seq(OffloadOthers()).map(_.toStrcitRule())
       val config = GlutenConfig.get
-      val transformRule = HeuristicTransform.WithRewrites(
-        Validators.newValidator(config, offloads),
-        Seq(PullOutPreProject),
-        offloads)
+      // Emulate Gluten's offloading on the driver. HeuristicTransform.static() pulls in the full
+      // set of component offload rules (it needs an active Spark session, which exists here on the
+      // driver), so the decision reflects the real offloading behavior.
+      val transformRule = HeuristicTransform.static()
       ColumnarCollapseTransformStages(config)(
         transformRule(projOp)).isInstanceOf[WholeStageTransformer]
     } catch {

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -55,6 +55,7 @@ import java.util.concurrent.{Callable, Executors, Future, SynchronousQueue}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 /** Gluten's stats tracker with vectorized aggregation inside to produce statistics efficiently. */
 private[stats] class GlutenDeltaJobStatsTracker(val delegate: DeltaJobStatisticsTracker)
@@ -89,14 +90,66 @@ object GlutenDeltaJobStatsTracker extends Logging {
   def apply(tracker: WriteJobStatsTracker): WriteJobStatsTracker = tracker match {
     case tracker: BasicWriteJobStatsTracker =>
       new GlutenDeltaJobStatsRowCountingTracker(tracker)
-    case tracker: DeltaJobStatisticsTracker =>
+    case tracker: DeltaJobStatisticsTracker
+        if canOffloadStats(tracker.dataCols, tracker.statsColExpr) =>
       new GlutenDeltaJobStatsTracker(tracker)
+    case tracker: DeltaJobStatisticsTracker =>
+      // The per-file statistics aggregation could not be offloaded to Velox (for example min/max
+      // over TIMESTAMP_NTZ). The native stats tracker assumes the aggregation collapses into a
+      // WholeStageTransformer and would otherwise crash with a ClassCastException, so use the
+      // row-based fallback tracker (columnar-to-row + the original Delta tracker) instead.
+      logWarning(
+        "Gluten Delta: per-file statistics aggregation cannot be offloaded to Velox; " +
+          "falling back to row-based stats collection.")
+      new GlutenDeltaJobStatsFallbackTracker(tracker)
     case tracker =>
       logWarning(
         "Gluten Delta: Creating fallback job stats tracker," +
           " this involves frequent columnar-to-row conversions which may cause performance" +
           " issues.")
       new GlutenDeltaJobStatsFallbackTracker(tracker)
+  }
+
+  /**
+   * Returns whether the Delta per-file statistics aggregation can be offloaded to a Velox
+   * whole-stage transformer. This mirrors the plan that [[GlutenDeltaTaskStatsTracker]] builds on
+   * the executors: if the aggregation/projection is not supported by Velox it stays a vanilla
+   * [[ProjectExec]] (i.e. does not collapse into a [[WholeStageTransformer]]), in which case the
+   * native stats tracker must not be used. Evaluated once on the driver so the executors never
+   * allocate native resources for a plan that cannot run.
+   */
+  private def canOffloadStats(dataCols: Seq[Attribute], statsColExpr: Expression): Boolean = {
+    try {
+      val aggregates = statsColExpr.collect {
+        case ae: AggregateExpression if ae.aggregateFunction.isInstanceOf[DeclarativeAggregate] =>
+          ae
+      }
+      val statsAttrs = aggregates.flatMap(_.aggregateFunction.aggBufferAttributes)
+      val statsResultAttrs = aggregates.flatMap(_.aggregateFunction.inputAggBufferAttributes)
+      val aggOp = SortAggregateExec(
+        None,
+        isStreaming = false,
+        None,
+        Seq.empty,
+        aggregates,
+        statsAttrs,
+        0,
+        statsResultAttrs,
+        StatisticsInputNode(dataCols))
+      val projOp = ProjectExec(statsResultAttrs, aggOp)
+      val offloads = Seq(OffloadOthers()).map(_.toStrcitRule())
+      val config = GlutenConfig.get
+      val transformRule = HeuristicTransform.WithRewrites(
+        Validators.newValidator(config, offloads),
+        Seq(PullOutPreProject),
+        offloads)
+      ColumnarCollapseTransformStages(config)(
+        transformRule(projOp)).isInstanceOf[WholeStageTransformer]
+    } catch {
+      case NonFatal(e) =>
+        logWarning("Gluten Delta: failed to plan native stats aggregation; using fallback.", e)
+        false
+    }
   }
 
   /** A columnar-based statistics collection for Gluten + Delta Lake. */

--- a/backends-velox/src-delta33/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+import java.io.File
+
+/**
+ * Regression test for the Gluten Delta per-file statistics tracker.
+ *
+ * Writing a Delta table whose collected min/max statistics cannot be offloaded to Velox -- for
+ * example over a TIMESTAMP_NTZ column -- used to crash the write task with a ClassCastException
+ * (ProjectExec cannot be cast to WholeStageTransformer), because the native stats tracker assumed
+ * the statistics aggregation always collapses into a WholeStageTransformer. The tracker must now
+ * fall back to row-based statistics collection instead of crashing.
+ */
+class GlutenDeltaStatsSuite extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  test("TIMESTAMP_NTZ stats fall back instead of crashing the write") {
+    withTempDir {
+      dir =>
+        val path = new File(dir, "ntz-stats").getCanonicalPath
+        // The maxValue statistic for a TIMESTAMP_NTZ near Long.MaxValue triggers the per-file
+        // statistics aggregation that cannot be offloaded to Velox.
+        val nearMaxMicros = Long.MaxValue - 999L
+        val data = Seq(nearMaxMicros)
+          .toDF("micros")
+          .selectExpr("micros AS id", "CAST(TIMESTAMP_MICROS(micros) AS TIMESTAMP_NTZ) AS ts")
+
+        // Without the fix this write fails with a ClassCastException (ProjectExec cannot be cast
+        // to WholeStageTransformer) while collecting statistics. With the fix it succeeds via the
+        // row-based fallback tracker. A count avoids materializing the TIMESTAMP_NTZ column, which
+        // is an unrelated read-path limitation.
+        data.coalesce(1).write.format("delta").save(path)
+
+        assert(spark.read.format("delta").load(path).count() === 1)
+    }
+  }
+}

--- a/backends-velox/src-delta33/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
@@ -39,10 +39,12 @@ class GlutenDeltaStatsSuite extends QueryTest with SharedSparkSession with Delta
     withTempDir {
       dir =>
         val path = new File(dir, "ntz-stats").getCanonicalPath
-        // The maxValue statistic for a TIMESTAMP_NTZ near Long.MaxValue triggers the per-file
-        // statistics aggregation that cannot be offloaded to Velox.
-        val nearMaxMicros = Long.MaxValue - 999L
-        val data = Seq(nearMaxMicros)
+        // Collecting min/max statistics over a TIMESTAMP_NTZ column is what cannot be offloaded to
+        // Velox (a type limitation, independent of the value), so any in-range timestamp exercises
+        // the same fallback path. Use a normal timestamp to keep the test focused on the fallback
+        // rather than on timestamp-overflow edge cases.
+        val micros = 1704067200000000L // 2024-01-01T00:00:00Z
+        val data = Seq(micros)
           .toDF("micros")
           .selectExpr("micros AS id", "CAST(TIMESTAMP_MICROS(micros) AS TIMESTAMP_NTZ) AS ts")
 

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -137,12 +137,11 @@ object GlutenDeltaJobStatsTracker extends Logging {
         statsResultAttrs,
         StatisticsInputNode(dataCols))
       val projOp = ProjectExec(statsResultAttrs, aggOp)
-      val offloads = Seq(OffloadOthers()).map(_.toStrcitRule())
       val config = GlutenConfig.get
-      val transformRule = HeuristicTransform.WithRewrites(
-        Validators.newValidator(config, offloads),
-        Seq(PullOutPreProject),
-        offloads)
+      // Emulate Gluten's offloading on the driver. HeuristicTransform.static() pulls in the full
+      // set of component offload rules (it needs an active Spark session, which exists here on the
+      // driver), so the decision reflects the real offloading behavior.
+      val transformRule = HeuristicTransform.static()
       ColumnarCollapseTransformStages(config)(
         transformRule(projOp)).isInstanceOf[WholeStageTransformer]
     } catch {

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/stats/GlutenDeltaJobStatsTracker.scala
@@ -55,6 +55,7 @@ import java.util.concurrent.{Callable, Executors, Future, SynchronousQueue}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 /** Gluten's stats tracker with vectorized aggregation inside to produce statistics efficiently. */
 private[stats] class GlutenDeltaJobStatsTracker(val delegate: DeltaJobStatisticsTracker)
@@ -89,14 +90,66 @@ object GlutenDeltaJobStatsTracker extends Logging {
   def apply(tracker: WriteJobStatsTracker): WriteJobStatsTracker = tracker match {
     case tracker: BasicWriteJobStatsTracker =>
       new GlutenDeltaJobStatsRowCountingTracker(tracker)
-    case tracker: DeltaJobStatisticsTracker =>
+    case tracker: DeltaJobStatisticsTracker
+        if canOffloadStats(tracker.dataCols, tracker.statsColExpr) =>
       new GlutenDeltaJobStatsTracker(tracker)
+    case tracker: DeltaJobStatisticsTracker =>
+      // The per-file statistics aggregation could not be offloaded to Velox (for example min/max
+      // over TIMESTAMP_NTZ). The native stats tracker assumes the aggregation collapses into a
+      // WholeStageTransformer and would otherwise crash with a ClassCastException, so use the
+      // row-based fallback tracker (columnar-to-row + the original Delta tracker) instead.
+      logWarning(
+        "Gluten Delta: per-file statistics aggregation cannot be offloaded to Velox; " +
+          "falling back to row-based stats collection.")
+      new GlutenDeltaJobStatsFallbackTracker(tracker)
     case tracker =>
       logWarning(
         "Gluten Delta: Creating fallback job stats tracker," +
           " this involves frequent columnar-to-row conversions which may cause performance" +
           " issues.")
       new GlutenDeltaJobStatsFallbackTracker(tracker)
+  }
+
+  /**
+   * Returns whether the Delta per-file statistics aggregation can be offloaded to a Velox
+   * whole-stage transformer. This mirrors the plan that [[GlutenDeltaTaskStatsTracker]] builds on
+   * the executors: if the aggregation/projection is not supported by Velox it stays a vanilla
+   * [[ProjectExec]] (i.e. does not collapse into a [[WholeStageTransformer]]), in which case the
+   * native stats tracker must not be used. Evaluated once on the driver so the executors never
+   * allocate native resources for a plan that cannot run.
+   */
+  private def canOffloadStats(dataCols: Seq[Attribute], statsColExpr: Expression): Boolean = {
+    try {
+      val aggregates = statsColExpr.collect {
+        case ae: AggregateExpression if ae.aggregateFunction.isInstanceOf[DeclarativeAggregate] =>
+          ae
+      }
+      val statsAttrs = aggregates.flatMap(_.aggregateFunction.aggBufferAttributes)
+      val statsResultAttrs = aggregates.flatMap(_.aggregateFunction.inputAggBufferAttributes)
+      val aggOp = SortAggregateExec(
+        None,
+        isStreaming = false,
+        None,
+        Seq.empty,
+        aggregates,
+        statsAttrs,
+        0,
+        statsResultAttrs,
+        StatisticsInputNode(dataCols))
+      val projOp = ProjectExec(statsResultAttrs, aggOp)
+      val offloads = Seq(OffloadOthers()).map(_.toStrcitRule())
+      val config = GlutenConfig.get
+      val transformRule = HeuristicTransform.WithRewrites(
+        Validators.newValidator(config, offloads),
+        Seq(PullOutPreProject),
+        offloads)
+      ColumnarCollapseTransformStages(config)(
+        transformRule(projOp)).isInstanceOf[WholeStageTransformer]
+    } catch {
+      case NonFatal(e) =>
+        logWarning("Gluten Delta: failed to plan native stats aggregation; using fallback.", e)
+        false
+    }
   }
 
   /** A columnar-based statistics collection for Gluten + Delta Lake. */

--- a/backends-velox/src-delta40/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+import java.io.File
+
+/**
+ * Regression test for the Gluten Delta per-file statistics tracker.
+ *
+ * Writing a Delta table whose collected min/max statistics cannot be offloaded to Velox -- for
+ * example over a TIMESTAMP_NTZ column -- used to crash the write task with a ClassCastException
+ * (ProjectExec cannot be cast to WholeStageTransformer), because the native stats tracker assumed
+ * the statistics aggregation always collapses into a WholeStageTransformer. The tracker must now
+ * fall back to row-based statistics collection instead of crashing.
+ */
+class GlutenDeltaStatsSuite extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  test("TIMESTAMP_NTZ stats fall back instead of crashing the write") {
+    withTempDir {
+      dir =>
+        val path = new File(dir, "ntz-stats").getCanonicalPath
+        // The maxValue statistic for a TIMESTAMP_NTZ near Long.MaxValue triggers the per-file
+        // statistics aggregation that cannot be offloaded to Velox.
+        val nearMaxMicros = Long.MaxValue - 999L
+        val data = Seq(nearMaxMicros)
+          .toDF("micros")
+          .selectExpr("micros AS id", "CAST(TIMESTAMP_MICROS(micros) AS TIMESTAMP_NTZ) AS ts")
+
+        // Without the fix this write fails with a ClassCastException (ProjectExec cannot be cast
+        // to WholeStageTransformer) while collecting statistics. With the fix it succeeds via the
+        // row-based fallback tracker. A count avoids materializing the TIMESTAMP_NTZ column, which
+        // is an unrelated read-path limitation.
+        data.coalesce(1).write.format("delta").save(path)
+
+        assert(spark.read.format("delta").load(path).count() === 1)
+    }
+  }
+}

--- a/backends-velox/src-delta40/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/gluten/execution/GlutenDeltaStatsSuite.scala
@@ -39,10 +39,12 @@ class GlutenDeltaStatsSuite extends QueryTest with SharedSparkSession with Delta
     withTempDir {
       dir =>
         val path = new File(dir, "ntz-stats").getCanonicalPath
-        // The maxValue statistic for a TIMESTAMP_NTZ near Long.MaxValue triggers the per-file
-        // statistics aggregation that cannot be offloaded to Velox.
-        val nearMaxMicros = Long.MaxValue - 999L
-        val data = Seq(nearMaxMicros)
+        // Collecting min/max statistics over a TIMESTAMP_NTZ column is what cannot be offloaded to
+        // Velox (a type limitation, independent of the value), so any in-range timestamp exercises
+        // the same fallback path. Use a normal timestamp to keep the test focused on the fallback
+        // rather than on timestamp-overflow edge cases.
+        val micros = 1704067200000000L // 2024-01-01T00:00:00Z
+        val data = Seq(micros)
           .toDF("micros")
           .selectExpr("micros AS id", "CAST(TIMESTAMP_MICROS(micros) AS TIMESTAMP_NTZ) AS ts")
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Uncovered by the Delta Spark UT pipeline (#12278).

`GlutenDeltaJobStatsTracker` builds the per-file statistics aggregation as a `SortAggregateExec -> ProjectExec` plan, runs Gluten's `HeuristicTransform`, then unconditionally casts the result to a `WholeStageTransformer`. When the statistics aggregation cannot be offloaded to Velox -- for example `min`/`max` over a `TIMESTAMP_NTZ` column, as exercised by Delta's `DataSkippingDeltaV1Suite` "data skipping on TIMESTAMP_NTZ near Long.MaxValue" -- the projection stays a vanilla `ProjectExec` and the cast throws:

```
java.lang.ClassCastException: org.apache.spark.sql.execution.ProjectExec cannot be cast to org.apache.gluten.execution.WholeStageTransformer
```

in the per-task tracker constructor (`GlutenDeltaJobStatsTracker.scala`), failing the write.

This PR decides on the **driver** whether the aggregation actually offloads: a new `canOffloadStats()` dry-runs the same transform pipeline once and checks whether it collapses into a `WholeStageTransformer`. If it does not, the `DeltaJobStatisticsTracker` is routed to the existing `GlutenDeltaJobStatsFallbackTracker` (columnar-to-row + the original Delta tracker, which produces correct statistics for any type) instead of the native tracker. Evaluating this on the driver also avoids the per-task constructor allocating a single-thread executor and a `NativePlanEvaluator` before the cast. The fix is applied to both the Delta 3.x (`src-delta33`) and Delta 4.x (`src-delta40`) copies.

## How was this patch tested?

Added `GlutenDeltaStatsSuite`, which writes a Delta table whose `TIMESTAMP_NTZ` min/max statistics cannot be offloaded to Velox. Before this change the write crashes with the `ClassCastException` above; after it, the write succeeds via the row-based fallback tracker.

Locally verified (Spark 3.5, Scala 2.12): the new suite fails without the fix (`Tests: succeeded 0, failed 1`, ClassCastException) and passes with it (`succeeded 1, failed 0`). A companion test-only PR (#12293) demonstrates the same red/green contrast on CI. Also confirmed end-to-end against Delta's `DataSkippingDeltaV1Suite` "TIMESTAMP_NTZ near Long.MaxValue" (succeeded 2, failed 0 with the fix).

`scalafmt`/spotless report no changes.

PR/CI unit test before the fix: https://github.com/apache/gluten/pull/12293 / https://github.com/apache/gluten/actions/runs/27509527767/job/81307865870?pr=12293

<img width="3046" height="1686" alt="image" src="https://github.com/user-attachments/assets/3c3415d2-dfae-4b79-9d17-88827054c822" />


## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI (claude-opus-4.8)
