### PR TITLE
[VL][Delta] Sync DeltaSQLCommandTest with Delta 4.3.0 (add checkInvalidBooleanTablePropertyError)

### DIFF
--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.test
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.config.VeloxDeltaConfig
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkException, SparkThrowable}
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -55,6 +55,24 @@ trait DeltaSQLCommandTest extends SharedSparkSession {
       .set(VeloxDeltaConfig.ENABLE_NATIVE_WRITE.key, "true")
       .set("spark.databricks.delta.snapshotPartitions", "2")
       .set("spark.gluten.sql.fallbackUnexpectedMetadataParquet", "true")
+  }
+
+  /**
+   * Spark master now routes some invalid Delta table-property updates through the newer
+   * UNSUPPORTED_TABLE_CHANGE error class while released Spark versions still report the legacy
+   * temporary error. Both variants preserve the same message payload.
+   */
+  protected def checkInvalidBooleanTablePropertyError(
+      error: SparkException,
+      invalidValue: String): Unit = {
+    val sparkThrowable = error.asInstanceOf[SparkThrowable]
+    val errorClass = sparkThrowable.getErrorClass()
+    val expectedMessage = "For input string: \"" + invalidValue + "\""
+    assert(
+      Set("_LEGACY_ERROR_TEMP_2045", "UNSUPPORTED_TABLE_CHANGE").contains(errorClass),
+      s"Unexpected error class $errorClass with parameters " +
+        s"${sparkThrowable.getMessageParameters()}")
+    assert(sparkThrowable.getMessageParameters().get("message") == expectedMessage)
   }
 }
 // spotless:on


### PR DESCRIPTION
## What changes are proposed in this pull request?

Gluten's `backends-velox/src-delta40/.../test/DeltaSQLCommandTest.scala` is kept
as a drop-in, API-compatible copy of Delta's upstream `DeltaSQLCommandTest`
trait. The Delta Spark UT pipeline patches this file over Delta's own copy (in a
checked-out Delta tree) so that Delta's suites run with the Gluten plugin
registered — which means it must expose the same surface as the Delta version it
shadows.

Delta v4.3.0 - https://github.com/delta-io/delta/commit/247c323b6f4f61d008464a3f60f6cfd0c9ba54a9#diff-aa13085a91889532d3e3d1b9524fc4eb76507823d7c9cd7c322afecd110ac6a2 - added a `checkInvalidBooleanTablePropertyError` helper to that
trait, and Delta's own suites now call it:

- `DeltaVariantShreddingSuite.scala:212`
- `typewidening/TypeWideningTableFeatureSuite.scala:86`

Because Gluten's copy overwrites Delta's, the missing helper made those Delta
suites fail to compile:

```
not found: value checkInvalidBooleanTablePropertyError
(spark / Test / compileIncremental) Compilation failed
```

This PR adds the method (plus the `SparkException` / `SparkThrowable` imports)
verbatim from Delta v4.3.0, restoring API parity. The helper accepts either the
legacy `_LEGACY_ERROR_TEMP_2045` error class or the newer
`UNSUPPORTED_TABLE_CHANGE` class that Spark master now raises, while asserting an
unchanged message payload.

## How was this patch tested?

- The method and imports are copied verbatim from Delta v4.3.0, so behavior
  matches upstream exactly.
- `SparkThrowable.getErrorClass()` is already used in the sibling
  `src-delta40/.../DeltaTestUtils.scala`, so the helper compiles under Gluten's
  own `-Pspark-4.0 -Pscala-2.13` build.
- With the helper present, Delta 4.3.0's `DeltaVariantShreddingSuite` and
  `TypeWideningTableFeatureSuite` compile again in the Delta Spark UT pipeline.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI