### PR TITLE
[GLUTEN-12260][VL] Fix CheckOverflowTransformer passing wrong child dataType

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DecimalArithmeticValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DecimalArithmeticValidateSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.functions
+
+import org.apache.gluten.execution.ProjectExecTransformer
+
+class DecimalArithmeticValidateSuite extends FunctionsValidateSuite {
+
+  import testImplicits._
+
+  // GLUTEN-12260: CheckOverflowTransformer was passing original.child.dataType (Spark's declared
+  // type on the raw BinaryArithmetic) instead of child.dataType (the transformer's actual output
+  // type, computed by DecimalArithmeticUtil.getResultType after rescaleLiteral).  The mismatch
+  // made createCheckOverflowExprNode generate a cast with the wrong source type, causing Velox
+  // type validation to fail and ColumnarPartialProjectRule to fall back the entire Project to JVM.
+  test("GLUTEN-12260: bigint aggregate divided by integer-valued decimal literal stays native") {
+    val t1 = Seq(200L).toDF("val")
+    val t2 = Seq(100L, 100L, 100L, 100L, 100L).toDF("val")
+    withTempView("t1_dec", "t2_dec") {
+      t1.createOrReplaceTempView("t1_dec")
+      t2.createOrReplaceTempView("t2_dec")
+      runQueryAndCompare(
+        """
+          |SELECT a.val,
+          |       (a.val - COALESCE(SUM(b.val), 0) / 5.0)
+          |           / (COALESCE(SUM(b.val), 0) / 5.0) AS growth_rate
+          |FROM t1_dec a CROSS JOIN t2_dec b
+          |GROUP BY a.val
+          |""".stripMargin
+      ) {
+        checkGlutenPlan[ProjectExecTransformer]
+      }
+    }
+  }
+}

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
@@ -87,7 +87,7 @@ case class CheckOverflowTransformer(
       context,
       substraitExprName,
       child.doTransform(context),
-      original.child.dataType,
+      child.dataType,
       original.dataType,
       original.nullable,
       original.nullOnOverflow)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #12260

**Root cause**

`CheckOverflowTransformer` was passing `original.child.dataType` — Spark's declared type on the raw `BinaryArithmetic` — to `createCheckOverflowExprNode` as the `childResultType` argument.

`DecimalArithmeticExpressionTransformer` overrides `dataType` to return `resultType`, the type computed by `DecimalArithmeticUtil.getResultType()` after `rescaleLiteral` adjusts the operands. When the literal is integer-valued (e.g. `5.0`, `BigDecimal.isValidLong == true`), `rescaleLiteral` rescales it, changing the result type. The transformer's actual output type therefore differs from Spark's declared type on the original expression.

`VeloxTransformerApi.createCheckOverflowExprNode` compares `childResultType` with the target `DecimalType` to decide whether to insert a cast:

```scala
if (childResultType.equals(dataType)) {
  childNode          // no cast needed
} else {
  ExpressionBuilder.makeCast(typeNode, childNode, nullOnOverflow)  // insert cast
}
```

With the wrong `childResultType`, the cast is generated with the wrong source type, making the Substrait plan invalid. Velox's SimpleFunction type validation rejects it, and `ColumnarPartialProjectRule` falls back the entire `Project` to JVM.

**Fix**

Pass `child.dataType` (the transformer's actual output type) instead of `original.child.dataType`. For transformers that do not override `dataType` (returning `original.dataType` by default) the behaviour is unchanged.

**Files changed**

- `UnaryExpressionTransformer.scala` — `original.child.dataType` → `child.dataType` in `CheckOverflowTransformer.doTransform`
- `DecimalArithmeticValidateSuite.scala` (new) — regression test that reproduces the exact trigger conditions from the issue report and asserts `ProjectExecTransformer` is used

---

## How was this patch tested?

New regression test `DecimalArithmeticValidateSuite` in `backends-velox`:

- Creates two BIGINT temp views
- Runs `SELECT a.val, (a.val - COALESCE(SUM(b.val), 0) / 5.0) / (COALESCE(SUM(b.val), 0) / 5.0) AS growth_rate FROM t1 CROSS JOIN t2 GROUP BY a.val` (the exact reproducer from #12260)
- Asserts `ProjectExecTransformer` is present in the executed plan (would fail before this fix)

Verified locally: 1/1 test passes.

---

## Was this patch authored or co-authored using generative AI tooling?

`Generated-by: Claude Code (claude-sonnet-4-6)`