### PR TITLE
[GLUTEN-12282][VL] Check JoinRel's post-join filter in native validation

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -401,6 +401,28 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
     }
   }
 
+  test("fallback when join post filter has unsupported expression") {
+    GlutenSuiteUtils.withFallbackEventListener(spark.sparkContext) {
+      events =>
+        val df = spark.sql("""
+                             |select tmp1.c1, tmp1.c2 from tmp1
+                             |left join tmp2
+                             |on tmp1.c1 = tmp2.c1
+                             |and tmp1.c2 not rlike '^[\\u4e00-\\u9fa5]{2,10}[0-9]+$'
+                             |""".stripMargin)
+        df.collect()
+        GlutenSuiteUtils.waitUntilEmpty(spark.sparkContext)
+
+        val broadcastHashJoin = find(df.queryExecution.executedPlan) {
+          _.isInstanceOf[BroadcastHashJoinExec]
+        }
+        assert(broadcastHashJoin.isDefined)
+        val fallbackReasons = events.flatMap(_.fallbackNodeToReason.values)
+        assert(fallbackReasons.nonEmpty)
+        assert(fallbackReasons.forall(_.contains("rlike due to Pattern")))
+    }
+  }
+
   test("no fallback event emitted for vanilla Spark execution with gluten disabled") {
     // Regression test: before the fix, GlutenQueryExecutionListener would post a
     // GlutenPlanFallbackEvent even when spark.gluten.enabled=false (e.g. the vanilla baseline run

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -1071,6 +1071,9 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
   }
 
   if (joinRel.has_post_join_filter()) {
+      if (!validateExpression(joinRel.post_join_filter(), rowType)) {
+        return false;
+      }
     auto expression = exprConverter_->toVeloxExpr(joinRel.post_join_filter(), rowType);
     exec::ExprSet exprSet({std::move(expression)}, execCtx_.get());
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -1071,9 +1071,9 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::JoinRel& joinRel
   }
 
   if (joinRel.has_post_join_filter()) {
-      if (!validateExpression(joinRel.post_join_filter(), rowType)) {
-        return false;
-      }
+    if (!validateExpression(joinRel.post_join_filter(), rowType)) {
+      return false;
+    }
     auto expression = exprConverter_->toVeloxExpr(joinRel.post_join_filter(), rowType);
     exec::ExprSet exprSet({std::move(expression)}, execCtx_.get());
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds native validation for JoinRel post-join filter expressions, fallback it if expression is not supported.

Fix https://github.com/apache/gluten/issues/12282


## How was this patch tested?

Add unit test.


## Was this patch authored or co-authored using generative AI tooling?

No.