### PR TITLE
[GLUTEN-12401][CORE] Use Path.toRealPath() for JniLibLoader symlink resolution

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
+++ b/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
@@ -43,16 +43,26 @@ public class JniLibLoader {
     this.workDir = workDir;
   }
 
-  private static String toRealPath(String libPath) {
-    String realPath = libPath;
+  /**
+   * Returns the canonical, fully-dereferenced absolute path for the given library path.
+   *
+   * <p>Delegates to {@link Path#toRealPath} so symbolic-link chains whose stored targets are
+   * relative (e.g. {@code lib.so -> lib.so.1 -> lib.so.1.2.3}) and symbolic-link cycles are handled
+   * by the JDK rather than a hand-rolled loop that resolved {@code readSymbolicLink} results
+   * against the process working directory and could spin forever on a cycle.
+   *
+   * <p>Package-private for testing.
+   */
+  static String toRealPath(String libPath) {
     try {
-      while (Files.isSymbolicLink(Paths.get(realPath))) {
-        realPath = Files.readSymbolicLink(Paths.get(realPath)).toString();
-      }
+      Path realPath = Paths.get(libPath).toRealPath();
       LOG.info("Read real path {} for libPath {}", realPath, libPath);
-      return realPath;
-    } catch (Throwable th) {
-      throw new GlutenException("Error to read real path for libPath: " + libPath, th);
+      return realPath.toString();
+    } catch (Exception e) {
+      // Wrap any operational failure (IOException, InvalidPathException, SecurityException,
+      // NPE, ...) as GlutenException so callers see a consistent type. Error subclasses
+      // (OOME, StackOverflowError, ...) are intentionally allowed to propagate.
+      throw new GlutenException("Error to read real path for libPath: " + libPath, e);
     }
   }
 

--- a/gluten-core/src/test/java/org/apache/gluten/jni/JniLibLoaderTest.java
+++ b/gluten-core/src/test/java/org/apache/gluten/jni/JniLibLoaderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.jni;
+
+import org.apache.gluten.exception.GlutenException;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+/** Tests for the symlink resolution path of {@link JniLibLoader#toRealPath(String)}. */
+public class JniLibLoaderTest {
+
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Before
+  public void assumeSymlinkSupport() throws Exception {
+    // Skip cleanly on filesystems / platforms that disallow symlinks or refuse to resolve them
+    // (FAT/SMB, Windows without privilege, some FUSE mounts, ...). The probe mirrors what the
+    // tests actually exercise — create a relative-target symlink AND walk it via toRealPath —
+    // so an environment that permits one but not the other still skips instead of red-failing.
+    File probeDir = tempFolder.newFolder("symlink-probe");
+    try {
+      Path target = probeDir.toPath().resolve("target");
+      Files.createFile(target);
+      Path link = probeDir.toPath().resolve("link");
+      Files.createSymbolicLink(link, Paths.get("target"));
+      link.toRealPath();
+    } catch (UnsupportedOperationException | SecurityException | java.io.IOException e) {
+      Assume.assumeNoException("filesystem does not support symbolic-link resolution", e);
+    }
+  }
+
+  @Test
+  public void toRealPathReturnsCanonicalAbsoluteForRegularFile() throws Exception {
+    // Force the input and the canonical real path to differ on every platform: address the file
+    // via a symlinked parent directory. A regression that returned the input verbatim would
+    // therefore fail on Linux (where /tmp is not a symlink) and not just on macOS (where /var is).
+    File realDir = tempFolder.newFolder("real-dir");
+    File regular = new File(realDir, "plain.so");
+    Assert.assertTrue("seed file created", regular.createNewFile());
+    Path linkDir = tempFolder.getRoot().toPath().resolve("link-dir");
+    Files.createSymbolicLink(linkDir, realDir.toPath());
+    String input = linkDir.resolve("plain.so").toString();
+
+    String resolved = JniLibLoader.toRealPath(input);
+
+    Assert.assertNotEquals(
+        "toRealPath must canonicalize the parent directory, not return the input verbatim",
+        input,
+        resolved);
+    Assert.assertEquals(
+        "regular file path should canonicalize to its real path",
+        regular.toPath().toRealPath().toString(),
+        resolved);
+  }
+
+  @Test
+  public void toRealPathResolvesRelativeSymlinkAgainstLinkParent() throws Exception {
+    // Versioned-library symlink chain:
+    //   <dir>/libfoo.so -> libfoo.so.1 -> libfoo.so.1.2.3 (regular file)
+    File dir = tempFolder.newFolder("nested-dir");
+    File realFile = new File(dir, "libfoo.so.1.2.3");
+    Assert.assertTrue("seed file created", realFile.createNewFile());
+
+    Path versioned = dir.toPath().resolve("libfoo.so.1");
+    Files.createSymbolicLink(versioned, Paths.get("libfoo.so.1.2.3"));
+    Path soname = dir.toPath().resolve("libfoo.so");
+    Files.createSymbolicLink(soname, Paths.get("libfoo.so.1"));
+
+    String resolved = JniLibLoader.toRealPath(soname.toString());
+
+    // Compare to the JDK-canonical real path of the underlying file. Do NOT re-canonicalize the
+    // returned string — a regression that returned the unresolved symlink path would otherwise be
+    // hidden by the comparison side following the link again.
+    Assert.assertEquals(
+        "relative symlinks must resolve against the link's parent, not the process CWD",
+        realFile.toPath().toRealPath().toString(),
+        resolved);
+  }
+
+  @Test
+  public void toRealPathRejectsSymlinkCycle() throws Exception {
+    // a -> b, b -> a — pre-fix the loop ran forever; the JDK throws FileSystemLoopException now.
+    File dir = tempFolder.newFolder("cycle-dir");
+    Path a = dir.toPath().resolve("a");
+    Path b = dir.toPath().resolve("b");
+    Files.createSymbolicLink(a, Paths.get("b"));
+    Files.createSymbolicLink(b, Paths.get("a"));
+
+    try {
+      JniLibLoader.toRealPath(a.toString());
+      Assert.fail("symlink cycle must not silently resolve to a real path");
+    } catch (GlutenException expected) {
+      // The cycle-detection contract: the JDK reports the loop. Linux maps ELOOP to
+      // FileSystemLoopException; macOS (current openjdk) surfaces a plain FileSystemException
+      // with "Too many levels of symbolic links" in the message. Accept either, but reject any
+      // other FileSystemException subclass (NoSuchFileException, AccessDeniedException, ...)
+      // so this test doesn't quietly degrade into "any FS failure passes".
+      Throwable cause = expected.getCause();
+      String causeMsg = cause == null ? "" : String.valueOf(cause.getMessage());
+      boolean reportsLoop =
+          cause instanceof java.nio.file.FileSystemLoopException
+              || (cause instanceof java.nio.file.FileSystemException
+                  && causeMsg
+                      .toLowerCase(Locale.ROOT)
+                      .contains("too many levels of symbolic links"));
+      Assert.assertTrue("cause should report a symlink loop, got: " + cause, reportsLoop);
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

`JniLibLoader.toRealPath()` previously walked symbolic links with a hand-rolled loop that called `Files.readSymbolicLink` and fed the *stored* (often relative) target back into `Paths.get(...)`. That resolved relative targets against the process working directory instead of the link's own parent, and the loop had no cycle guard. This PR rewrites the method to delegate to `Path#toRealPath` so symlink-chain resolution (including `.`/`..` normalisation) and cycle detection (`FileSystemLoopException` on Linux; `FileSystemException` carrying "Too many levels of symbolic links" on current openjdk macOS) are handled by the JDK. Visibility is widened from `private` to package-private so a unit test in the same package can call it directly. The caught type is `Exception` (not `Throwable`), wrapping `IOException`/`InvalidPathException`/`SecurityException`/`NullPointerException` as `GlutenException` while intentionally letting `Error` subclasses propagate. A JUnit 4 test covers a plain regular file (canonicalisation via a symlinked parent dir, so the assertion bites on Linux too), a versioned-library symlink chain with relative targets, and a 2-cycle. A `@Before` probe skips cleanly on filesystems that do not support symbolic-link creation or resolution.

### Why are the changes needed?

Closes #12401. Versioned native libraries are typically published as a chain like `libfoo.so -> libfoo.so.1 -> libfoo.so.1.2.3`, where the stored target of `libfoo.so` is the *relative* `libfoo.so.1`. The old loop's second iteration called `Files.isSymbolicLink(Paths.get("libfoo.so.1"))`, which probes the JVM's working directory instead of the directory holding the link, so resolution silently returned a wrong path that `System.load` then rejected (or, if the working directory happened to contain a matching name, loaded the wrong library). A symlink cycle would also spin forever inside the loop. `Path#toRealPath` removes both issues with a single JDK call.

### Does this PR introduce any user-facing change?

No. Behaviour change is limited to error cases the old loop would have mishandled (relative-symlink failures and cycles), where callers now get a wrapped `GlutenException` instead of an incorrect or hung load.

### How was this patch tested?

`mvn -pl gluten-core -Pspark-3.5 spotless:check` passes. New tests `JniLibLoaderTest` (3 tests) pass against the fix. Each test was also verified against the old buggy implementation and observed to fail with the expected red signal (input-verbatim assertion on the regular-file test, path-not-equal on the chain test, `Assert.fail` on the cycle test). Existing `gluten-core` tests are unchanged.