### PR TITLE
Enable timestampadd(timestamp_ntz) native execution in Velox backend.

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -611,6 +611,10 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
         runQueryAndCompare("select second(ts) from view") {
           checkGlutenPlan[ProjectExecTransformer]
         }
+        // timestampadd(timestamp_ntz) runs natively; output stays timestamp_ntz.
+        runQueryAndCompare("select timestampadd(hour, 1, ts) from view") {
+          checkGlutenPlan[ProjectExecTransformer]
+        }
     }
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -25,7 +25,7 @@ import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.expressions.{Hour, Minute, Second}
+import org.apache.spark.sql.catalyst.expressions.{Hour, Minute, Second, TimestampAdd}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.datasources.WriteFilesExec
@@ -271,7 +271,7 @@ object Validators {
           case p if HiveTableScanExecTransformer.isHiveTableScan(p) => true
           case _ => false
         }
-        val isExtractOnNtz = plan match {
+        val isSupportedNtz = plan match {
           case p: ProjectExec =>
             p.projectList.forall {
               expr =>
@@ -281,12 +281,13 @@ object Validators {
                   case Hour(child, _) => containsNTZ(child.dataType)
                   case Minute(child, _) => containsNTZ(child.dataType)
                   case Second(child, _) => containsNTZ(child.dataType)
+                  case TimestampAdd(_, _, child, _) => containsNTZ(child.dataType)
                   case _ => false
                 }
             }
           case _ => false
         }
-        if (isScan || isExtractOnNtz) {
+        if (isScan || isSupportedNtz) {
           return pass()
         }
       }


### PR DESCRIPTION
Enable timestampadd(timestamp_ntz) to run natively in the Velox backend instead of falling back to Spark.

Velox PR: [facebookincubator/velox#17800](https://github.com/facebookincubator/velox/pull/17800)
Related issue: [#11622](https://github.com/apache/gluten/issues/11622)