### PR TITLE
[UT][VL] Refresh TPC-H q19 plan stability golden file

### DIFF
--- a/gluten-ut/spark40/src/test/resources/backends-velox/gluten-tpch-plan-stability/q19/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/gluten-tpch-plan-stability/q19/explain.txt
@@ -35,12 +35,12 @@ Input [6]: [l_partkey#1, l_quantity#2, l_extendedprice#3, l_discount#4, l_shipin
 Output [4]: [p_partkey#7, p_brand#8, p_size#9, p_container#10]
 Batched: true
 Location: InMemoryFileIndex [{warehouse_dir}/part]
-PushedFilters: [IsNotNull(p_size), GreaterThanOrEqual(p_size,1), IsNotNull(p_partkey), Or(Or(And(And(EqualTo(p_brand,Brand#11),In(p_container, [SM BOX,SM CASE,SM PACK,SM PKG])),LessThanOrEqual(p_size,5)),And(And(EqualTo(p_brand,Brand#12),In(p_container, [MED BAG,MED BOX,MED PACK,MED PKG])),LessThanOrEqual(p_size,10))),And(And(EqualTo(p_brand,Brand#13),In(p_container, [LG BOX,LG CASE,LG PACK,LG PKG])),LessThanOrEqual(p_size,15)))]
+PushedFilters: [IsNotNull(p_size), GreaterThanOrEqual(p_size,1), IsNotNull(p_partkey), Or(Or(And(And(EqualTo(p_brand,Brand#11),In(p_container, [SM BOX,SM CASE,SM PACK,SM PKG])),LessThanOrEqual(p_size,5)),And(And(EqualTo(p_brand,Brand#6),In(p_container, [MED BAG,MED BOX,MED PACK,MED PKG])),LessThanOrEqual(p_size,10))),And(And(EqualTo(p_brand,Brand#12),In(p_container, [LG BOX,LG CASE,LG PACK,LG PKG])),LessThanOrEqual(p_size,15)))]
 ReadSchema: struct<p_partkey:bigint,p_brand:string,p_size:int,p_container:string>
 
 (5) FilterExecTransformer
 Input [4]: [p_partkey#7, p_brand#8, p_size#9, p_container#10]
-Arguments: (((isnotnull(p_size#9) AND (p_size#9 >= 1)) AND isnotnull(p_partkey#7)) AND (((((p_brand#8 = Brand#11) AND p_container#10 IN (SM CASE,SM BOX,SM PACK,SM PKG)) AND (p_size#9 <= 5)) OR (((p_brand#8 = Brand#12) AND p_container#10 IN (MED BAG,MED BOX,MED PKG,MED PACK)) AND (p_size#9 <= 10))) OR (((p_brand#8 = Brand#13) AND p_container#10 IN (LG CASE,LG BOX,LG PACK,LG PKG)) AND (p_size#9 <= 15))))
+Arguments: (((isnotnull(p_size#9) AND (p_size#9 >= 1)) AND isnotnull(p_partkey#7)) AND (((((p_brand#8 = Brand#11) AND p_container#10 IN (SM CASE,SM BOX,SM PACK,SM PKG)) AND (p_size#9 <= 5)) OR (((p_brand#8 = Brand#6) AND p_container#10 IN (MED BAG,MED BOX,MED PKG,MED PACK)) AND (p_size#9 <= 10))) OR (((p_brand#8 = Brand#12) AND p_container#10 IN (LG CASE,LG BOX,LG PACK,LG PKG)) AND (p_size#9 <= 15))))
 
 (6) WholeStageCodegenTransformer (1)
 Input [4]: [p_partkey#7, p_brand#8, p_size#9, p_container#10]
@@ -60,48 +60,48 @@ Input [4]: [p_partkey#7, p_brand#8, p_size#9, p_container#10]
 Left keys [1]: [l_partkey#1]
 Right keys [1]: [p_partkey#7]
 Join type: Inner
-Join condition: (((((((p_brand#8 = Brand#11) AND p_container#10 IN (SM CASE,SM BOX,SM PACK,SM PKG)) AND (l_quantity#2 >= 1)) AND (l_quantity#2 <= 11)) AND (p_size#9 <= 5)) OR (((((p_brand#8 = Brand#12) AND p_container#10 IN (MED BAG,MED BOX,MED PKG,MED PACK)) AND (l_quantity#2 >= 10)) AND (l_quantity#2 <= 20)) AND (p_size#9 <= 10))) OR (((((p_brand#8 = Brand#13) AND p_container#10 IN (LG CASE,LG BOX,LG PACK,LG PKG)) AND (l_quantity#2 >= 20)) AND (l_quantity#2 <= 30)) AND (p_size#9 <= 15)))
+Join condition: (((((((p_brand#8 = Brand#11) AND p_container#10 IN (SM CASE,SM BOX,SM PACK,SM PKG)) AND (l_quantity#2 >= 1)) AND (l_quantity#2 <= 11)) AND (p_size#9 <= 5)) OR (((((p_brand#8 = Brand#6) AND p_container#10 IN (MED BAG,MED BOX,MED PKG,MED PACK)) AND (l_quantity#2 >= 10)) AND (l_quantity#2 <= 20)) AND (p_size#9 <= 10))) OR (((((p_brand#8 = Brand#12) AND p_container#10 IN (LG CASE,LG BOX,LG PACK,LG PKG)) AND (l_quantity#2 >= 20)) AND (l_quantity#2 <= 30)) AND (p_size#9 <= 15)))
 
 (11) ProjectExecTransformer
-Output [1]: [(l_extendedprice#3 * (1 - l_discount#4)) AS _pre_1#14]
+Output [1]: [(l_extendedprice#3 * (1 - l_discount#4)) AS _pre_1#13]
 Input [8]: [l_partkey#1, l_quantity#2, l_extendedprice#3, l_discount#4, p_partkey#7, p_brand#8, p_size#9, p_container#10]
 
 (12) FlushableHashAggregateExecTransformer
-Input [1]: [_pre_1#14]
+Input [1]: [_pre_1#13]
 Keys: []
-Functions [1]: [partial_sum(_pre_1#14)]
-Aggregate Attributes [2]: [sum#15, isEmpty#16]
-Results [2]: [sum#17, isEmpty#18]
+Functions [1]: [partial_sum(_pre_1#13)]
+Aggregate Attributes [2]: [sum#14, isEmpty#15]
+Results [2]: [sum#16, isEmpty#17]
 
 (13) WholeStageCodegenTransformer (2)
-Input [2]: [sum#17, isEmpty#18]
+Input [2]: [sum#16, isEmpty#17]
 Arguments: false
 
 (14) VeloxResizeBatches
-Input [2]: [sum#17, isEmpty#18]
+Input [2]: [sum#16, isEmpty#17]
 Arguments: 1024, 2147483647, 10485760
 
 (15) ColumnarExchange
-Input [2]: [sum#17, isEmpty#18]
+Input [2]: [sum#16, isEmpty#17]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=2], [shuffle_writer_type=hash]
 
 (16) InputAdapter
-Input [2]: [sum#17, isEmpty#18]
+Input [2]: [sum#16, isEmpty#17]
 
 (17) InputIteratorTransformer
-Input [2]: [sum#17, isEmpty#18]
+Input [2]: [sum#16, isEmpty#17]
 
 (18) RegularHashAggregateExecTransformer
-Input [2]: [sum#17, isEmpty#18]
+Input [2]: [sum#16, isEmpty#17]
 Keys: []
 Functions [1]: [sum((l_extendedprice#3 * (1 - l_discount#4)))]
-Aggregate Attributes [1]: [sum((l_extendedprice#3 * (1 - l_discount#4)))#19]
-Results [1]: [sum((l_extendedprice#3 * (1 - l_discount#4)))#19 AS revenue#20]
+Aggregate Attributes [1]: [sum((l_extendedprice#3 * (1 - l_discount#4)))#18]
+Results [1]: [sum((l_extendedprice#3 * (1 - l_discount#4)))#18 AS revenue#19]
 
 (19) WholeStageCodegenTransformer (3)
-Input [1]: [revenue#20]
+Input [1]: [revenue#19]
 Arguments: false
 
 (20) VeloxColumnarToRow
-Input [1]: [revenue#20]
+Input [1]: [revenue#19]
 


### PR DESCRIPTION
Fixes #12375.

## Problem

`GlutenTPCHPlanStabilitySuite` → `tpch/q19` has been failing in `spark-test-spark40` CI runs for PRs that touch Velox backend Scala files.

### Root cause

`GlutenPlanStabilitySuite.glutenNormalizeIds()` uses the regex `(?<prefix>(?<!id=)#)\\d+L?` which matches **any** `#<number>` in the explain text — including TPC-H string literals. The `p_brand` filter in q19 uses values `Brand#11`, `Brand#12`, `Brand#13` (actual TPC-H spec data values). These appear unquoted in the explain output:

```
EqualTo(p_brand, Brand#12)
```

The normalizer incorrectly treats `#12` as an ExprId and remaps it sequentially. The suite code itself warns about this at line 67–68:

> *"Running all suites together in one JVM is recommended to avoid ExprId normalization issues where string constants (e.g., Brand#23 in TPCH q19) may collide with ExprId numbers."*

### What changed

The golden file was committed in #11805 (`c37fee4e5`, 2026-03-24). Since then **264 commits** landed on `main`, shifting the ExprId counter. `Brand#12` now normalizes to `Brand#6` and `_pre_1#14` shifts to `_pre_1#13`.

**Exact diff (original vs current):**
```
- EqualTo(p_brand, Brand#12) ... Brand#13
+ EqualTo(p_brand, Brand#6)  ... Brand#12

- _pre_1#14 / sum#15 / isEmpty#16
+ _pre_1#13 / sum#14 / isEmpty#15
```

### Evidence that this is pre-existing

Ran `GlutenTPCHPlanStabilitySuite` on `main` at commit `6097b59a6` (2026-06-25, [MINOR][VL] Build Arrow 18 with patch for Power #12344) — without any pending PR applied:

```
Tests: succeeded 21, failed 1  ← q19 fails on main too
BUILD FAILURE
```

Then regenerated with `SPARK_GENERATE_GOLDEN_FILES=1` and re-ran:

```
Tests: succeeded 22, failed 0
BUILD SUCCESS
```

Only `q19/explain.txt` changed. `simplified.txt` and all other queries (q1–q18, q20–q22) are unaffected.

### Why it only surfaces on PRs touching Velox backend Scala files

`spark-test-spark40` is only triggered when Velox backend Scala files are modified. Most PRs touch native C++ code, docs, or non-Velox modules and never trigger this check.

## Fix

Regenerated `q19/explain.txt` by running `GlutenTPCHPlanStabilitySuite` with `SPARK_GENERATE_GOLDEN_FILES=1 SPARK_ANSI_SQL_MODE=false`.

A proper long-term fix (tracked in #12375) would be to make `glutenNormalizeIds` skip `#N` occurrences inside string literal contexts.

## Impact

- Only `gluten-ut/spark40/src/test/resources/backends-velox/gluten-tpch-plan-stability/q19/explain.txt` changes
- No production code changes
- No other test queries affected