### PR TITLE
[VL] Support lead, lag and nth_value offloading with constant input

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -468,9 +468,9 @@ object VeloxBackendSettings extends BackendSettingsApi {
           }
           windowExpression.windowFunction match {
             case _: RowNumber | _: Rank | _: CumeDist | _: DenseRank | _: PercentRank | _: NTile =>
-            case nv: NthValue if !nv.input.foldable =>
-            case l: Lag if !l.input.foldable =>
-            case l: Lead if !l.input.foldable =>
+            case _: NthValue =>
+            case _: Lag =>
+            case _: Lead =>
             case aggrExpr: AggregateExpression
                 if !aggrExpr.aggregateFunction.isInstanceOf[ApproximatePercentile]
                   && !aggrExpr.aggregateFunction.isInstanceOf[Percentile]

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -509,13 +509,6 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
         " (partition by l_suppkey order by l_suppkey, l_orderkey) from lineitem ") {
       checkGlutenPlan[WindowExecTransformer]
     }
-
-    // Foldable input of nth_value is not supported.
-    runQueryAndCompare(
-      "select l_suppkey, l_orderkey, nth_value(1, 2) over" +
-        " (partition by l_suppkey order by l_orderkey) from lineitem ") {
-      checkSparkPlan[WindowExec]
-    }
   }
 
   test("df.count()") {

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/WindowFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/WindowFunctionsValidateSuite.scala
@@ -34,4 +34,23 @@ class WindowFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  test("lag/lead, nth_value window function with constant input") {
+    runQueryAndCompare(
+      "select lag(10, -2) over" +
+        " (partition by l_suppkey order by l_orderkey) from lineitem") {
+      checkGlutenPlan[WindowExecTransformer]
+    }
+
+    runQueryAndCompare(
+      "select lead(10, -2) over" +
+        " (partition by l_suppkey order by l_orderkey) from lineitem") {
+      checkGlutenPlan[WindowExecTransformer]
+    }
+
+    runQueryAndCompare(
+      "select nth_value(10, 2) over" +
+        " (partition by l_suppkey order by l_orderkey) from lineitem") {
+      checkGlutenPlan[WindowExecTransformer]
+    }
+  }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/WindowFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/WindowFunctionsValidateSuite.scala
@@ -36,13 +36,13 @@ class WindowFunctionsValidateSuite extends FunctionsValidateSuite {
 
   test("lag/lead, nth_value window function with constant input") {
     runQueryAndCompare(
-      "select lag(10, -2) over" +
+      "select lag(10, 2) over" +
         " (partition by l_suppkey order by l_orderkey) from lineitem") {
       checkGlutenPlan[WindowExecTransformer]
     }
 
     runQueryAndCompare(
-      "select lead(10, -2) over" +
+      "select lead(10, 2) over" +
         " (partition by l_suppkey order by l_orderkey) from lineitem") {
       checkGlutenPlan[WindowExecTransformer]
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

This is already one Velox PR supports constant inputs for them. See https://github.com/facebookincubator/velox/pull/16915.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
New tests are added.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?
No.
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
