### PR TITLE
[GLUTEN-12350][CORE] Place ConsistentHash virtual nodes by Node.key() instead of toString()

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
+++ b/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
@@ -201,6 +201,7 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
   private boolean add(T node) {
     boolean added = false;
     if (node != null && !nodes.containsKey(node)) {
+      Preconditions.checkArgument(node.key() != null, "Node key must not be null: %s", node);
       Set<Partition<T>> partitions =
           IntStream.range(0, replicate)
               .mapToObj(idx -> new Partition<T>(node, idx))
@@ -236,7 +237,10 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
     }
 
     public String getPartitionKey() {
-      return String.format("%s:%d", node, index);
+      // Hash the node by its logical key() so the ring is stable and reproducible across JVMs.
+      // Avoid node.toString() (which may default to the identity hash) and String.format (slow on
+      // this hot path, called per virtual node during add()).
+      return node.key() + ":" + index;
     }
 
     public T getNode() {
@@ -254,6 +258,12 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
 
   /** Base interface for the node in the ring. */
   public interface Node {
+    /**
+     * A stable, non-null identifier for this node. The ring hashes each virtual node by this key,
+     * so it MUST be deterministic across JVMs and process restarts (e.g. derived from a host or
+     * executor id) and consistent with {@link Object#equals}: two equal nodes must return the same
+     * key. Returning identity- or {@code toString()}-based values breaks ring stability.
+     */
     String key();
   }
 

--- a/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
+++ b/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
@@ -199,29 +199,34 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
   }
 
   private boolean add(T node) {
-    boolean added = false;
-    if (node != null && !nodes.containsKey(node)) {
-      Preconditions.checkArgument(node.key() != null, "Node key must not be null: %s", node);
-      Set<Partition<T>> partitions =
-          IntStream.range(0, replicate)
-              .mapToObj(idx -> new Partition<T>(node, idx))
-              .collect(Collectors.toSet());
-      nodes.put(node, partitions);
-
-      // allocate slot.
-      for (Partition<T> partition : partitions) {
-        long slot;
-        int seed = 0;
-        do {
-          slot = this.hasher.hash(partition.getPartitionKey(), seed++);
-        } while (ring.containsKey(slot));
-
-        partition.setSlot(slot);
-        ring.put(slot, partition);
-      }
-      added = true;
+    if (node == null) {
+      return false;
     }
-    return added;
+    // Validate the key before any map lookup: nodes.containsKey() invokes the node's
+    // hashCode()/equals(), which may themselves dereference key() and NPE on a null key, masking
+    // the intended fail-fast here.
+    Preconditions.checkArgument(node.key() != null, "Node key must not be null: %s", node);
+    if (nodes.containsKey(node)) {
+      return false;
+    }
+    Set<Partition<T>> partitions =
+        IntStream.range(0, replicate)
+            .mapToObj(idx -> new Partition<T>(node, idx))
+            .collect(Collectors.toSet());
+    nodes.put(node, partitions);
+
+    // allocate slot.
+    for (Partition<T> partition : partitions) {
+      long slot;
+      int seed = 0;
+      do {
+        slot = this.hasher.hash(partition.getPartitionKey(), seed++);
+      } while (ring.containsKey(slot));
+
+      partition.setSlot(slot);
+      ring.put(slot, partition);
+    }
+    return true;
   }
 
   public static class Partition<T extends ConsistentHash.Node> {
@@ -229,18 +234,21 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
 
     private final int index;
 
+    // Hash the node by its logical key() so the ring is stable and reproducible across JVMs (avoid
+    // node.toString(), which may fall back to the identity hash). Computed once: the key is
+    // immutable and re-read on every collision-retry in add().
+    private final String partitionKey;
+
     private long slot;
 
     public Partition(T node, int index) {
       this.node = node;
       this.index = index;
+      this.partitionKey = node.key() + ":" + index;
     }
 
     public String getPartitionKey() {
-      // Hash the node by its logical key() so the ring is stable and reproducible across JVMs.
-      // Avoid node.toString() (which may default to the identity hash) and String.format (slow on
-      // this hot path, called per virtual node during add()).
-      return node.key() + ":" + index;
+      return partitionKey;
     }
 
     public T getNode() {

--- a/gluten-core/src/test/java/org/apache/gluten/hash/ConsistentHashTest.java
+++ b/gluten-core/src/test/java/org/apache/gluten/hash/ConsistentHashTest.java
@@ -20,6 +20,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -113,6 +115,52 @@ public class ConsistentHashTest {
     for (ConsistentHash.Node node : allocateAllNodes) {
       Assert.assertTrue(nodes.contains(node));
     }
+  }
+
+  @Test
+  public void testRingHashesOnNodeKeyNotToString() {
+    // A node whose key() differs from toString(). The ring must hash partitions by key() so the
+    // distribution is stable/reproducible; relying on toString() would silently break any Node
+    // that overrides only the contractual key().
+    final List<String> hashedKeys = new ArrayList<>();
+    ConsistentHash.Hasher recordingHasher =
+        (key, seed) -> {
+          hashedKeys.add(key);
+          return key.hashCode() + seed;
+        };
+    ConsistentHash<ConsistentHash.Node> ring = new ConsistentHash<>(REPLICAS, recordingHasher);
+
+    ConsistentHash.Node node =
+        new ConsistentHash.Node() {
+          @Override
+          public String key() {
+            return "logical-key";
+          }
+
+          @Override
+          public String toString() {
+            return "DISPLAY-ONLY";
+          }
+        };
+    ring.addNode(node);
+
+    // Every partition key fed to the hasher must derive from key(), never from toString().
+    Assert.assertEquals(REPLICAS, hashedKeys.size());
+    Assert.assertTrue(hashedKeys.stream().allMatch(k -> k.startsWith("logical-key:")));
+    Assert.assertTrue(hashedKeys.stream().noneMatch(k -> k.contains("DISPLAY-ONLY")));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testAddNodeRejectsNullKey() {
+    // The ring hashes on key(); a null key would silently collapse distinct nodes onto identical
+    // hash inputs, so it must fail fast.
+    consistentHash.addNode(
+        new ConsistentHash.Node() {
+          @Override
+          public String key() {
+            return null;
+          }
+        });
   }
 
   private static class HostNode implements ConsistentHash.Node {


### PR DESCRIPTION
## What changes are proposed in this pull request?

`ConsistentHash.Partition.getPartitionKey()` built its hash input from the node object directly:

```java
return String.format("%s:%d", node, index);
```

`%s` resolves to `node.toString()`, so `Node.key()` was never used. This PR places virtual nodes on the ring by `node.key()`, adds a fail-fast check for a null key, and documents the `key()` contract.

`Node.key()` exists so the ring is keyed on a stable, logical id. Using `toString()` instead left `key()` as dead code, and the ring only happened to be correct because the one implementation (`ExecutorNode`) returns the same value from both methods. A future `Node` that implements only `key()` would be placed by `Object.toString()` (the identity hash), producing a different layout on every run and across JVMs — i.e. not consistent hashing at all. No user-facing change.

Fixes #12350.

## How was this patch tested?

Added two unit tests in `ConsistentHashTest`: one asserts partitions are hashed by `key()` and never `toString()`, the other that a null key is rejected. The existing cases still pass.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
