### PR TITLE
[VL][CH] Compute broadcast aggregates in a single pass

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHSparkPlanExecApi.scala
@@ -568,7 +568,11 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
       CHExecUtil.buildSideRDD(dataSize, newChild, isNullAware, keyColumnIndex).collect
 
     val batches = countsAndBytes.map(_._2)
-    val totalBatchesSize = batches.map(_.length).sum
+    val (totalBatchesSize, rowCount, hasNullKeyValues) =
+      countsAndBytes.foldLeft((0, 0L, false)) {
+        case ((size, rows, hasNull), (count, bytes, hasNullKey)) =>
+          (size + bytes.length, rows + count, hasNull || hasNullKey)
+      }
     val rawSize = dataSize.value
     if (rawSize >= GlutenConfig.get.maxBroadcastTableSize) {
       throw new GlutenException(
@@ -581,8 +585,6 @@ class CHSparkPlanExecApi extends SparkPlanExecApi with Logging {
         s"Invalid rawSize($rawSize) or totalBatchesSize ($totalBatchesSize). Ensure the shuffle" +
           s" written bytes is correct.")
     }
-    val rowCount = countsAndBytes.map(_._1).sum
-    val hasNullKeyValues = countsAndBytes.map(_._3).foldLeft[Boolean](false)((b, a) => { b || a })
     numOutputRows += rowCount
     ClickHouseBuildSideRelation(
       mode,

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -850,14 +850,17 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
       .mapPartitions(itr => Iterator(BroadcastUtils.serializeStream(itr)))
       .filter(_.numRows != 0)
       .collect
-    val rawSize = serialized.map(_.sizeInBytes()).sum
+    val (rawSize, totalNumRows) = serialized.foldLeft((0L, 0L)) {
+      case ((accSize, accRows), result) =>
+        (accSize + result.sizeInBytes(), accRows + result.numRows)
+    }
     if (rawSize >= GlutenConfig.get.maxBroadcastTableSize) {
       throw new SparkException(
         "Cannot broadcast the table that is larger than " +
           s"${SparkMemoryUtil.bytesToString(GlutenConfig.get.maxBroadcastTableSize)}: " +
           s"${SparkMemoryUtil.bytesToString(rawSize)}")
     }
-    numOutputRows += serialized.map(_.numRows).sum
+    numOutputRows += totalNumRows
     dataSize += rawSize
 
     val rawThreads =


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two small, equivalent refactors that fold multiple traversals over a collected `Seq` into a single pass:

- `VeloxSparkPlanExecApi.collectExecuteBroadcastByteArray`: previously walked `serialized` twice — once to sum `sizeInBytes` and again to sum `numRows`. Combined into one `foldLeft`.
- `CHSparkPlanExecApi.collectExecuteBroadcastHashRelationByteArray`: previously walked `countsAndBytes` three times — `map+sum` for `totalBatchesSize`, `map+sum` for `rowCount`, and `map+foldLeft` for `hasNullKeyValues`. Combined into one `foldLeft`.

### How was this patch tested?

No behavior change; covered by existing broadcast join tests.