### PR TITLE
[GLUTEN-11570][VL] Wire spark.sql.binaryOutputStyle to Velox to_pretty_string

### DIFF
--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -97,6 +97,8 @@ const std::string kSparkLegacyStatisticalAggregate = "spark.sql.legacy.statistic
 
 const std::string kSparkJsonIgnoreNullFields = "spark.sql.jsonGenerator.ignoreNullFields";
 
+const std::string kSparkBinaryOutputStyle = "spark.sql.binaryOutputStyle";
+
 // cudf
 const std::string kCudfEnabled = "spark.gluten.sql.columnar.cudf";
 constexpr bool kCudfEnabledDefault = false;

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -777,6 +777,9 @@ std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryC
         configs[veloxKey] = valueOptional.value();
       }
     };
+    setIfExists(
+        kSparkBinaryOutputStyle,
+        SparkQueryConfig::qualify(SparkQueryConfig::kBinaryOutputStyle));
     setIfExists(kQueryTraceEnabled, velox::core::QueryConfig::kQueryTraceEnabled);
     setIfExists(kQueryTraceDir, velox::core::QueryConfig::kQueryTraceDir);
     setIfExists(kQueryTraceMaxBytes, velox::core::QueryConfig::kQueryTraceMaxBytes);

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -242,9 +242,42 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
       ("12".getBytes(StandardCharsets.UTF_8), "ABC.".getBytes(StandardCharsets.UTF_8)),
       ("34".getBytes(StandardCharsets.UTF_8), "12346".getBytes(StandardCharsets.UTF_8))
     ).toDF()
-    val expectedAnswer =
-      Seq(Seq("_1", "_2"), Seq("[31 32]", "[41 42 43 2E]"), Seq("[33 34]", "[31 32 33 34 36]"))
-    assert(df.getRows(10, 20) === expectedAnswer)
+
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "HEX_DISCRETE") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("[31 32]", "[41 42 43 2E]"),
+        Seq("[33 34]", "[31 32 33 34 36]"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "HEX") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("3132", "4142432E"),
+        Seq("3334", "3132333436"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "BASE64") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("MTI", "QUJDLg"),
+        Seq("MzQ", "MTIzNDY"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "UTF-8") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("12", "ABC."),
+        Seq("34", "12346"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "BASIC") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("[49, 50]", "[65, 66, 67, 46]"),
+        Seq("[51, 52]", "[49, 50, 51, 52, 54]"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
   }
 
   // TODO: fix in spark-4.0

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameSuite.scala
@@ -400,9 +400,42 @@ class GlutenDataFrameSuite extends DataFrameSuite with GlutenSQLTestsTrait {
       ("12".getBytes(StandardCharsets.UTF_8), "ABC.".getBytes(StandardCharsets.UTF_8)),
       ("34".getBytes(StandardCharsets.UTF_8), "12346".getBytes(StandardCharsets.UTF_8))
     ).toDF()
-    val expectedAnswer =
-      Seq(Seq("_1", "_2"), Seq("[31 32]", "[41 42 43 2E]"), Seq("[33 34]", "[31 32 33 34 36]"))
-    assert(df.getRows(10, 20) === expectedAnswer)
+
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "HEX_DISCRETE") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("[31 32]", "[41 42 43 2E]"),
+        Seq("[33 34]", "[31 32 33 34 36]"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "HEX") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("3132", "4142432E"),
+        Seq("3334", "3132333436"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "BASE64") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("MTI", "QUJDLg"),
+        Seq("MzQ", "MTIzNDY"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "UTF-8") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("12", "ABC."),
+        Seq("34", "12346"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
+    withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> "BASIC") {
+      val expectedAnswer = Seq(
+        Seq("_1", "_2"),
+        Seq("[49, 50]", "[65, 66, 67, 46]"),
+        Seq("[51, 52]", "[49, 50, 51, 52, 54]"))
+      assert(df.getRows(10, 20) === expectedAnswer)
+    }
   }
 
   // TODO: fix in spark-4.0


### PR DESCRIPTION
## What changes were proposed in this pull request?

Spark 4.0+ introduced `spark.sql.binaryOutputStyle` to control how binary values are rendered. Velox's `to_pretty_string` previously only supported the default `HEX_DISCRETE` style. This change wires the Spark config through Gluten to Velox so all 5 styles (`HEX_DISCRETE`, `HEX`, `BASE64`, `UTF-8`, `BASIC`) are honored.

  - Add `kSparkBinaryOutputStyle = "spark.sql.binaryOutputStyle"` constant.
  - Forward it via `setIfExists` in `WholeStageResultIterator`, mapping to
    Velox's `SparkQueryConfig::kBinaryOutputStyle` (`binary_output_style`).
  - Expand `GlutenDataFrameSuite.getRows: binary` in spark40 and spark41 to
    cover all 5 styles, mirroring the upstream Spark `DataFrameSuite` test.

## Depends on

Velox PR: https://github.com/facebookincubator/velox/pull/17884
(adds `SparkQueryConfig::kBinaryOutputStyle` + 5 styles in `ToPrettyStringVarbinaryFunction`).

Once that lands, this PR's behavior fully kicks in. With only this Gluten PR (and the Velox PR not yet merged), the existing `HEX_DISCRETE` behavior is preserved, but `HEX`/`BASE64`/`UTF-8`/`BASIC` will not take effect.

## How was this patch tested?

`GlutenDataFrameSuite.getRows: binary` in spark40 and spark41; this test covers all 5 styles using `withSQLConf(SQLConf.BINARY_OUTPUT_STYLE.key -> ...)`, mirroring the upstream Spark `DataFrameSuite.getRows: binary` test.

  Fixes #11570
