### PR TITLE
[VL] Remove invalid code path for shuffle read

### DIFF
--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/perf/GlutenDeltaOptimizedWriterExec.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/perf/GlutenDeltaOptimizedWriterExec.scala
@@ -337,7 +337,6 @@ private class GlutenOptimizedWriterShuffleReader(
       false
     ).toCompletionIterator
 
-    // Create a key/value iterator for each stream
     val recordIter = dep match {
       case columnarDep: ColumnarShuffleDependency[Int, ColumnarBatch, ColumnarBatch] =>
         // If the dependency is a ColumnarShuffleDependency, we use the columnar serializer.

--- a/backends-velox/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializer.scala
@@ -25,7 +25,7 @@ import org.apache.gluten.utils.ArrowAbiUtil
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
-import org.apache.spark.serializer.{DeserializationStream, SerializationStream, Serializer, SerializerInstance}
+import org.apache.spark.serializer.{DeserializationStream, Serializer, SerializerInstance}
 import org.apache.spark.shuffle.GlutenShuffleUtils
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.internal.SQLConf
@@ -39,7 +39,6 @@ import org.apache.arrow.c.ArrowSchema
 import org.apache.arrow.memory.BufferAllocator
 
 import java.io._
-import java.nio.ByteBuffer
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -132,10 +131,6 @@ private class ColumnarBatchSerializerInstanceImpl(
       allocator.close()
     }
     shuffleReaderHandle
-  }
-
-  override def deserializeStream(in: InputStream): DeserializationStream = {
-    new TaskDeserializationStream(Iterator((null, in)))
   }
 
   override def deserializeStreams(
@@ -250,17 +245,4 @@ private class ColumnarBatchSerializerInstanceImpl(
 
     override def resourceName(): String = getClass.getName
   }
-
-  // Columnar shuffle write process don't need this.
-  override def serializeStream(s: OutputStream): SerializationStream =
-    throw new UnsupportedOperationException
-
-  // These methods are never called by shuffle code.
-  override def serialize[T: ClassTag](t: T): ByteBuffer = throw new UnsupportedOperationException
-
-  override def deserialize[T: ClassTag](bytes: ByteBuffer): T =
-    throw new UnsupportedOperationException
-
-  override def deserialize[T: ClassTag](bytes: ByteBuffer, loader: ClassLoader): T =
-    throw new UnsupportedOperationException
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializerInstance.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/vectorized/ColumnarBatchSerializerInstance.scala
@@ -29,6 +29,7 @@ abstract class ColumnarBatchSerializerInstance extends SerializerInstance {
   /** Deserialize the streams of ColumnarBatches. */
   def deserializeStreams(streams: Iterator[(BlockId, InputStream)]): DeserializationStream
 
+  // These methods are never called by shuffle code.
   override def serialize[T: ClassTag](t: T): ByteBuffer = {
     throw new UnsupportedOperationException
   }
@@ -42,6 +43,10 @@ abstract class ColumnarBatchSerializerInstance extends SerializerInstance {
   }
 
   override def serializeStream(s: OutputStream): SerializationStream = {
+    throw new UnsupportedOperationException
+  }
+
+  override def deserializeStream(s: InputStream): DeserializationStream = {
     throw new UnsupportedOperationException
   }
 }

--- a/backends-velox/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleReader.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/shuffle/ColumnarShuffleReader.scala
@@ -70,6 +70,15 @@ class ColumnarShuffleReader[K, C](
 
   /** Read the combined key-values for this reduce task */
   override def read(): Iterator[Product2[K, C]] = {
+    val columnarDep = dep match {
+      case d: ColumnarShuffleDependency[_, _, _] =>
+        d.asInstanceOf[ColumnarShuffleDependency[K, _, C]]
+      case other =>
+        throw new IllegalArgumentException(
+          s"ColumnarShuffleReader requires ColumnarShuffleDependency " +
+            s"but got ${other.getClass.getName}")
+    }
+
     val wrappedStreams = new ShuffleBlockFetcherIterator(
       context,
       blockManager.blockStoreClient,
@@ -91,26 +100,11 @@ class ColumnarShuffleReader[K, C](
       fetchContinuousBlocksInBatch
     ).toCompletionIterator
 
-    val recordIter = dep match {
-      case columnarDep: ColumnarShuffleDependency[K, _, C] =>
-        // If the dependency is a ColumnarShuffleDependency, we use the columnar serializer.
-        columnarDep.serializer
-          .newInstance()
-          .asInstanceOf[ColumnarBatchSerializerInstance]
-          .deserializeStreams(wrappedStreams)
-          .asKeyValueIterator
-      case _ =>
-        val serializerInstance = dep.serializer.newInstance()
-        // Create a key/value iterator for each stream
-        wrappedStreams.flatMap {
-          case (blockId, wrappedStream) =>
-            // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
-            // NextIterator. The NextIterator makes sure that close() is called on the
-            // underlying InputStream when all records have been read.
-            serializerInstance.deserializeStream(wrappedStream).asKeyValueIterator
-        }
-    }
-
+    val recordIter = columnarDep.serializer
+      .newInstance()
+      .asInstanceOf[ColumnarBatchSerializerInstance]
+      .deserializeStreams(wrappedStreams)
+      .asKeyValueIterator
     // Update the context task metrics for each record read.
     val metricIter = CompletionIterator[(Any, Any), Iterator[(Any, Any)]](
       recordIter.map {


### PR DESCRIPTION
Refine code paths for shuffle reader and deserialiser:

1. ColumnarShuffleReader only accept shuffle dependency as `ColumnarShuffleDependency`. Other type of dependencies are invalid.
2. ColumnarBatchSerializer calls native reader to deserialise input streams in batch. ~`deserializeStream` is not used.~