### PR TITLE
[CORE] Bump version to 1.8.0-SNAPSHOT

### DIFF
--- a/backends-clickhouse/pom.xml
+++ b/backends-clickhouse/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>backends-clickhouse</artifactId>

--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>backends-velox</artifactId>

--- a/dev/info.sh
+++ b/dev/info.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 set -e
 
-version='1.7.0-SNAPSHOT'
+version='1.8.0-SNAPSHOT'
 cb='```'
 
 if [ ! -x "$(command -v cmake)" ]; then

--- a/dev/release/bump-version.sh
+++ b/dev/release/bump-version.sh
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 <new-version>  e.g., 1.7.0-SNAPSHOT"
+  echo "Usage: $0 <new-version>  e.g., 1.8.0-SNAPSHOT"
   exit 1
 }
 

--- a/gluten-arrow/pom.xml
+++ b/gluten-arrow/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-celeborn/pom.xml
+++ b/gluten-celeborn/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-core/pom.xml
+++ b/gluten-core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gluten-core</artifactId>

--- a/gluten-delta/pom.xml
+++ b/gluten-delta/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-flink/docs/Flink.md
+++ b/gluten-flink/docs/Flink.md
@@ -98,8 +98,8 @@ export FLINK_HOME=
 cd $FLINK_HOME
 mkdir -p gluten_lib
 ln -s $VELOX4J_HOME/target/velox4j-0.1.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar
-ln -s $GLUTEN_FLINK_HOME/runtime/target/gluten-flink-runtime-1.7.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-runtime-1.6.0.jar
-ln -s $GLUTEN_FLINK_HOME/loader/target/gluten-flink-loader-1.7.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-loader-1.6.0.jar
+ln -s $GLUTEN_FLINK_HOME/runtime/target/gluten-flink-runtime-1.8.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-runtime-1.8.0-SNAPSHOT.jar
+ln -s $GLUTEN_FLINK_HOME/loader/target/gluten-flink-loader-1.8.0-SNAPSHOT.jar $FLINK_HOME/gluten_lib/gluten-flink-loader-1.8.0-SNAPSHOT.jar
 ```
 
 And make them loaded before flink libraries.
@@ -110,7 +110,7 @@ Gluten classes need to be loaded first in Flink,
 you can modify the constructFlinkClassPath function in `$FLINK_HOME/bin/config.sh` like this: 
 
 ```
-GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.6.0.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.6.0.jar:"
+GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.8.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.8.0-SNAPSHOT.jar:"
 echo "$GLUTEN_JAR""$FLINK_CLASSPATH""$FLINK_DIST"
 ```
 
@@ -156,7 +156,7 @@ make rocksdbjava -i
     ```
 - modify `${FLINK_HOME}/bin/config.sh` as follows
     ```
-    GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.6.0.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.6.0.jar:$FLINK_HOME/gluten_lib/rocksdbjni-6.20.3-linux64.jar"
+    GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.8.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.8.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/rocksdbjni-6.20.3-linux64.jar"
     echo "$GLUTEN_JAR""$FLINK_CLASSPATH""$FLINK_DIST"
     ```
 - set rocksdb config in `${FLINK_HOME}/conf/config.yaml`

--- a/gluten-flink/docs/Gluten-Flink-troubleshooting.md
+++ b/gluten-flink/docs/Gluten-Flink-troubleshooting.md
@@ -10,6 +10,6 @@ Gluten classes need to be loaded first in Flink,
 you can modify the constructFlinkClassPath function in `$FLINK_HOME/bin/config.sh` like this:
 
 ```
-GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.6.0.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.6.0.jar:"
+GLUTEN_JAR="$FLINK_HOME/gluten_lib/gluten-flink-loader-1.8.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/velox4j-0.1.0-SNAPSHOT.jar:$FLINK_HOME/gluten_lib/gluten-flink-runtime-1.8.0-SNAPSHOT.jar:"
 echo "$GLUTEN_JAR""$FLINK_CLASSPATH""$FLINK_DIST"
 ```

--- a/gluten-flink/loader/pom.xml
+++ b/gluten-flink/loader/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-flink</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-flink/planner/pom.xml
+++ b/gluten-flink/planner/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-flink</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-flink/pom.xml
+++ b/gluten-flink/pom.xml
@@ -17,7 +17,7 @@
 
   <groupId>org.apache.gluten</groupId>
   <artifactId>gluten-flink</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Gluten Flink</name>
 

--- a/gluten-flink/runtime/pom.xml
+++ b/gluten-flink/runtime/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-flink</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-flink/ut/pom.xml
+++ b/gluten-flink/ut/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-flink</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-hudi/pom.xml
+++ b/gluten-hudi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-iceberg/pom.xml
+++ b/gluten-iceberg/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-kafka/pom.xml
+++ b/gluten-kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-paimon/pom.xml
+++ b/gluten-paimon/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-substrait/pom.xml
+++ b/gluten-substrait/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gluten-substrait</artifactId>

--- a/gluten-ui/pom.xml
+++ b/gluten-ui/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gluten-ui</artifactId>

--- a/gluten-uniffle/pom.xml
+++ b/gluten-uniffle/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/common/pom.xml
+++ b/gluten-ut/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-ut</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/pom.xml
+++ b/gluten-ut/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/spark33/pom.xml
+++ b/gluten-ut/spark33/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-ut</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/spark34/pom.xml
+++ b/gluten-ut/spark34/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-ut</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/spark35/pom.xml
+++ b/gluten-ut/spark35/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-ut</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/spark40/pom.xml
+++ b/gluten-ut/spark40/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-ut</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/spark41/pom.xml
+++ b/gluten-ut/spark41/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-ut</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/gluten-ut/test/pom.xml
+++ b/gluten-ut/test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-ut</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
   <groupId>org.apache.gluten</groupId>
   <artifactId>gluten-parent</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Gluten Parent Pom</name>

--- a/shims/common/pom.xml
+++ b/shims/common/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/pom.xml
+++ b/shims/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/spark33/pom.xml
+++ b/shims/spark33/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/spark34/pom.xml
+++ b/shims/spark34/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/spark35/pom.xml
+++ b/shims/spark35/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/spark40/pom.xml
+++ b/shims/spark40/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/shims/spark41/pom.xml
+++ b/shims/spark41/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>spark-sql-columnar-shims</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tools/gluten-it/3rd/pom.xml
+++ b/tools/gluten-it/3rd/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-it</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.apache.gluten</groupId>
   <artifactId>gluten-it-3rd</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/tools/gluten-it/common/pom.xml
+++ b/tools/gluten-it/common/pom.xml
@@ -21,18 +21,18 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-it</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>gluten-it-common</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.gluten</groupId>
       <artifactId>gluten-it-3rd</artifactId>
-      <version>1.7.0-SNAPSHOT</version>
+      <version>1.8.0-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/tools/gluten-it/package/pom.xml
+++ b/tools/gluten-it/package/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache.gluten</groupId>
     <artifactId>gluten-it</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
   </parent>
   <artifactId>gluten-it-package</artifactId>
   <packaging>pom</packaging>

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -40,7 +40,7 @@
     <delta.version>2.4.0</delta.version>
     <celeborn.version>0.6.3</celeborn.version>
     <uniffle.version>0.10.0</uniffle.version>
-    <gluten.version>1.7.0-SNAPSHOT</gluten.version>
+    <gluten.version>1.8.0-SNAPSHOT</gluten.version>
     <tpch.version>1.1</tpch.version>
     <tpcds.version>1.4</tpcds.version>
 

--- a/tools/gluten-it/pom.xml
+++ b/tools/gluten-it/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>org.apache.gluten</groupId>
   <artifactId>gluten-it</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>3rd</module>

--- a/tools/qualification-tool/pom.xml
+++ b/tools/qualification-tool/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.gluten</groupId>
   <artifactId>qualification-tool</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <name>Qualification Tool</name>
 
   <properties>

--- a/tools/workload/benchmark_velox/params.yaml.template
+++ b/tools/workload/benchmark_velox/params.yaml.template
@@ -2,7 +2,7 @@
 gluten_home: /home/sparkuser/gluten
 
 # Local path to gluten jar.
-gluten_target_jar: /home/sparkuser/gluten-velox-bundle-spark3.5_2.12-linux_amd64-1.7.0-SNAPSHOT.jar
+gluten_target_jar: /home/sparkuser/gluten-velox-bundle-spark3.5_2.12-linux_amd64-1.8.0-SNAPSHOT.jar
 
 # Spark app master.
 master: yarn

--- a/tools/workload/benchmark_velox/tpc_workload.ipynb
+++ b/tools/workload/benchmark_velox/tpc_workload.ipynb
@@ -21,7 +21,7 @@
     "gluten_home='/home/sparkuser/gluten'\n",
     "\n",
     "# Local path to gluten jar.\n",
-    "gluten_target_jar='/home/sparkuser/gluten-velox-bundle-spark3.5_2.12-linux_amd64-1.7.0-SNAPSHOT.jar'\n",
+    "gluten_target_jar='/home/sparkuser/gluten-velox-bundle-spark3.5_2.12-linux_amd64-1.8.0-SNAPSHOT.jar'\n",
     "\n",
     "# Spark app master. e.g. 'yarn'\n",
     "master='yarn'\n",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
We have already cut branch-1.7 for preparing the new release. So we need to bump the version for main branch.

Bump version from 1.7.0-SNAPSHOT to 1.8.0-SNAPSHOT across all modules (via bump-version.sh) and supporting scripts/docs. Also corrects stale gluten-flink jar version references (1.6.0 → 1.8.0-SNAPSHOT) in the Flink docs.
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
CI.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?
No.
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
