### PR TITLE
[GLUTEN-12378][CORE] Return a defensive copy from ConsistentHash.getPartition()

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
+++ b/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
@@ -258,7 +258,11 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
       return node;
     }
 
-    public void setSlot(long slot) {
+    // Non-public on purpose: only ConsistentHash.add() assigns the slot, during ring construction
+    // (accessible as a nestmate). Keeping it out of the public API stops callers of getPartition()
+    // from mutating ring state through a returned Partition (e.g. changing a slot so removeNode()
+    // drops the wrong entry).
+    private void setSlot(long slot) {
       this.slot = slot;
     }
 

--- a/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
+++ b/gluten-core/src/main/java/org/apache/gluten/hash/ConsistentHash.java
@@ -162,7 +162,10 @@ public class ConsistentHash<T extends ConsistentHash.Node> {
   public Set<Partition<T>> getPartition(T node) {
     lock.readLock().lock();
     try {
-      return nodes.get(node);
+      // Return a defensive copy: the map value is internal mutable state, and getNodes() copies
+      // for the same reason. Callers get a snapshot they can't use to mutate the ring.
+      Set<Partition<T>> partitions = nodes.get(node);
+      return partitions == null ? null : new HashSet<>(partitions);
     } finally {
       lock.readLock().unlock();
     }

--- a/gluten-core/src/test/java/org/apache/gluten/hash/ConsistentHashTest.java
+++ b/gluten-core/src/test/java/org/apache/gluten/hash/ConsistentHashTest.java
@@ -163,6 +163,20 @@ public class ConsistentHashTest {
         });
   }
 
+  @Test
+  public void testGetPartitionReturnsDefensiveCopy() {
+    HostNode node = new HostNode("executor-1");
+    consistentHash.addNode(node);
+
+    Set<ConsistentHash.Partition<ConsistentHash.Node>> partitions =
+        consistentHash.getPartition(node);
+    Assert.assertEquals(REPLICAS, partitions.size());
+
+    // Mutating the returned set must not affect the ring's internal state.
+    partitions.clear();
+    Assert.assertEquals(REPLICAS, consistentHash.getPartition(node).size());
+  }
+
   private static class HostNode implements ConsistentHash.Node {
     private final String host;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

`ConsistentHash` is `@ThreadSafe` and its accessors return defensive copies — except `getPartition()`, which returned the internal set directly:

```java
return nodes.get(node);
```

That set is the same instance held in the internal `nodes` map, so a caller could mutate the ring through it (e.g. `getPartition(node).clear()`), and the reference escaped after the read lock was released. This PR makes `getPartition()` a safe snapshot accessor:

- Return a defensive copy of the set, matching `getNodes()`.
- Make `Partition.setSlot()` non-public. Copying the set alone still left the `Partition` elements shared and mutable; since `setSlot()` was public, a caller could change a slot and corrupt the ring (e.g. so `removeNode()` later drops the wrong entry). Only `add()` assigns slots during construction, so `setSlot()` is now `private` (reached as a nestmate).

This is latent today — `getPartition()` has no production caller and the internal set isn't mutated after a node is added — so there's no user-facing change; it's an encapsulation/consistency fix.

Fixes #12378.

## How was this patch tested?

Added a unit test that adds a node, clears the set returned by `getPartition()`, and verifies the ring still reports all partitions. Making `setSlot()` non-public is enforced at compile time (no external caller exists). The existing `ConsistentHashTest` cases still pass.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
