### PR TITLE
[GUTEN-12406][VL] Fix broadcast build once with generated build key alias

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -743,7 +743,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
           }
         }
 
-        val originalBuildKeys = findLogicalLink(child)
+        val newBuildKeys = findLogicalLink(child)
           .flatMap(_.getTagValue(JoinKeysTag.ORIGINAL_JOIN_KEYS))
           .getOrElse {
             if (SparkHashJoinUtils.canRewriteAsLongType(buildKeys) && buildKeys.nonEmpty) {
@@ -752,15 +752,6 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
               buildKeys
             }
           }
-        // Use child output because original keys may not match the physical
-        // output attributes after rewrite or aliasing.
-        val outputByExprId = child.output.map(attr => attr.exprId -> attr).toMap
-        val newBuildKeys = originalBuildKeys.map {
-          _.transform {
-            case attr: AttributeReference =>
-              outputByExprId.getOrElse(attr.exprId, attr)
-          }
-        }
 
         val noNeedPreOp = newBuildKeys.forall {
           case _: AttributeReference | _: BoundReference => true
@@ -768,7 +759,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
         }
 
         if (noNeedPreOp) {
-          (child, child.output, newBuildKeys)
+          (child, child.output, Seq.empty[Expression])
         } else {
           // pre projection in case of expression join keys
           val appendedProjections = new ArrayBuffer[NamedExpression]()

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -743,7 +743,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
           }
         }
 
-        val newBuildKeys = findLogicalLink(child)
+        val originalBuildKeys = findLogicalLink(child)
           .flatMap(_.getTagValue(JoinKeysTag.ORIGINAL_JOIN_KEYS))
           .getOrElse {
             if (SparkHashJoinUtils.canRewriteAsLongType(buildKeys) && buildKeys.nonEmpty) {
@@ -752,6 +752,15 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
               buildKeys
             }
           }
+        // Use child output because original keys may not match the physical
+        // output attributes after rewrite or aliasing.
+        val outputByExprId = child.output.map(attr => attr.exprId -> attr).toMap
+        val newBuildKeys = originalBuildKeys.map {
+          _.transform {
+            case attr: AttributeReference =>
+              outputByExprId.getOrElse(attr.exprId, attr)
+          }
+        }
 
         val noNeedPreOp = newBuildKeys.forall {
           case _: AttributeReference | _: BoundReference => true
@@ -759,7 +768,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
         }
 
         if (noNeedPreOp) {
-          (child, child.output, Seq.empty[Expression])
+          (child, child.output, newBuildKeys)
         } else {
           // pre projection in case of expression join keys
           val appendedProjections = new ArrayBuffer[NamedExpression]()

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -204,10 +204,12 @@ case class ColumnarBuildSideRelation(
           )
         }
 
+        val outputByExprId = newOutput.asScala.map(attr => attr.exprId -> attr).toMap
         val joinKeys = keys.asScala.map {
           key =>
             val attr = ConverterUtils.getAttrFromExpr(key)
-            ConverterUtils.genColumnNameWithExprId(attr)
+            val outputAttr = outputByExprId.getOrElse(attr.exprId, attr)
+            ConverterUtils.genColumnNameWithExprId(outputAttr)
         }.toArray
 
         val hashJoinBuilder = HashJoinBuilder.create(runtime)

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
@@ -174,10 +174,12 @@ class UnsafeColumnarBuildSideRelation(
           )
         }
 
+        val outputByExprId = newOutput.asScala.map(attr => attr.exprId -> attr).toMap
         val joinKeys = keys.asScala.map {
           key =>
             val attr = ConverterUtils.getAttrFromExpr(key)
-            ConverterUtils.genColumnNameWithExprId(attr)
+            val outputAttr = outputByExprId.getOrElse(attr.exprId, attr)
+            ConverterUtils.genColumnNameWithExprId(outputAttr)
         }.toArray
 
         val hashJoinBuilder = HashJoinBuilder.create(runtime)

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxHashJoinSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxHashJoinSuite.scala
@@ -357,6 +357,38 @@ class VeloxHashJoinSuite extends VeloxWholeStageTransformerSuite {
     }
   }
 
+  test("Broadcast build once with generated build key alias") {
+    withSQLConf(
+      ("spark.sql.autoBroadcastJoinThreshold", "10MB"),
+      ("spark.sql.adaptive.enabled", "false"),
+      (VeloxConfig.VELOX_BROADCAST_BUILD_HASHTABLE_ONCE_PER_EXECUTOR.key, "true")
+    ) {
+      createTPCHNotNullTables()
+      val query =
+        """
+          |SELECT /*+ BROADCAST(r) */ l.l_orderkey, l.l_partkey, r.key
+          |FROM lineitem l
+          |LEFT JOIN (
+          |  SELECT p_partkey, key
+          |  FROM (
+          |    SELECT p_partkey, concat('{"Key":"', CAST(p_partkey AS STRING), '"}') AS json_field
+          |    FROM part
+          |  ) p
+          |  LATERAL VIEW json_tuple(json_field, 'Key') b AS key
+          |) r
+          |ON l.l_partkey = r.p_partkey
+          | AND CAST(l.l_partkey AS STRING) = r.key
+          |""".stripMargin
+
+      runQueryAndCompare(query) {
+        df =>
+          val plan = df.queryExecution.executedPlan
+          val broadcastJoins = plan.collect { case bhj: BroadcastHashJoinExecTransformer => bhj }
+          assert(broadcastJoins.nonEmpty, "Should use broadcast hash join")
+      }
+    }
+  }
+
   test("Reuse broadcast exchange with different hash table") {
     withSQLConf(
       ("spark.sql.adaptive.enabled", "false")


### PR DESCRIPTION
## What changes are proposed in this pull request?
Use real new output as build keys for `buildHashTable()` in broadcast relation.
Fix https://github.com/apache/gluten/issues/12406.

## How was this patch tested?
Add unit test.

## Was this patch authored or co-authored using generative AI tooling?
No.
