### PR TITLE
[GLUTEN-12392][CORE] Return early in JniLibLoader.loadAndCreateLink() when the library is already loaded

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
+++ b/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
@@ -90,10 +90,16 @@ public class JniLibLoader {
     }
   }
 
+  /**
+   * Same contract as {@link #load(String)}, with the addition of creating a symbolic link named
+   * {@code linkName} in {@code workDir} pointing at the extracted library. Returns immediately if
+   * {@code libPath} was already loaded by this instance.
+   */
   public synchronized void loadAndCreateLink(String libPath, String linkName) {
     try {
       if (loadedLibraries.contains(libPath)) {
         LOG.debug("Library {} has already been loaded, skipping", libPath);
+        return;
       }
       File file = moveToWorkDir(workDir, libPath);
       loadWithLink(file.getAbsolutePath(), linkName);


### PR DESCRIPTION
### What changes were proposed in this pull request?

`JniLibLoader.loadAndCreateLink()` had an early-skip log line for libraries already loaded by the instance, but the branch was missing a `return;` — so `moveToWorkDir` and the symlink rebuild ran anyway. The sibling `load()` does `return;` in the same branch, so the two methods diverged. This PR adds the missing `return;` so the method mirrors `load()`, plus a short Javadoc on `loadAndCreateLink` documenting the contract ("same as `load`, plus a symbolic link; returns immediately if already loaded") so the behaviour is pinned rather than only enforced by code-shape symmetry.

### Why are the changes needed?

Closes #12392. Because `System.load` is deduped further down via `LOADED_LIBRARY_PATHS`, the bug does not cause a double native load — but every repeat call still re-extracts the library to the work directory and delete+recreates the symlink. That is wasted I/O at best, and a delete/recreate race against any concurrent reader of the work directory at worst.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

`mvn -pl gluten-core -Pspark-3.5 spotless:check` passes. Existing `gluten-core` tests (`mvn -pl gluten-core -Pspark-3.5 test`) still pass. The fix is a 1-line behavioural alignment with `load()` — a reflection-based unit test was considered and rejected to avoid coupling tests to the private `loadedLibraries` field; the contract is captured by Javadoc instead.