### PR TITLE
[MINOR][FLINK] Enable parallel Maven builds (-T 1C) in Flink CI

### DIFF
--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   MAVEN_OPTS: >-
-    -Xmx2g
+    -Xmx4g
     --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
     --add-opens=java.base/sun.nio.ch=org.apache.arrow.memory.core,ALL-UNNAMED
     --add-opens=java.base/java.lang=ALL-UNNAMED
@@ -84,12 +84,12 @@ jobs:
           git clone -b gluten-0530 https://github.com/bigo-sg/velox4j.git
           cd velox4j && git reset --hard 115edf79d265a61c30d45dfcc6ce932ad92378ca
           git apply $GITHUB_WORKSPACE/gluten-flink/patches/fix-velox4j.patch
-          $GITHUB_WORKSPACE/build/mvn clean install -DskipTests -Dgpg.skip -Dspotless.skip=true
+          $GITHUB_WORKSPACE/build/mvn clean install -T 1C -DskipTests -Dgpg.skip -Dspotless.skip=true
           cd ..
           ccache -s
           git clone https://github.com/nexmark/nexmark.git
           cd nexmark
-          $GITHUB_WORKSPACE/build/mvn clean install -DskipTests
+          $GITHUB_WORKSPACE/build/mvn clean install -T 1C -DskipTests
       - name: Save ccache
         if: always()
         uses: actions/cache/save@v4
@@ -99,7 +99,7 @@ jobs:
       - name: Build Gluten Flink
         run: |
           cd $GITHUB_WORKSPACE/gluten-flink
-          $GITHUB_WORKSPACE/build/mvn clean package -Dmaven.test.skip=true
+          $GITHUB_WORKSPACE/build/mvn clean package -T 1C -Dmaven.test.skip=true
       - name: Run Unit Tests
         run: |
           cd $GITHUB_WORKSPACE/gluten-flink


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Use all available CPU cores for Maven module compilation by adding -T 1C (one thread per core) to all mvn invocations. Also bump MAVEN_OPTS heap from 2g to 4g to accommodate the higher memory pressure from concurrent module builds.
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
