### PR TITLE
[VL] Fix occasional shutdown crashes

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/init/NativeBackendInitializer.java
@@ -59,7 +59,7 @@ public final class NativeBackendInitializer {
       throw new IllegalStateException("Already initialized");
     }
     initialize0(rl, conf);
-    SparkShutdownManagerUtil.addHook(
+    SparkShutdownManagerUtil.addHookForLibUnloading(
         () -> {
           shutdown();
           return BoxedUnit.UNIT;

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkShutdownManagerUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkShutdownManagerUtil.scala
@@ -17,12 +17,15 @@
 package org.apache.spark.util
 
 object SparkShutdownManagerUtil {
+  private val LIB_UNLOADING_PRIORITY = ShutdownHookManager.SPARK_CONTEXT_SHUTDOWN_PRIORITY - 1
+  assert(LIB_UNLOADING_PRIORITY > ShutdownHookManager.TEMP_DIR_SHUTDOWN_PRIORITY)
+
   def addHook(hook: () => Unit): AnyRef = {
     ShutdownHookManager.addShutdownHook(ShutdownHookManager.DEFAULT_SHUTDOWN_PRIORITY)(hook)
   }
 
   def addHookForLibUnloading(hook: () => Unit): AnyRef = {
-    ShutdownHookManager.addShutdownHook(ShutdownHookManager.SPARK_CONTEXT_SHUTDOWN_PRIORITY)(hook)
+    ShutdownHookManager.addShutdownHook(LIB_UNLOADING_PRIORITY)(hook)
   }
 
   def addHookForTempDirRemoval(hook: () => Unit): AnyRef = {


### PR DESCRIPTION
Fixes errors that happen randomly like:

```
Current thread (0x00007f7c6100c160):  JavaThread "spark-listener-group-appStatus" daemon [_thread_in_native, id=712523, stack(0x00007f7bea5fc000,0x00007f7bea6fc000)]

Stack: [0x00007f7bea5fc000,0x00007f7bea6fc000],  sp=0x00007f7bea6f6610,  free space=1001k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libvelox.so+0x1ff0cc9]  gluten::defaultLeafVeloxMemoryPool()+0x9

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  org.apache.gluten.vectorized.PlanEvaluatorJniWrapper.nativeValidateWithFailureReason([B)Lorg/apache/gluten/validate/NativePlanValidationInfo;+0
j  org.apache.gluten.vectorized.NativePlanEvaluator.doNativeValidateWithFailureReason([B)Lorg/apache/gluten/validate/NativePlanValidationInfo;+5
j  org.apache.gluten.backendsapi.velox.VeloxValidatorApi.$anonfun$doNativeValidateWithFailureReason$1(Lorg/apache/gluten/backendsapi/velox/VeloxValidatorApi;Lorg/apache/gluten/substrait/plan/PlanNode;)Lorg/apache/gluten/execution/ValidationResult;+19
j  org.apache.gluten.backendsapi.velox.VeloxValidatorApi$$Lambda$3325+0x00007f7cf910e080.apply()Ljava/lang/Object;+8
j  org.apache.spark.task.TaskResources$.runUnsafe(Lscala/Function0;)Ljava/lang/Object;+28
j  org.apache.gluten.backendsapi.velox.VeloxValidatorApi.doNativeValidateWithFailureReason(Lorg/apache/gluten/substrait/plan/PlanNode;)Lorg/apache/gluten/execution/ValidationResult;+10
j  org.apache.gluten.execution.TransformSupport.doNativeValidation(Lorg/apache/gluten/substrait/SubstraitContext;Lorg/apache/gluten/substrait/rel/RelNode;)Lorg/apache/gluten/execution/ValidationResult;+39
j  org.apache.gluten.execution.TransformSupport.doNativeValidation$(Lorg/apache/gluten/execution/TransformSupport;Lorg/apache/gluten/substrait/SubstraitContext;Lorg/apache/gluten/substrait/rel/RelNode;)Lorg/apache/gluten/execution/ValidationResult;+3
j  org.apache.gluten.execution.FileSourceScanExecTransformerBase.doNativeValidation(Lorg/apache/gluten/substrait/SubstraitContext;Lorg/apache/gluten/substrait/rel/RelNode;)Lorg/apache/gluten/execution/ValidationResult;+3
j  org.apache.gluten.execution.BasicScanExecTransformer.doValidateInternal()Lorg/apache/gluten/execution/ValidationResult;+95
j  org.apache.gluten.execution.BasicScanExecTransformer.doValidateInternal$(Lorg/apache/gluten/execution/BasicScanExecTransformer;)Lorg/apache/gluten/execution/ValidationResult;+1
j  org.apache.gluten.execution.FileSourceScanExecTransformerBase.doValidateInternal()Lorg/apache/gluten/execution/ValidationResult;+138
j  org.apache.gluten.execution.ValidatablePlan.$anonfun$doValidate$3(Lorg/apache/gluten/execution/ValidatablePlan;)Lorg/apache/gluten/execution/ValidationResult;+7
j  org.apache.gluten.execution.ValidatablePlan$$Lambda$3298+0x00007f7cf90f4378.apply()Ljava/lang/Object;+4
j  org.apache.gluten.execution.ValidatablePlan.failValidationWithException(Lscala/Function0;Lscala/Function0;)Lorg/apache/gluten/execution/ValidationResult;+1
j  org.apache.gluten.execution.ValidatablePlan.failValidationWithException$(Lorg/apache/gluten/execution/ValidatablePlan;Lscala/Function0;Lscala/Function0;)Lorg/apache/gluten/execution/ValidationResult;+3
j  org.apache.gluten.execution.FileSourceScanExecTransformerBase.failValidationWithException(Lscala/Function0;Lscala/Function0;)Lorg/apache/gluten/execution/ValidationResult;+3
j  org.apache.gluten.execution.ValidatablePlan.doValidate()Lorg/apache/gluten/execution/ValidationResult;+148
j  org.apache.gluten.execution.ValidatablePlan.doValidate$(Lorg/apache/gluten/execution/ValidatablePlan;)Lorg/apache/gluten/execution/ValidationResult;+1
j  org.apache.gluten.execution.FileSourceScanExecTransformerBase.doValidate()Lorg/apache/gluten/execution/ValidationResult;+1
j  org.apache.gluten.extension.columnar.validator.Validators$FallbackByNativeValidation.validate(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/gluten/extension/columnar/validator/Validator$OutCome;+37
j  org.apache.gluten.extension.columnar.validator.Validator$Builder$ValidatorPipeline.$anonfun$validate$1(Lorg/apache/spark/sql/execution/SparkPlan;Lorg/apache/gluten/extension/columnar/validator/Validator$OutCome;Lorg/apache/gluten/extension/columnar/validator/Validator;)Lorg/apache/gluten/extension/columnar/validator/Validator$OutCome;+54
j  org.apache.gluten.extension.columnar.validator.Validator$Builder$ValidatorPipeline$$Lambda$3283+0x00007f7cf90e4438.apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+12
J 4197 c1 scala.collection.LinearSeqOps.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (55 bytes) @ 0x00007f7d5975563c [0x00007f7d597552a0+0x000000000000039c]
J 4195 c1 scala.collection.immutable.List.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (7 bytes) @ 0x00007f7d59754aec [0x00007f7d59754a40+0x00000000000000ac]
j  org.apache.gluten.extension.columnar.validator.Validator$Builder$ValidatorPipeline.validate(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/gluten/extension/columnar/validator/Validator$OutCome;+16
j  org.apache.gluten.extension.columnar.heuristic.AddFallbackTags.addFallbackTag(Lorg/apache/spark/sql/execution/SparkPlan;)V+5
j  org.apache.gluten.extension.columnar.heuristic.AddFallbackTags.$anonfun$apply$1(Lorg/apache/gluten/extension/columnar/heuristic/AddFallbackTags;Lorg/apache/spark/sql/execution/SparkPlan;)V+14
j  org.apache.gluten.extension.columnar.heuristic.AddFallbackTags.$anonfun$apply$1$adapted(Lorg/apache/gluten/extension/columnar/heuristic/AddFallbackTags;Lorg/apache/spark/sql/execution/SparkPlan;)Ljava/lang/Object;+2
j  org.apache.gluten.extension.columnar.heuristic.AddFallbackTags$$Lambda$3282+0x00007f7cf90e3dc0.apply(Ljava/lang/Object;)Ljava/lang/Object;+8
j  org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(Lscala/Function1;)V+17
j  org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1(Lscala/Function1;Lorg/apache/spark/sql/catalyst/trees/TreeNode;)V+2
j  org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1$adapted(Lscala/Function1;Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Ljava/lang/Object;+2
j  org.apache.spark.sql.catalyst.trees.TreeNode$$Lambda$2790+0x00007f7cf8f53820.apply(Ljava/lang/Object;)Ljava/lang/Object;+8
J 8735 c1 scala.collection.immutable.Vector.foreach(Lscala/Function1;)V (136 bytes) @ 0x00007f7d59e4cb8c [0x00007f7d59e4c7a0+0x00000000000003ec]
j  org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(Lscala/Function1;)V+10
j  org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1(Lscala/Function1;Lorg/apache/spark/sql/catalyst/trees/TreeNode;)V+2
j  org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$foreachUp$1$adapted(Lscala/Function1;Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Ljava/lang/Object;+2
j  org.apache.spark.sql.catalyst.trees.TreeNode$$Lambda$2790+0x00007f7cf8f53820.apply(Ljava/lang/Object;)Ljava/lang/Object;+8
J 8735 c1 scala.collection.immutable.Vector.foreach(Lscala/Function1;)V (136 bytes) @ 0x00007f7d59e4cb8c [0x00007f7d59e4c7a0+0x00000000000003ec]
j  org.apache.spark.sql.catalyst.trees.TreeNode.foreachUp(Lscala/Function1;)V+10
j  org.apache.gluten.extension.columnar.heuristic.AddFallbackTags.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+7
j  org.apache.gluten.extension.columnar.heuristic.AddFallbackTags.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform$WithRewrites.$anonfun$apply$3(Lorg/apache/spark/sql/execution/SparkPlan;Lorg/apache/spark/sql/catalyst/rules/Rule;)Lorg/apache/spark/sql/execution/SparkPlan;+36
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform$WithRewrites$$Lambda$3278+0x00007f7cf90e0fd8.apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+8
J 4197 c1 scala.collection.LinearSeqOps.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (55 bytes) @ 0x00007f7d5975563c [0x00007f7d597552a0+0x000000000000039c]
J 4195 c1 scala.collection.immutable.List.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (7 bytes) @ 0x00007f7d59754aec [0x00007f7d59754a40+0x00000000000000ac]
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform$WithRewrites.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+42
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform$WithRewrites.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform.$anonfun$apply$1(Lorg/apache/spark/sql/execution/SparkPlan;Lorg/apache/spark/sql/catalyst/rules/Rule;)Lorg/apache/spark/sql/execution/SparkPlan;+36
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform$$Lambda$3277+0x00007f7cf90e0a30.apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+8
J 4197 c1 scala.collection.LinearSeqOps.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (55 bytes) @ 0x00007f7d5975563c [0x00007f7d597552a0+0x000000000000039c]
J 4195 c1 scala.collection.immutable.List.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (7 bytes) @ 0x00007f7d59754aec [0x00007f7d59754a40+0x00000000000000ac]
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+10
j  org.apache.gluten.extension.columnar.heuristic.HeuristicTransform.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
j  org.apache.gluten.extension.columnar.LoggedRule.$anonfun$apply$1(Lorg/apache/gluten/extension/columnar/LoggedRule;Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+5
j  org.apache.gluten.extension.columnar.LoggedRule$$Lambda$3269+0x00007f7cf90d79a0.apply()Ljava/lang/Object;+8
j  org.apache.gluten.metrics.GlutenTimeMetric$.withNanoTime(Lscala/Function0;Lscala/Function1;)Ljava/lang/Object;+5
j  org.apache.gluten.metrics.GlutenTimeMetric$.withMillisTime(Lscala/Function0;Lscala/Function1;)Ljava/lang/Object;+8
j  org.apache.gluten.metrics.GlutenTimeMetric$.recordMillisTime(Lscala/Function0;)Lscala/Tuple2;+13
j  org.apache.gluten.extension.columnar.LoggedRule.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+10
j  org.apache.gluten.extension.columnar.LoggedRule.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
J 8402 c1 org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$2(Lorg/apache/spark/sql/catalyst/rules/RuleExecutor;Lorg/apache/spark/sql/catalyst/rules/QueryExecutionMetering;Lorg/apache/spark/sql/catalyst/rules/PlanChangeLogger;ZLorg/apache/spark/sql/catalyst/rules/RuleExecutor$Batch;Lscala/Option;Lscala/runtime/LazyBoolean;Lorg/apache/spark/sql/catalyst/trees/TreeNode;Lorg/apache/spark/sql/catalyst/rules/Rule;)Lorg/apache/spark/sql/catalyst/trees/TreeNode; (349 bytes) @ 0x00007f7d59d92a2c [0x00007f7d59d92480+0x00000000000005ac]
J 8304 c1 org.apache.spark.sql.catalyst.rules.RuleExecutor$$Lambda$1962+0x00007f7cf8c34d38.apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; (40 bytes) @ 0x00007f7d59d5ffdc [0x00007f7d59d5fd40+0x000000000000029c]
J 4197 c1 scala.collection.LinearSeqOps.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (55 bytes) @ 0x00007f7d5975563c [0x00007f7d597552a0+0x000000000000039c]
J 4195 c1 scala.collection.immutable.List.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (7 bytes) @ 0x00007f7d59754aec [0x00007f7d59754a40+0x00000000000000ac]
j  org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1(Lorg/apache/spark/sql/catalyst/rules/RuleExecutor;Lscala/runtime/ObjectRef;Lorg/apache/spark/sql/catalyst/rules/QueryExecutionMetering;Lorg/apache/spark/sql/catalyst/rules/PlanChangeLogger;ZLscala/Option;Lscala/runtime/LazyBoolean;Lorg/apache/spark/sql/catalyst/rules/RuleExecutor$Batch;)V+61
j  org.apache.spark.sql.catalyst.rules.RuleExecutor.$anonfun$execute$1$adapted(Lorg/apache/spark/sql/catalyst/rules/RuleExecutor;Lscala/runtime/ObjectRef;Lorg/apache/spark/sql/catalyst/rules/QueryExecutionMetering;Lorg/apache/spark/sql/catalyst/rules/PlanChangeLogger;ZLscala/Option;Lscala/runtime/LazyBoolean;Lorg/apache/spark/sql/catalyst/rules/RuleExecutor$Batch;)Ljava/lang/Object;+12
j  org.apache.spark.sql.catalyst.rules.RuleExecutor$$Lambda$1961+0x00007f7cf8c34968.apply(Ljava/lang/Object;)Ljava/lang/Object;+32
J 3392 c1 scala.collection.immutable.List.foreach(Lscala/Function1;)V (32 bytes) @ 0x00007f7d5960969c [0x00007f7d59609480+0x000000000000021c]
j  org.apache.spark.sql.catalyst.rules.RuleExecutor.execute(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+236
j  org.apache.gluten.extension.columnar.heuristic.HeuristicApplier.transformPlan(Ljava/lang/String;Lscala/collection/immutable/Seq;Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+31
j  org.apache.gluten.extension.columnar.heuristic.HeuristicApplier.org$apache$gluten$extension$columnar$heuristic$HeuristicApplier$$$anonfun$makeRule$1(Lorg/apache/spark/sql/execution/SparkPlan;Lorg/apache/gluten/extension/columnar/ColumnarRuleApplier$ColumnarRuleCall;)Lorg/apache/spark/sql/execution/SparkPlan;+10
j  org.apache.gluten.extension.columnar.heuristic.HeuristicApplier$$anonfun$makeRule$3.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+9
j  org.apache.gluten.extension.columnar.heuristic.HeuristicApplier$$anonfun$makeRule$3.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
j  org.apache.gluten.extension.columnar.heuristic.HeuristicApplier.apply(Lorg/apache/spark/sql/execution/SparkPlan;Z)Lorg/apache/spark/sql/execution/SparkPlan;+25
j  org.apache.gluten.extension.GlutenColumnarRule.org$apache$gluten$extension$GlutenColumnarRule$$$anonfun$postColumnarTransitions$1(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+337
j  org.apache.gluten.extension.GlutenColumnarRule$$anonfun$postColumnarTransitions$2.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+5
j  org.apache.gluten.extension.GlutenColumnarRule$$anonfun$postColumnarTransitions$2.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
j  org.apache.gluten.extension.injector.InjectorControl$Disabler$DisablerOps$$anon$5$$anon$7.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+38
j  org.apache.gluten.extension.injector.InjectorControl$Disabler$DisablerOps$$anon$5$$anon$7.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
j  org.apache.spark.sql.execution.ApplyColumnarRulesAndInsertTransitions.$anonfun$apply$2(Lscala/runtime/ObjectRef;Lorg/apache/spark/sql/execution/ColumnarRule;)V+12
j  org.apache.spark.sql.execution.ApplyColumnarRulesAndInsertTransitions.$anonfun$apply$2$adapted(Lscala/runtime/ObjectRef;Lorg/apache/spark/sql/execution/ColumnarRule;)Ljava/lang/Object;+2
j  org.apache.spark.sql.execution.ApplyColumnarRulesAndInsertTransitions$$Lambda$3210+0x00007f7cf90ac7f8.apply(Ljava/lang/Object;)Ljava/lang/Object;+8
J 3392 c1 scala.collection.immutable.List.foreach(Lscala/Function1;)V (32 bytes) @ 0x00007f7d5960969c [0x00007f7d59609480+0x000000000000021c]
j  org.apache.spark.sql.execution.ApplyColumnarRulesAndInsertTransitions.apply(Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+57
j  org.apache.spark.sql.execution.ApplyColumnarRulesAndInsertTransitions.apply(Lorg/apache/spark/sql/catalyst/trees/TreeNode;)Lorg/apache/spark/sql/catalyst/trees/TreeNode;+5
j  org.apache.spark.sql.execution.QueryExecution$.$anonfun$prepareForExecution$1(Lorg/apache/spark/sql/catalyst/rules/PlanChangeLogger;Lorg/apache/spark/sql/execution/SparkPlan;Lorg/apache/spark/sql/catalyst/rules/Rule;)Lorg/apache/spark/sql/execution/SparkPlan;+40
j  org.apache.spark.sql.execution.QueryExecution$$$Lambda$3176+0x00007f7cf909ad18.apply(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+12
J 4197 c1 scala.collection.LinearSeqOps.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (55 bytes) @ 0x00007f7d5975563c [0x00007f7d597552a0+0x000000000000039c]
J 4195 c1 scala.collection.immutable.List.foldLeft(Ljava/lang/Object;Lscala/Function2;)Ljava/lang/Object; (7 bytes) @ 0x00007f7d59754aec [0x00007f7d59754a40+0x00000000000000ac]
j  org.apache.spark.sql.execution.QueryExecution$.prepareForExecution(Lscala/collection/immutable/Seq;Lorg/apache/spark/sql/execution/SparkPlan;)Lorg/apache/spark/sql/execution/SparkPlan;+16
j  org.apache.spark.sql.execution.QueryExecution.$anonfun$lazyExecutedPlan$2(Lorg/apache/spark/sql/execution/QueryExecution;)Lorg/apache/spark/sql/execution/SparkPlan;+17
j  org.apache.spark.sql.execution.QueryExecution$$Lambda$3121+0x00007f7cf9065dc8.apply()Ljava/lang/Object;+4
j  org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(Ljava/lang/String;Lscala/Function0;)Ljava/lang/Object;+5
j  org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$2(Lorg/apache/spark/sql/execution/QueryExecution;Ljava/lang/String;Lscala/Function0;)Ljava/lang/Object;+6
j  org.apache.spark.sql.execution.QueryExecution$$Lambda$1814+0x00007f7cf8b11288.apply()Ljava/lang/Object;+12
j  org.apache.spark.sql.execution.QueryExecution$.withInternalError(Ljava/lang/String;Lscala/Function0;)Ljava/lang/Object;+1
j  org.apache.spark.sql.execution.QueryExecution.$anonfun$executePhase$1(Lorg/apache/spark/sql/execution/QueryExecution;Ljava/lang/String;Lscala/Function0;)Ljava/lang/Object;+17
j  org.apache.spark.sql.execution.QueryExecution$$Lambda$1813+0x00007f7cf8b10fc8.apply()Ljava/lang/Object;+12
j  org.apache.spark.sql.SparkSession.withActive(Lscala/Function0;)Ljava/lang/Object;+27
j  org.apache.spark.sql.execution.QueryExecution.executePhase(Ljava/lang/String;Lscala/Function0;)Ljava/lang/Object;+12
j  org.apache.spark.sql.execution.QueryExecution.$anonfun$lazyExecutedPlan$1(Lorg/apache/spark/sql/execution/QueryExecution;)Lorg/apache/spark/sql/execution/SparkPlan;+17
j  org.apache.spark.sql.execution.QueryExecution$$Lambda$1804+0x00007f7cf8b0d040.apply()Ljava/lang/Object;+4
j  scala.util.Try$.apply(Lscala/Function0;)Lscala/util/Try;+1
j  org.apache.spark.util.Utils$.doTryWithCallerStacktrace(Lscala/Function0;)Lscala/util/Try;+4
j  org.apache.spark.util.LazyTry.tryT$lzycompute()Lscala/util/Try;+19
j  org.apache.spark.util.LazyTry.tryT()Lscala/util/Try;+8
j  org.apache.spark.util.LazyTry.get()Ljava/lang/Object;+4
j  org.apache.spark.sql.execution.QueryExecution.executedPlan()Lorg/apache/spark/sql/execution/SparkPlan;+4
j  org.apache.spark.sql.execution.GlutenImplicits$.$anonfun$collectQueryExecutionFallbackSummary$2(Lorg/apache/spark/sql/SparkSession;Lorg/apache/spark/sql/catalyst/plans/logical/LogicalPlan;Lorg/apache/spark/sql/catalyst/util/StringUtils$PlanStringConcat;Lscala/Some;)Lscala/Tuple2;+21
j  org.apache.spark.sql.execution.GlutenImplicits$$$Lambda$3800+0x00007f7cf925a190.apply()Ljava/lang/Object;+16
j  org.apache.spark.sql.execution.GlutenImplicits$.withSQLConf(Lscala/collection/immutable/Seq;Lscala/Function0;)Ljava/lang/Object;+140
j  org.apache.spark.sql.execution.GlutenImplicits$.handlePlanWithAQEAndTableCache$1(Lorg/apache/spark/sql/execution/SparkPlan;Lorg/apache/spark/sql/catalyst/plans/logical/LogicalPlan;ZLorg/apache/spark/sql/SparkSession;Lscala/runtime/IntRef;Lscala/runtime/IntRef;Lscala/collection/mutable/ArrayBuffer;Lscala/collection/mutable/ArrayBuffer;)V+82
j  org.apache.spark.sql.execution.GlutenImplicits$.collectQueryExecutionFallbackSummary(Lorg/apache/spark/sql/SparkSession;Lorg/apache/spark/sql/execution/QueryExecution;)Lorg/apache/spark/sql/execution/GlutenImplicits$FallbackSummary;+104
j  org.apache.spark.sql.execution.GlutenQueryExecutionListener.onSQLExecutionEnd(Lorg/apache/spark/sql/execution/ui/SparkListenerSQLExecutionEnd;)V+73
j  org.apache.spark.sql.execution.GlutenQueryExecutionListener.onOtherEvent(Lorg/apache/spark/scheduler/SparkListenerEvent;)V+45
j  org.apache.spark.scheduler.SparkListenerBus.doPostEvent(Lorg/apache/spark/scheduler/SparkListenerInterface;Lorg/apache/spark/scheduler/SparkListenerEvent;)V+1059
j  org.apache.spark.scheduler.SparkListenerBus.doPostEvent$(Lorg/apache/spark/scheduler/SparkListenerBus;Lorg/apache/spark/scheduler/SparkListenerInterface;Lorg/apache/spark/scheduler/SparkListenerEvent;)V+3
j  org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(Lorg/apache/spark/scheduler/SparkListenerInterface;Lorg/apache/spark/scheduler/SparkListenerEvent;)V+3
j  org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(Ljava/lang/Object;Ljava/lang/Object;)V+9
j  org.apache.spark.util.ListenerBus.postToAll(Ljava/lang/Object;)V+85
j  org.apache.spark.util.ListenerBus.postToAll$(Lorg/apache/spark/util/ListenerBus;Ljava/lang/Object;)V+2
j  org.apache.spark.scheduler.AsyncEventQueue.super$postToAll(Lorg/apache/spark/scheduler/SparkListenerEvent;)V+2
j  org.apache.spark.scheduler.AsyncEventQueue.$anonfun$dispatch$1(Lorg/apache/spark/scheduler/AsyncEventQueue;)J+48
j  org.apache.spark.scheduler.AsyncEventQueue$$Lambda$1204+0x00007f7cf8681720.apply$mcJ$sp()J+4
j  scala.runtime.java8.JFunction0$mcJ$sp.apply()Ljava/lang/Object;+1
j  scala.util.DynamicVariable.withValue(Ljava/lang/Object;Lscala/Function0;)Ljava/lang/Object;+14
j  org.apache.spark.scheduler.AsyncEventQueue.org$apache$spark$scheduler$AsyncEventQueue$$dispatch()V+16
j  org.apache.spark.scheduler.AsyncEventQueue$$anon$2.$anonfun$run$1(Lorg/apache/spark/scheduler/AsyncEventQueue$$anon$2;)V+4
j  org.apache.spark.scheduler.AsyncEventQueue$$anon$2$$Lambda$1202+0x00007f7cf8681440.apply$mcV$sp()V+4
j  org.apache.spark.util.Utils$.tryOrStopSparkContext(Lorg/apache/spark/SparkContext;Lscala/Function0;)V+1
j  org.apache.spark.scheduler.AsyncEventQueue$$anon$2.run()V+16
v  ~StubRoutines::call_stub
```

