### PR TITLE
[FLINK] Add ccache to speed up velox4j native compilation in CI

### DIFF
--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -48,6 +48,7 @@ env:
     --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
     --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+  CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
 jobs:
   flink-test:
@@ -55,10 +56,21 @@ jobs:
     container: apache/gluten:centos-8-jdk17
     steps:
       - uses: actions/checkout@v4
+      - name: Restore ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-flink-centos8-${{github.sha}}
+          restore-keys: |
+            ccache-flink-centos8
       - name: Prepare
         run: |
           source /opt/rh/gcc-toolset-11/enable
-          sudo dnf install -y patchelf
+          sudo dnf install -y patchelf ccache
+          export CCACHE_DIR=${CCACHE_DIR}
+          export CCACHE_MAXSIZE=2G
+          mkdir -p ${CCACHE_DIR}
+          ccache -sz
           sudo yum install https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tzdata-2026a-1.el9.noarch.rpm -y
           sudo .github/workflows/util/install-flink-deps.sh
           # Remove system fmt v11 from the CI image to avoid header conflicts with
@@ -74,9 +86,16 @@ jobs:
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..
+          ccache -s
           git clone https://github.com/nexmark/nexmark.git
           cd nexmark
           $GITHUB_WORKSPACE/build/mvn clean install -DskipTests
+      - name: Save ccache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-flink-centos8-${{github.sha}}
       - name: Build Gluten Flink
         run: |
           cd $GITHUB_WORKSPACE/gluten-flink

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -68,7 +68,7 @@ jobs:
           source /opt/rh/gcc-toolset-11/enable
           sudo dnf install -y patchelf ccache
           export CCACHE_DIR=${CCACHE_DIR}
-          export CCACHE_MAXSIZE=2G
+          export CCACHE_MAXSIZE=4G
           mkdir -p ${CCACHE_DIR}
           ccache -sz
           sudo yum install https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tzdata-2026a-1.el9.noarch.rpm -y


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Add ccache to speed up velox4j native compilation in CI, from 86 min to 12 min.
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
