### PR TITLE
[GLUTEN-12341][FLINK] Update watermark gauge in output collector

### DIFF
--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/runtime/tasks/GlutenOutputCollector.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/streaming/runtime/tasks/GlutenOutputCollector.java
@@ -49,6 +49,7 @@ public class GlutenOutputCollector<T> implements WatermarkGaugeExposingOutput<St
 
   @Override
   public void emitWatermark(Watermark watermark) {
+    watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
     // This is only used when task is finished, so broadcast it.
     outputs.values().forEach(output -> output.emitWatermark(watermark));
   }
@@ -73,7 +74,9 @@ public class GlutenOutputCollector<T> implements WatermarkGaugeExposingOutput<St
     StatefulElement element = (StatefulElement) record.getValue();
     OutputWithChainingCheck<StreamRecord<T>> output = outputs.get(element.getNodeId());
     if (element.isWatermark()) {
-      output.emitWatermark(new Watermark(element.asWatermark().getTimestamp()));
+      Watermark watermark = new Watermark(element.asWatermark().getTimestamp());
+      watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+      output.emitWatermark(watermark);
     } else {
       output.collect(record);
     }

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/streaming/runtime/tasks/GlutenOutputCollectorTest.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/streaming/runtime/tasks/GlutenOutputCollectorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.streaming.runtime.tasks;
+
+import io.github.zhztheplayer.velox4j.stateful.StatefulElement;
+import io.github.zhztheplayer.velox4j.stateful.StatefulWatermark;
+
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OutputWithChainingCheck;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.util.OutputTag;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlutenOutputCollectorTest {
+
+  @Test
+  void emitWatermarkUpdatesGaugeAndBroadcastsToAllOutputs() {
+    TestingOutput<StatefulElement> firstOutput = new TestingOutput<>();
+    TestingOutput<StatefulElement> secondOutput = new TestingOutput<>();
+    GlutenOutputCollector<StatefulElement> collector =
+        new GlutenOutputCollector<>(
+            Map.of("first", firstOutput, "second", secondOutput), new SimpleCounter());
+
+    collector.emitWatermark(new Watermark(100L));
+
+    assertThat(collector.getWatermarkGauge().getValue()).isEqualTo(100L);
+    assertThat(firstOutput.watermarks).extracting(Watermark::getTimestamp).containsExactly(100L);
+    assertThat(secondOutput.watermarks).extracting(Watermark::getTimestamp).containsExactly(100L);
+  }
+
+  @Test
+  void collectStatefulWatermarkUpdatesGaugeAndRoutesByNodeId() {
+    TestingOutput<StatefulElement> firstOutput = new TestingOutput<>();
+    TestingOutput<StatefulElement> secondOutput = new TestingOutput<>();
+    GlutenOutputCollector<StatefulElement> collector =
+        new GlutenOutputCollector<>(
+            Map.of("first", firstOutput, "second", secondOutput), new SimpleCounter());
+
+    collector.collect(new StreamRecord<>(new StatefulWatermark("first", 200L)));
+
+    assertThat(collector.getWatermarkGauge().getValue()).isEqualTo(200L);
+    assertThat(firstOutput.watermarks).extracting(Watermark::getTimestamp).containsExactly(200L);
+    assertThat(secondOutput.watermarks).isEmpty();
+  }
+
+  private static class TestingOutput<T> implements OutputWithChainingCheck<StreamRecord<T>> {
+    private final List<Watermark> watermarks = new ArrayList<>();
+    private final List<StreamRecord<T>> records = new ArrayList<>();
+    private final WatermarkGauge watermarkGauge = new WatermarkGauge();
+
+    @Override
+    public void emitWatermark(Watermark watermark) {
+      watermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+      watermarks.add(watermark);
+    }
+
+    @Override
+    public WatermarkGauge getWatermarkGauge() {
+      return watermarkGauge;
+    }
+
+    @Override
+    public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {}
+
+    @Override
+    public void emitLatencyMarker(LatencyMarker latencyMarker) {}
+
+    @Override
+    public void collect(StreamRecord<T> record) {
+      records.add(record);
+    }
+
+    @Override
+    public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {}
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void emitRecordAttributes(RecordAttributes recordAttributes) {}
+
+    @Override
+    public boolean collectAndCheckIfChained(StreamRecord<T> record) {
+      collect(record);
+      return false;
+    }
+
+    @Override
+    public <X> boolean collectAndCheckIfChained(OutputTag<X> outputTag, StreamRecord<X> record) {
+      collect(outputTag, record);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Implement #12341 
## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
UTs
## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by gpt