### PR TITLE
[GLUTEN-11622][VL] Enable minute/second(timestamp_ntz) native execution

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -603,6 +603,14 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
         runQueryAndCompare("select hour(ts) from view") {
           checkGlutenPlan[ProjectExecTransformer]
         }
+        // minute(timestamp_ntz) runs natively; output is int (no NTZ propagation).
+        runQueryAndCompare("select minute(ts) from view") {
+          checkGlutenPlan[ProjectExecTransformer]
+        }
+        // second(timestamp_ntz) runs natively; output is int (no NTZ propagation).
+        runQueryAndCompare("select second(ts) from view") {
+          checkGlutenPlan[ProjectExecTransformer]
+        }
     }
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -25,7 +25,7 @@ import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.Hour
+import org.apache.spark.sql.catalyst.expressions.{Hour, Minute, Second}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.datasources.WriteFilesExec
@@ -271,7 +271,7 @@ object Validators {
           case p if HiveTableScanExecTransformer.isHiveTableScan(p) => true
           case _ => false
         }
-        val isHourOnNtz = plan match {
+        val isExtractOnNtz = plan match {
           case p: ProjectExec =>
             p.projectList.forall {
               expr =>
@@ -279,12 +279,14 @@ object Validators {
                   !expr.references.exists(a => containsNTZ(a.dataType))) ||
                 expr.exists {
                   case Hour(child, _) => containsNTZ(child.dataType)
+                  case Minute(child, _) => containsNTZ(child.dataType)
+                  case Second(child, _) => containsNTZ(child.dataType)
                   case _ => false
                 }
             }
           case _ => false
         }
-        if (isScan || isHourOnNtz) {
+        if (isScan || isExtractOnNtz) {
           return pass()
         }
       }


### PR DESCRIPTION
Enable minute(timestamp_ntz) and second(timestamp_ntz) to run natively in the Velox backend instead of falling back to Spark.
Velox PR: facebookincubator/velox#17759 


Related issue: #11622