### PR TITLE
[GLUTEN-12313][VL] followup to cleanup CI image

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -33,31 +33,6 @@ env:
   DOCKERHUB_REPO: apache/gluten
 
 jobs:
-  build-vcpkg-centos-7:
-    if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: .
-          file: dev/docker/Dockerfile.centos7-static-build
-          push: true
-          tags: ${{ env.DOCKERHUB_REPO }}:vcpkg-centos-7
-
   build-vcpkg-centos-7-gcc13:
     if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ubuntu-latest
@@ -169,56 +144,6 @@ jobs:
           file: dev/docker/cudf/Dockerfile.centos-9-jdk17-cuda12.9-cudf
           push: true
           tags: ${{ env.DOCKERHUB_REPO }}:centos-9-jdk17-cuda12.9-cudf
-
-  build-vcpkg-centos-8:
-    if: ${{ startsWith(github.repository, 'apache/') }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
-        with:
-          images: ${{ env.DOCKERHUB_REPO }}
-          tags: vcpkg-centos-8
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: .
-          file: dev/docker/Dockerfile.centos8-static-build
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }}",push-by-digest=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-vcpkg-centos-8-${{ matrix.os }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
 
   build-vcpkg-centos-8-gcc13:
     if: ${{ startsWith(github.repository, 'apache/') }}
@@ -451,9 +376,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        digests: [ vcpkg-centos-8, vcpkg-centos-9 ]
+        digests: [ vcpkg-centos-9 ]
     needs:
-      - build-vcpkg-centos-8
       - build-vcpkg-centos-9
 
     steps:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -146,7 +146,7 @@ jobs:
           tags: ${{ env.DOCKERHUB_REPO }}:centos-9-jdk17-cuda12.9-cudf
 
   build-vcpkg-centos-8-gcc13:
-
+    if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -196,7 +196,7 @@ jobs:
           retention-days: 1
 
   build-vcpkg-centos-9:
-
+    if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -146,7 +146,7 @@ jobs:
           tags: ${{ env.DOCKERHUB_REPO }}:centos-9-jdk17-cuda12.9-cudf
 
   build-vcpkg-centos-8-gcc13:
-    if: ${{ startsWith(github.repository, 'apache/') }}
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -196,7 +196,7 @@ jobs:
           retention-days: 1
 
   build-vcpkg-centos-9:
-    if: ${{ startsWith(github.repository, 'apache/') }}
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/dev/docker/Dockerfile.centos8-gcc13-static-build
+++ b/dev/docker/Dockerfile.centos8-gcc13-static-build
@@ -28,9 +28,8 @@ RUN set -ex; \
     yum update -y && yum install -y epel-release sudo dnf && yum install -y ccache; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-1.8.0-openjdk-devel patch git perl python3 automake libtool flex; \
-    dnf -y --enablerepo=powertools install autoconf-archive ninja-build; \
+    dnf -y --enablerepo=powertools install autoconf-archive ninja-build cmake; \
     pip3 install --upgrade pip; \
-    pip3 install cmake==3.31.4; \
     rpm -qa | grep tzdata; \
     dnf clean all; \
     git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \

--- a/dev/docker/Dockerfile.centos8-gcc13-static-build
+++ b/dev/docker/Dockerfile.centos8-gcc13-static-build
@@ -35,7 +35,7 @@ RUN set -ex; \
     rm -f cmake-3.31.12-linux-$(uname -m).sh; \
     rpm -qa | grep tzdata; \
     dnf clean all; \
-    git clone --depth=1 https://github.com/zhouyuan/gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     mkdir -p ${VCPKG_PATH}; \
     echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \
     if [ "$(uname -m)" = "aarch64" ]; then \

--- a/dev/docker/Dockerfile.centos8-gcc13-static-build
+++ b/dev/docker/Dockerfile.centos8-gcc13-static-build
@@ -28,11 +28,14 @@ RUN set -ex; \
     yum update -y && yum install -y epel-release sudo dnf && yum install -y ccache; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-1.8.0-openjdk-devel patch git perl python3 automake libtool flex; \
-    dnf -y --enablerepo=powertools install autoconf-archive ninja-build cmake; \
-    pip3 install --upgrade pip; \
+    dnf -y --enablerepo=powertools install autoconf-archive ninja-build; \
+    wget https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-linux-$(uname -m).sh; \
+    chmod +x cmake-3.31.12-linux-$(uname -m).sh; \
+    ./cmake-3.31.12-linux-$(uname -m).sh --skip-license --prefix=/usr/local; \
+    rm -f cmake-3.31.12-linux-$(uname -m).sh; \
     rpm -qa | grep tzdata; \
     dnf clean all; \
-    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/zhouyuan/gluten /opt/gluten; \
     mkdir -p ${VCPKG_PATH}; \
     echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \
     if [ "$(uname -m)" = "aarch64" ]; then \

--- a/dev/docker/Dockerfile.centos9-static-build
+++ b/dev/docker/Dockerfile.centos9-static-build
@@ -26,8 +26,7 @@ ENV VCPKG_BINARY_SOURCES=clear;files,${VCPKG_PATH},readwrite
 
 RUN set -ex; \
     yum update -y && yum install -y epel-release sudo dnf && yum install -y ccache; \
-    dnf install -y --setopt=install_weak_deps=False gcc-toolset-12 gcc-toolset-13 perl-FindBin; \
-    pip install cmake==3.31.4; \
+    dnf install -y --setopt=install_weak_deps=False gcc-toolset-12 gcc-toolset-13 perl-FindBin cmake; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-17-openjdk-devel patch git perl; \
     dnf clean all; \

--- a/dev/docker/Dockerfile.centos9-static-build
+++ b/dev/docker/Dockerfile.centos9-static-build
@@ -30,7 +30,7 @@ RUN set -ex; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-17-openjdk-devel patch git perl; \
     dnf clean all; \
-    git clone --depth=1 https://github.com/zhouyuan/gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
     cd /opt/gluten && bash ./dev/vcpkg/setup-build-depends.sh; \
     mkdir -p ${VCPKG_PATH}; \
     echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \

--- a/dev/docker/Dockerfile.centos9-static-build
+++ b/dev/docker/Dockerfile.centos9-static-build
@@ -30,7 +30,7 @@ RUN set -ex; \
     echo "check_certificate = off" >> ~/.wgetrc; \
     yum install -y java-17-openjdk-devel patch git perl; \
     dnf clean all; \
-    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
+    git clone --depth=1 https://github.com/zhouyuan/gluten /opt/gluten; \
     cd /opt/gluten && bash ./dev/vcpkg/setup-build-depends.sh; \
     mkdir -p ${VCPKG_PATH}; \
     echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \

--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -157,9 +157,6 @@ install_centos_8() {
 
     pip3 install --upgrade pip
 
-    # Requires cmake >= 3.28.3
-    pip3 install cmake==3.28.3
-
     dnf -y --enablerepo=powertools install autoconf-archive ninja-build
 
     install_maven_from_source
@@ -175,8 +172,6 @@ install_centos_9() {
 
     pip3 install --upgrade pip
 
-    # Requires cmake >= 3.28.3
-    pip3 install cmake==3.28.3
 
     dnf -y --enablerepo=crb install autoconf-archive ninja-build
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

This patch removed the unused docker images. Also fixed the cmake issue in vcpkg-centos-8/9 image


<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
manually verified

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->


Related issue: #12313