### PR TITLE
[FLINK] Support Apache Pulsar as DataSource

### DIFF
--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -37,6 +37,7 @@ env:
     --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
     --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED
+    --add-opens=java.base/sun.reflect.generics.repository=ALL-UNNAMED
   JAVA_TOOL_OPTIONS: >-
     --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
     --add-opens=java.base/sun.nio.ch=org.apache.arrow.memory.core,ALL-UNNAMED
@@ -50,6 +51,7 @@ env:
     --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
     --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED
+    --add-opens=java.base/sun.reflect.generics.repository=ALL-UNNAMED
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
 jobs:

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -82,7 +82,7 @@ jobs:
           export fmt_SOURCE=BUNDLED
           export folly_SOURCE=BUNDLED
           git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
-          cd velox4j && git reset --hard 97fc1edafebd0f505e613d260f77f92f5252d048
+          cd velox4j && git reset --hard 7a87ee8223a9efae961ec1b50bd009eac8314615
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -83,6 +83,7 @@ jobs:
           export folly_SOURCE=BUNDLED
           git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
           cd velox4j && git reset --hard dd957863fb755c17de6c29211c4597aec27acb08
+
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -49,6 +49,7 @@ env:
     --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
     --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+    --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
 jobs:

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -36,6 +36,7 @@ env:
     --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
     --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+    --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED
   JAVA_TOOL_OPTIONS: >-
     --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
     --add-opens=java.base/sun.nio.ch=org.apache.arrow.memory.core,ALL-UNNAMED

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -82,8 +82,7 @@ jobs:
           export fmt_SOURCE=BUNDLED
           export folly_SOURCE=BUNDLED
           git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
-          cd velox4j && git reset --hard dd957863fb755c17de6c29211c4597aec27acb08
-
+          cd velox4j && git reset --hard 97fc1edafebd0f505e613d260f77f92f5252d048
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -82,7 +82,7 @@ jobs:
           export fmt_SOURCE=BUNDLED
           export folly_SOURCE=BUNDLED
           git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
-          cd velox4j && git reset --hard 97fc1edafebd0f505e613d260f77f92f5252d048
+          cd velox4j && git reset --hard dd957863fb755c17de6c29211c4597aec27acb08
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -82,7 +82,7 @@ jobs:
           export fmt_SOURCE=BUNDLED
           export folly_SOURCE=BUNDLED
           git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
-          cd velox4j && git reset --hard dd957863fb755c17de6c29211c4597aec27acb08
+          cd velox4j && git reset --hard 97fc1edafebd0f505e613d260f77f92f5252d048
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -82,7 +82,7 @@ jobs:
           export fmt_SOURCE=BUNDLED
           export folly_SOURCE=BUNDLED
           git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
-          cd velox4j && git reset --hard 7a87ee8223a9efae961ec1b50bd009eac8314615
+          cd velox4j && git reset --hard dd957863fb755c17de6c29211c4597aec27acb08
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..

--- a/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -222,7 +222,9 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             Configuration.class.getName(),
             streamExecEnv.getConfiguration(),
             ResolvedSchema.class.getName(),
-            schema));
+            schema,
+            VeloxSourceSinkFactory.FACTORY_CLASS_LOADER_KEY,
+            CommonExecSink.class.getClassLoader()));
     // --- End Gluten-specific code changes ---
   }
 

--- a/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -259,7 +259,7 @@ public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBa
             offset,
             windowType,
             outputType,
-            true,
+            windowing.isRowtime(),
             rowtimeIndex,
             windowStartIndex,
             windowEndIndex);

--- a/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
+++ b/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
@@ -220,7 +220,7 @@ public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBas
             offset,
             windowType,
             outputType,
-            false,
+            windowing.isRowtime(),
             rowtimeIndex,
             -1,
             -1);

--- a/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
+++ b/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTableSourceScan.java
@@ -183,7 +183,9 @@ public class StreamExecTableSourceScan extends CommonExecTableSourceScan
             "checkpoint.enabled",
             planner.getExecEnv().getCheckpointConfig().isCheckpointingEnabled(),
             "watermarkPushDownSpec",
-            watermarkPushDownSpec));
+            watermarkPushDownSpec,
+            VeloxSourceSinkFactory.FACTORY_CLASS_LOADER_KEY,
+            StreamExecTableSourceScan.class.getClassLoader()));
     // --- End Gluten-specific code changes ---
   }
 }

--- a/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -313,5 +313,4 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
     transform.setStateKeyType(selector.getProducedType());
     return transform;
   }
-
 }

--- a/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -58,6 +58,7 @@ import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.planner.utils.TableConfigUtils;
 import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty;
+import org.apache.flink.table.runtime.groupwindow.WindowProperty;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.util.TimeWindowUtil;
@@ -312,5 +313,14 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
     transform.setStateKeySelector(selector);
     transform.setStateKeyType(selector.getProducedType());
     return transform;
+  }
+
+  private int getWindowPropertyIndex(Class<? extends WindowProperty> propertyClass) {
+    for (int i = 0; i < namedWindowProperties.length; i++) {
+      if (propertyClass.isInstance(namedWindowProperties[i].getProperty())) {
+        return grouping.length + aggCalls.length + i;
+      }
+    }
+    return -1;
   }
 }

--- a/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/gluten-flink/planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -58,7 +58,6 @@ import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.planner.utils.TableConfigUtils;
 import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty;
-import org.apache.flink.table.runtime.groupwindow.WindowProperty;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.util.TimeWindowUtil;
@@ -315,12 +314,4 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
     return transform;
   }
 
-  private int getWindowPropertyIndex(Class<? extends WindowProperty> propertyClass) {
-    for (int i = 0; i < namedWindowProperties.length; i++) {
-      if (propertyClass.isInstance(namedWindowProperties[i].getProperty())) {
-        return grouping.length + aggCalls.length + i;
-      }
-    }
-    return -1;
-  }
 }

--- a/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/WindowUtils.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/WindowUtils.java
@@ -48,6 +48,7 @@ public class WindowUtils {
     int windowType = -1;
     WindowSpec windowSpec = windowing.getWindow();
     if (windowSpec instanceof HoppingWindowSpec) {
+      windowType = 0;
       size = ((HoppingWindowSpec) windowSpec).getSize().toMillis();
       slide = ((HoppingWindowSpec) windowSpec).getSlide().toMillis();
       if (size % slide != 0) {
@@ -63,6 +64,7 @@ public class WindowUtils {
       }
       windowType = 0;
     } else if (windowSpec instanceof TumblingWindowSpec) {
+      windowType = 1;
       size = ((TumblingWindowSpec) windowSpec).getSize().toMillis();
       Duration windowOffset = ((TumblingWindowSpec) windowSpec).getOffset();
       if (windowOffset != null) {

--- a/gluten-flink/planner/src/main/java/org/apache/gluten/velox/PulsarSourceSinkFactory.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/velox/PulsarSourceSinkFactory.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.velox;
+
+import org.apache.gluten.streaming.api.operators.GlutenStreamSource;
+import org.apache.gluten.table.runtime.operators.GlutenSourceFunction;
+import org.apache.gluten.util.LogicalTypeConverter;
+import org.apache.gluten.util.PlanNodeIdGenerator;
+
+import io.github.zhztheplayer.velox4j.connector.PulsarConnectorSplit;
+import io.github.zhztheplayer.velox4j.connector.PulsarTableHandle;
+import io.github.zhztheplayer.velox4j.plan.StatefulPlanNode;
+import io.github.zhztheplayer.velox4j.plan.TableScanNode;
+import io.github.zhztheplayer.velox4j.type.RowType;
+
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
+public class PulsarSourceSinkFactory implements VeloxSourceSinkFactory {
+
+  private static final String CONNECTOR_ID = "connector-pulsar";
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public boolean match(Transformation<RowData> transformation) {
+    if (transformation instanceof SourceTransformation) {
+      Source source = ((SourceTransformation) transformation).getSource();
+      return isPulsarSource(source);
+    }
+    return false;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Override
+  public Transformation<RowData> buildVeloxSource(
+      Transformation<RowData> transformation, Map<String, Object> parameters) {
+    RowType outputType =
+        (RowType)
+            LogicalTypeConverter.toVLType(
+                ((InternalTypeInfo<?>) transformation.getOutputType()).toLogicalType());
+    try {
+      ScanTableSource tableSource =
+          (ScanTableSource) parameters.get(ScanTableSource.class.getName());
+      SourceTransformation sourceTransformation = (SourceTransformation) transformation;
+      Source source = sourceTransformation.getSource();
+      Map<String, String> pulsarTableParameters = buildTableParameters(tableSource, source);
+      String topic = required(pulsarTableParameters, "topic");
+      String serviceUrl = required(pulsarTableParameters, "service.url");
+      String subscriptionName = required(pulsarTableParameters, "subscription.name");
+      String format = pulsarTableParameters.getOrDefault("format", "raw");
+
+      String planId = PlanNodeIdGenerator.newId();
+      PulsarTableHandle pulsarTableHandle =
+          new PulsarTableHandle(CONNECTOR_ID, topic, outputType, pulsarTableParameters);
+      PulsarConnectorSplit connectorSplit =
+          new PulsarConnectorSplit(CONNECTOR_ID, serviceUrl, topic, subscriptionName, format);
+      TableScanNode pulsarScan =
+          new TableScanNode(planId, outputType, pulsarTableHandle, List.of());
+      GlutenStreamSource sourceOp =
+          new GlutenStreamSource(
+              new GlutenSourceFunction(
+                  new StatefulPlanNode(pulsarScan.getId(), pulsarScan),
+                  Map.of(pulsarScan.getId(), outputType),
+                  pulsarScan.getId(),
+                  connectorSplit,
+                  RowData.class),
+              "PulsarSource");
+      return new LegacySourceTransformation<RowData>(
+          sourceTransformation.getName(),
+          sourceOp,
+          transformation.getOutputType(),
+          sourceTransformation.getParallelism(),
+          sourceTransformation.getBoundedness(),
+          false);
+    } catch (Exception e) {
+      throw new FlinkRuntimeException(e);
+    }
+  }
+
+  @Override
+  public Transformation<RowData> buildVeloxSink(
+      Transformation<RowData> transformation, Map<String, Object> parameters) {
+    throw new FlinkRuntimeException("Unimplemented method 'buildSink'");
+  }
+
+  static Map<String, String> buildTableParameters(Object tableSource, Object source) {
+    Map<String, String> options = new HashMap<>();
+    putAllStringOptions(options, tableSource);
+    putAllStringOptions(options, source);
+
+    firstString(tableSource, source, "serviceUrl", "serviceURL", "pulsarServiceUrl")
+        .ifPresent(value -> options.put("service.url", value));
+    option(options, "service-url", "pulsar.service.url", "service.url", "pulsar.client.serviceUrl")
+        .ifPresent(value -> options.put("service.url", value));
+
+    firstString(tableSource, source, "adminUrl", "adminURL", "pulsarAdminUrl")
+        .ifPresent(value -> options.put("admin.url", value));
+    option(options, "admin-url", "pulsar.admin.url", "admin.url")
+        .ifPresent(value -> options.put("admin.url", value));
+
+    firstTopic(tableSource, source).ifPresent(value -> options.put("topic", value));
+    option(options, "topic", "topics").ifPresent(value -> options.put("topic", value));
+
+    firstString(tableSource, source, "subscriptionName")
+        .ifPresent(value -> options.put("subscription.name", value));
+    option(
+            options,
+            "subscription-name",
+            "subscription.name",
+            "pulsar.subscription.name",
+            "pulsar.consumer.subscriptionName",
+            "properties.subscription.name",
+            "source.subscription-name")
+        .ifPresent(value -> options.put("subscription.name", value));
+
+    options.putIfAbsent("subscription.name", "gluten-pulsar-" + UUID.randomUUID().toString());
+    firstString(tableSource, source, "subscriptionType")
+        .or(
+            () ->
+                option(
+                    options,
+                    "source.subscription-type",
+                    "subscription.type",
+                    "pulsar.subscription.type"))
+        .map(PulsarSourceSinkFactory::normalizeSubscriptionType)
+        .ifPresent(value -> options.put("subscription.type", value));
+    option(options, "value.format")
+        .or(
+            () -> {
+              String resolvedFormat = resolveFormat(tableSource);
+              if (!"raw".equals(resolvedFormat)) {
+                return Optional.of(resolvedFormat);
+              }
+              return option(options, "format").filter(value -> !"raw".equals(value));
+            })
+        .ifPresent(value -> options.put("format", value));
+    options.putIfAbsent("format", "raw");
+    option(
+            options,
+            "scan.startup.mode",
+            "startup.mode",
+            "initial.position",
+            "source.start.message-id")
+        .map(PulsarSourceSinkFactory::toInitialPosition)
+        .ifPresent(value -> options.put("initial.position", value));
+    options.putIfAbsent("initial.position", "latest");
+    return options;
+  }
+
+  static boolean isPulsarSource(Object source) {
+    return containsPulsarClass(source, 2, Collections.newSetFromMap(new IdentityHashMap<>()));
+  }
+
+  private static String required(Map<String, String> options, String key) {
+    String value = options.get(key);
+    if (value == null || value.isEmpty()) {
+      throw new FlinkRuntimeException("Missing Pulsar option: " + key);
+    }
+    return value;
+  }
+
+  private static String resolveFormat(Object tableSource) {
+    Optional<Object> decodingFormat = firstField(tableSource, "valueDecodingFormat", "format");
+    if (decodingFormat.isEmpty()) {
+      decodingFormat =
+          firstField(tableSource, "deserializationSchemaFactory")
+              .flatMap(factory -> firstField(factory, "valueDecodingFormat"));
+    }
+    if (decodingFormat.isPresent() && decodingFormat.get() instanceof DecodingFormat) {
+      String className = decodingFormat.get().getClass().getName();
+      if (className.contains("JsonFormatFactory")) {
+        return "json";
+      } else if (className.contains("CsvFormatFactory")) {
+        return "csv";
+      }
+    }
+    return "raw";
+  }
+
+  private static String toInitialPosition(String startupMode) {
+    String normalized = startupMode.toLowerCase().replace("_", "-");
+    if (normalized.contains("earliest")) {
+      return "earliest";
+    }
+    if (normalized.contains("latest")) {
+      return "latest";
+    }
+    return normalized;
+  }
+
+  private static String normalizeSubscriptionType(String subscriptionType) {
+    return subscriptionType.toLowerCase(Locale.ROOT).replace("-", "_");
+  }
+
+  private static Optional<String> firstTopic(Object... targets) {
+    for (Object target : targets) {
+      Optional<Object> topics = firstField(target, "topics", "topic", "topicName");
+      if (topics.isPresent()) {
+        Object value = topics.get();
+        if (value instanceof Collection) {
+          return ((Collection<?>) value).stream().findFirst().map(String::valueOf);
+        }
+        if (value instanceof String[]) {
+          return Arrays.stream((String[]) value).findFirst();
+        }
+        String text = String.valueOf(value);
+        if (!text.isEmpty()) {
+          return Optional.of(text);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<String> firstString(Object first, Object second, String... fieldNames) {
+    return firstField(first, fieldNames)
+        .or(() -> firstField(second, fieldNames))
+        .map(String::valueOf)
+        .filter(value -> !value.isEmpty());
+  }
+
+  private static Optional<String> option(Map<String, String> options, String... keys) {
+    for (String key : keys) {
+      String value = options.get(key);
+      if (value != null && !value.isEmpty()) {
+        return Optional.of(value);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static void putAllStringOptions(Map<String, String> output, Object target) {
+    firstField(target, "properties", "tableOptions", "options", "configuration")
+        .ifPresent(value -> putAllStringOptions(output, value));
+    if (target instanceof Properties) {
+      Properties properties = (Properties) target;
+      for (String key : properties.stringPropertyNames()) {
+        output.put(key, properties.getProperty(key));
+      }
+    } else if (target instanceof Map) {
+      ((Map<?, ?>) target)
+          .forEach(
+              (key, value) -> {
+                if (key != null && value != null) {
+                  output.put(String.valueOf(key), String.valueOf(value));
+                }
+              });
+    }
+  }
+
+  private static Optional<Object> firstField(Object target, String... fieldNames) {
+    if (target == null) {
+      return Optional.empty();
+    }
+    for (String fieldName : fieldNames) {
+      Optional<Object> value = field(target, fieldName);
+      if (value.isPresent()) {
+        return value;
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<Object> field(Object target, String fieldName) {
+    Class<?> clazz = target.getClass();
+    while (clazz != null) {
+      try {
+        Field field = clazz.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return Optional.ofNullable(field.get(target));
+      } catch (NoSuchFieldException e) {
+        clazz = clazz.getSuperclass();
+      } catch (IllegalAccessException e) {
+        throw new FlinkRuntimeException(e);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static boolean containsPulsarClass(Object target, int depth, Set<Object> visited) {
+    if (target == null || depth < 0 || visited.contains(target)) {
+      return false;
+    }
+    visited.add(target);
+
+    Class<?> clazz = target.getClass();
+    if (clazz.getName().toLowerCase(Locale.ROOT).contains("pulsar")) {
+      return true;
+    }
+    if (isLeafClass(clazz)) {
+      return false;
+    }
+    if (target instanceof Collection) {
+      return ((Collection<?>) target)
+          .stream().anyMatch(value -> containsPulsarClass(value, depth - 1, visited));
+    }
+    if (target instanceof Map) {
+      return ((Map<?, ?>) target)
+          .values().stream().anyMatch(value -> containsPulsarClass(value, depth - 1, visited));
+    }
+    if (clazz.isArray()) {
+      if (target instanceof Object[]) {
+        return Arrays.stream((Object[]) target)
+            .anyMatch(value -> containsPulsarClass(value, depth - 1, visited));
+      }
+      return false;
+    }
+
+    Class<?> current = clazz;
+    while (current != null && !isLeafClass(current)) {
+      for (Field declaredField : current.getDeclaredFields()) {
+        if (Modifier.isStatic(declaredField.getModifiers())) {
+          continue;
+        }
+        try {
+          declaredField.setAccessible(true);
+          if (containsPulsarClass(declaredField.get(target), depth - 1, visited)) {
+            return true;
+          }
+        } catch (IllegalAccessException e) {
+          throw new FlinkRuntimeException(e);
+        }
+      }
+      current = current.getSuperclass();
+    }
+    return false;
+  }
+
+  private static boolean isLeafClass(Class<?> clazz) {
+    return clazz.isPrimitive()
+        || clazz.isEnum()
+        || clazz.getName().startsWith("java.lang.")
+        || clazz.getName().startsWith("java.time.");
+  }
+}

--- a/gluten-flink/planner/src/main/java/org/apache/gluten/velox/PulsarSourceSinkFactory.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/velox/PulsarSourceSinkFactory.java
@@ -180,7 +180,37 @@ public class PulsarSourceSinkFactory implements VeloxSourceSinkFactory {
   }
 
   static boolean isPulsarSource(Object source) {
-    return source.getClass().getSimpleName().equals("PulsarSource");
+    return isPulsarSource(source, 0);
+  }
+
+  private static boolean isPulsarSource(Object source, int depth) {
+    if (source == null || depth > 3) {
+      return false;
+    }
+    if (source.getClass().getSimpleName().equals("PulsarSource")) {
+      return true;
+    }
+    // Check wrapped source fields (e.g. Flink wraps PulsarSource in a SourceReaderContext wrapper)
+    for (java.lang.reflect.Field f : source.getClass().getDeclaredFields()) {
+      Class<?> fieldType = f.getType();
+      // Only recurse into non-primitive, non-collection, non-map fields that could wrap a Source
+      if (fieldType.isPrimitive()
+          || fieldType == String.class
+          || Collection.class.isAssignableFrom(fieldType)
+          || Map.class.isAssignableFrom(fieldType)
+          || fieldType.isEnum()) {
+        continue;
+      }
+      f.setAccessible(true);
+      try {
+        Object inner = f.get(source);
+        if (inner != null && isPulsarSource(inner, depth + 1)) {
+          return true;
+        }
+      } catch (IllegalAccessException ignored) {
+      }
+    }
+    return false;
   }
 
   private static String required(Map<String, String> options, String key) {

--- a/gluten-flink/planner/src/main/java/org/apache/gluten/velox/PulsarSourceSinkFactory.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/velox/PulsarSourceSinkFactory.java
@@ -20,6 +20,7 @@ import org.apache.gluten.streaming.api.operators.GlutenStreamSource;
 import org.apache.gluten.table.runtime.operators.GlutenSourceFunction;
 import org.apache.gluten.util.LogicalTypeConverter;
 import org.apache.gluten.util.PlanNodeIdGenerator;
+import org.apache.gluten.util.ReflectUtils;
 
 import io.github.zhztheplayer.velox4j.connector.PulsarConnectorSplit;
 import io.github.zhztheplayer.velox4j.connector.PulsarTableHandle;
@@ -37,19 +38,14 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.UUID;
 
 public class PulsarSourceSinkFactory implements VeloxSourceSinkFactory {
@@ -184,7 +180,7 @@ public class PulsarSourceSinkFactory implements VeloxSourceSinkFactory {
   }
 
   static boolean isPulsarSource(Object source) {
-    return containsPulsarClass(source, 2, Collections.newSetFromMap(new IdentityHashMap<>()));
+    return source.getClass().getSimpleName().equals("PulsarSource");
   }
 
   private static String required(Map<String, String> options, String key) {
@@ -301,71 +297,11 @@ public class PulsarSourceSinkFactory implements VeloxSourceSinkFactory {
     Class<?> clazz = target.getClass();
     while (clazz != null) {
       try {
-        Field field = clazz.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return Optional.ofNullable(field.get(target));
-      } catch (NoSuchFieldException e) {
+        return Optional.ofNullable(ReflectUtils.getObjectField(clazz, target, fieldName));
+      } catch (FlinkRuntimeException e) {
         clazz = clazz.getSuperclass();
-      } catch (IllegalAccessException e) {
-        throw new FlinkRuntimeException(e);
       }
     }
     return Optional.empty();
-  }
-
-  private static boolean containsPulsarClass(Object target, int depth, Set<Object> visited) {
-    if (target == null || depth < 0 || visited.contains(target)) {
-      return false;
-    }
-    visited.add(target);
-
-    Class<?> clazz = target.getClass();
-    if (clazz.getName().toLowerCase(Locale.ROOT).contains("pulsar")) {
-      return true;
-    }
-    if (isLeafClass(clazz)) {
-      return false;
-    }
-    if (target instanceof Collection) {
-      return ((Collection<?>) target)
-          .stream().anyMatch(value -> containsPulsarClass(value, depth - 1, visited));
-    }
-    if (target instanceof Map) {
-      return ((Map<?, ?>) target)
-          .values().stream().anyMatch(value -> containsPulsarClass(value, depth - 1, visited));
-    }
-    if (clazz.isArray()) {
-      if (target instanceof Object[]) {
-        return Arrays.stream((Object[]) target)
-            .anyMatch(value -> containsPulsarClass(value, depth - 1, visited));
-      }
-      return false;
-    }
-
-    Class<?> current = clazz;
-    while (current != null && !isLeafClass(current)) {
-      for (Field declaredField : current.getDeclaredFields()) {
-        if (Modifier.isStatic(declaredField.getModifiers())) {
-          continue;
-        }
-        try {
-          declaredField.setAccessible(true);
-          if (containsPulsarClass(declaredField.get(target), depth - 1, visited)) {
-            return true;
-          }
-        } catch (IllegalAccessException e) {
-          throw new FlinkRuntimeException(e);
-        }
-      }
-      current = current.getSuperclass();
-    }
-    return false;
-  }
-
-  private static boolean isLeafClass(Class<?> clazz) {
-    return clazz.isPrimitive()
-        || clazz.isEnum()
-        || clazz.getName().startsWith("java.lang.")
-        || clazz.getName().startsWith("java.time.");
   }
 }

--- a/gluten-flink/planner/src/main/resources/META-INF/services/org.apache.gluten.velox.VeloxSourceSinkFactory
+++ b/gluten-flink/planner/src/main/resources/META-INF/services/org.apache.gluten.velox.VeloxSourceSinkFactory
@@ -1,5 +1,6 @@
 org.apache.gluten.velox.FromElementsSourceFactory
 org.apache.gluten.velox.KafkaSourceSinkFactory
+org.apache.gluten.velox.PulsarSourceSinkFactory
 org.apache.gluten.velox.PrintSinkFactory
 org.apache.gluten.velox.NexmarkSourceFactory
 org.apache.gluten.velox.FileSystemSinkFactory

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/config/VeloxConnectorConfig.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/config/VeloxConnectorConfig.java
@@ -33,6 +33,7 @@ public class VeloxConnectorConfig {
       List.of(
           "connector-nexmark",
           "connector-kafka",
+          "connector-pulsar",
           "connector-fuzzer",
           "connector-filesystem",
           "connector-from-elements",

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
@@ -110,6 +110,7 @@ public class GlutenSourceFunction<OUT> extends RichParallelSourceFunction<OUT>
           processAvailableElement(sourceContext);
           break;
         case BLOCKED:
+          task.waitFor();
           break;
         default:
           return;

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/velox/VeloxSourceSinkFactory.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/velox/VeloxSourceSinkFactory.java
@@ -22,13 +22,28 @@ import org.apache.flink.table.data.RowData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
 public interface VeloxSourceSinkFactory {
 
   static final Logger LOG = LoggerFactory.getLogger(VeloxSourceSinkFactory.class);
+
+  String FACTORY_CLASS_LOADER_KEY = "velox.source-sink.factory.classloader";
+
+  List<String> FACTORY_CLASS_NAMES =
+      List.of(
+          "org.apache.gluten.velox.FromElementsSourceFactory",
+          "org.apache.gluten.velox.KafkaSourceSinkFactory",
+          "org.apache.gluten.velox.PulsarSourceSinkFactory",
+          "org.apache.gluten.velox.PrintSinkFactory",
+          "org.apache.gluten.velox.NexmarkSourceFactory",
+          "org.apache.gluten.velox.FileSystemSinkFactory",
+          "org.apache.gluten.velox.FuzzerSourceSinkFactory");
 
   /** Match the conditions to determine if the operator can be offloaded to velox. */
   boolean match(Transformation<RowData> transformation);
@@ -43,21 +58,67 @@ public interface VeloxSourceSinkFactory {
 
   /** Choose the matched source/sink factory by given transformation. */
   private static Optional<VeloxSourceSinkFactory> getFactory(
-      Transformation<RowData> transformation) {
+      Transformation<RowData> transformation, Map<String, Object> parameters) {
     ServiceLoader<VeloxSourceSinkFactory> factories =
         ServiceLoader.load(VeloxSourceSinkFactory.class);
-    for (VeloxSourceSinkFactory factory : factories) {
-      if (factory.match(transformation)) {
-        return Optional.of(factory);
+    try {
+      for (VeloxSourceSinkFactory factory : factories) {
+        if (factory.match(transformation)) {
+          return Optional.of(factory);
+        }
+      }
+    } catch (ServiceConfigurationError e) {
+      LOG.warn("Failed to load Velox source/sink factory", e);
+    }
+    for (String factoryClassName : FACTORY_CLASS_NAMES) {
+      Optional<VeloxSourceSinkFactory> factory = loadFactory(factoryClassName, parameters);
+      if (factory.isPresent() && factory.get().match(transformation)) {
+        return factory;
       }
     }
     return Optional.empty();
   }
 
+  private static Optional<VeloxSourceSinkFactory> loadFactory(
+      String factoryClassName, Map<String, Object> parameters) {
+    Object classLoader = parameters.get(FACTORY_CLASS_LOADER_KEY);
+    if (classLoader instanceof ClassLoader) {
+      Optional<VeloxSourceSinkFactory> factory =
+          loadFactory(factoryClassName, (ClassLoader) classLoader);
+      if (factory.isPresent()) {
+        return factory;
+      }
+    }
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    Optional<VeloxSourceSinkFactory> factory = loadFactory(factoryClassName, contextClassLoader);
+    if (factory.isPresent()) {
+      return factory;
+    }
+    return loadFactory(factoryClassName, VeloxSourceSinkFactory.class.getClassLoader());
+  }
+
+  private static Optional<VeloxSourceSinkFactory> loadFactory(
+      String factoryClassName, ClassLoader classLoader) {
+    try {
+      return Optional.of(
+          (VeloxSourceSinkFactory)
+              Class.forName(factoryClassName, true, classLoader)
+                  .getDeclaredConstructor()
+                  .newInstance());
+    } catch (ClassNotFoundException e) {
+      return Optional.empty();
+    } catch (InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchMethodException e) {
+      throw new RuntimeException("Failed to instantiate Velox source/sink factory", e);
+    }
+  }
+
   /** Build Velox source, or fallback to flink orignal source . */
   static Transformation<RowData> buildSource(
       Transformation<RowData> transformation, Map<String, Object> parameters) {
-    Optional<VeloxSourceSinkFactory> factory = getFactory(transformation);
+    Optional<VeloxSourceSinkFactory> factory = getFactory(transformation, parameters);
     if (factory.isEmpty()) {
       LOG.warn(
           "Not find matched factory to build velox source transformation, and we will use flink original transformation {} instead.",
@@ -71,7 +132,7 @@ public interface VeloxSourceSinkFactory {
   /** Build Velox sink, or fallback to flink original sink. */
   static Transformation<RowData> buildSink(
       Transformation<RowData> transformation, Map<String, Object> parameters) {
-    Optional<VeloxSourceSinkFactory> factory = getFactory(transformation);
+    Optional<VeloxSourceSinkFactory> factory = getFactory(transformation, parameters);
     if (factory.isEmpty()) {
       LOG.warn(
           "Not find matched factory to build velox sink transformation, and we will use flink original transformation {} instead.",

--- a/gluten-flink/ut/pom.xml
+++ b/gluten-flink/ut/pom.xml
@@ -54,6 +54,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.gluten</groupId>
+      <artifactId>gluten-flink-planner</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-streaming-java</artifactId>
       <version>${flink.version}</version>

--- a/gluten-flink/ut/pom.xml
+++ b/gluten-flink/ut/pom.xml
@@ -39,6 +39,7 @@
             --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
             --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
             --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED
             --add-opens=java.base/sun.nio.ch=ALL-UNNAMED</extraJavaTestArgs>
   </properties>
 

--- a/gluten-flink/ut/pom.xml
+++ b/gluten-flink/ut/pom.xml
@@ -97,12 +97,6 @@
       <version>${flink.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.github.nexmark</groupId>
-      <artifactId>nexmark-flink</artifactId>
-      <version>0.3-SNAPSHOT</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.github.zhztheplayer</groupId>
       <artifactId>velox4j</artifactId>
       <version>${velox4j.version}</version>
@@ -225,4 +219,24 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>nexmark-tests</id>
+      <activation>
+        <property>
+          <name>maven.test.skip</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.nexmark</groupId>
+          <artifactId>nexmark-flink</artifactId>
+          <version>0.3-SNAPSHOT</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/gluten-flink/ut/pom.xml
+++ b/gluten-flink/ut/pom.xml
@@ -40,6 +40,7 @@
             --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
             --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
             --add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED
+            --add-opens=java.base/sun.reflect.generics.repository=ALL-UNNAMED
             --add-opens=java.base/sun.nio.ch=ALL-UNNAMED</extraJavaTestArgs>
   </properties>
 

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/custom/NexmarkTest.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/custom/NexmarkTest.java
@@ -71,7 +71,7 @@ public class NexmarkTest {
         }
       };
 
-  private static final int KAFKA_PORT = 9092;
+  private static final int KAFKA_PORT = 19092;
   private static String topicName = "nexmark";
 
   @RegisterExtension
@@ -83,7 +83,7 @@ public class NexmarkTest {
   private static final Map<String, String> KAFKA_VARIABLES =
       new HashMap<>() {
         {
-          put("BOOTSTRAP_SERVERS", "localhost:9092");
+          put("BOOTSTRAP_SERVERS", "localhost:" + KAFKA_PORT);
           put("NEXMARK_TABLE", "kafka");
         }
       };
@@ -282,6 +282,16 @@ public class NexmarkTest {
         for (Path entry : stream) {
           queryFiles.add(entry.getFileName().toString());
         }
+      }
+
+      String queryFilter = System.getProperty("nexmark.queries");
+      if (queryFilter != null && !queryFilter.trim().isEmpty()) {
+        List<String> selectedQueries =
+            Arrays.stream(queryFilter.split(","))
+                .map(String::trim)
+                .filter(query -> !query.isEmpty())
+                .collect(Collectors.toList());
+        queryFiles.retainAll(selectedQueries);
       }
 
       return queryFiles.stream().sorted().collect(Collectors.toList());

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/velox/NexmarkSourceFactoryTest.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/velox/NexmarkSourceFactoryTest.java
@@ -141,7 +141,7 @@ class NexmarkSourceFactoryTest {
             long.class,
             long.class);
     Object generatorConfig =
-        generatorConfigCtor.newInstance(nexmarkConfig, 0L, 0L, maxEvents, maxEvents, 0L);
+        generatorConfigCtor.newInstance(nexmarkConfig, 0L, 0L, maxEvents, 0L, 0L);
 
     Class<?> nexmarkSourceCls = Class.forName(NEXMARK_SOURCE_CN);
     Constructor<?> nexmarkSourceCtor =

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/velox/PulsarSourceSinkFactoryTest.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/velox/PulsarSourceSinkFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.velox;
+
+import org.apache.gluten.table.runtime.config.VeloxConnectorConfig;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PulsarSourceSinkFactoryTest {
+
+  @Test
+  void serviceLoaderDiscoversPulsarFactory() {
+    List<String> factoryNames =
+        StreamSupport.stream(ServiceLoader.load(VeloxSourceSinkFactory.class).spliterator(), false)
+            .map(factory -> factory.getClass().getName())
+            .collect(Collectors.toList());
+
+    assertThat(factoryNames).contains("org.apache.gluten.velox.PulsarSourceSinkFactory");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void runtimeConnectorConfigIncludesPulsarConnector() throws Exception {
+    Field connectors = VeloxConnectorConfig.class.getDeclaredField("CONNECTORS");
+    connectors.setAccessible(true);
+
+    assertThat((List<String>) connectors.get(null)).contains("connector-pulsar");
+  }
+
+  @Test
+  void tableParametersMapFlinkSqlOptionsToVeloxPulsarOptions() {
+    FakePulsarSource source = new FakePulsarSource();
+    source.options.put("pulsar.client.serviceUrl", "pulsar://127.0.0.1:16650");
+    source.options.put("admin-url", "http://127.0.0.1:18080");
+    source.options.put("topics", "persistent://public/default/gluten-pulsar-smoke");
+    source.options.put("pulsar.consumer.subscriptionName", "gluten-test-sub");
+    source.options.put("format", "raw");
+    source.options.put("value.format", "json");
+    source.options.put("source.start.message-id", "earliest");
+    source.subscriptionType = FakeSubscriptionType.Shared;
+
+    Map<String, String> tableParameters =
+        PulsarSourceSinkFactory.buildTableParameters(null, source);
+
+    assertThat(tableParameters)
+        .containsEntry("service.url", "pulsar://127.0.0.1:16650")
+        .containsEntry("admin.url", "http://127.0.0.1:18080")
+        .containsEntry("topic", "persistent://public/default/gluten-pulsar-smoke")
+        .containsEntry("subscription.name", "gluten-test-sub")
+        .containsEntry("subscription.type", "shared")
+        .containsEntry("format", "json")
+        .containsEntry("initial.position", "earliest");
+  }
+
+  @Test
+  void detectsWrappedPulsarSource() {
+    assertThat(PulsarSourceSinkFactory.isPulsarSource(new WrappedSource())).isTrue();
+  }
+
+  private static class FakePulsarSource {
+    private final Map<String, String> options = new HashMap<>();
+    private FakeSubscriptionType subscriptionType;
+  }
+
+  private static class WrappedSource {
+    private final Object source = new FakePulsarSource();
+  }
+
+  private enum FakeSubscriptionType {
+    Shared
+  }
+}

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/velox/PulsarSourceSinkFactoryTest.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/velox/PulsarSourceSinkFactoryTest.java
@@ -53,7 +53,7 @@ class PulsarSourceSinkFactoryTest {
 
   @Test
   void tableParametersMapFlinkSqlOptionsToVeloxPulsarOptions() {
-    FakePulsarSource source = new FakePulsarSource();
+    PulsarSource source = new PulsarSource();
     source.options.put("pulsar.client.serviceUrl", "pulsar://127.0.0.1:16650");
     source.options.put("admin-url", "http://127.0.0.1:18080");
     source.options.put("topics", "persistent://public/default/gluten-pulsar-smoke");
@@ -81,13 +81,13 @@ class PulsarSourceSinkFactoryTest {
     assertThat(PulsarSourceSinkFactory.isPulsarSource(new WrappedSource())).isTrue();
   }
 
-  private static class FakePulsarSource {
+  private static class PulsarSource {
     private final Map<String, String> options = new HashMap<>();
     private FakeSubscriptionType subscriptionType;
   }
 
   private static class WrappedSource {
-    private final Object source = new FakePulsarSource();
+    private final Object source = new PulsarSource();
   }
 
   private enum FakeSubscriptionType {


### PR DESCRIPTION
## Summary

Add Gluten Flink planner/runtime support for Pulsar sources backed by Velox. Solves #12310 .
Depends on https://github.com/bigo-sg/velox/pull/42 and https://github.com/bigo-sg/velox4j/pull/35.

This patch:
- Adds a `PulsarSourceSinkFactory` that maps Flink Pulsar table/source options to Velox Pulsar connector parameters.
- Registers `connector-pulsar` in Gluten Flink connector config and service discovery.
- Passes the planner classloader into runtime source/sink factory discovery so planner-side factories can be loaded reliably.
- Makes blocked Velox source tasks wait instead of spinning.
- Adds unit tests for Pulsar factory discovery, connector config registration, option mapping, and wrapped Pulsar source detection.

## Test Plan

- `mvn -pl ut -am -Dtest=PulsarSourceSinkFactoryTest -DfailIfNoTests=false test`
- Manually verified a Flink SQL Pulsar source job with parallelism 2 against local Pulsar standalone:
  - job remained RUNNING
  - two Pulsar CPP consumers were connected under a Shared subscription
  - both Flink source subtasks consumed records
  - Pulsar backlog reached 0 for the test subscription

## AI Tooling Disclosure
Cowork with codex.