### PR TITLE
[GLUTEN-12413][VL] Fix Generate pre-project to use Alias in project list and AttributeRe…

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
@@ -186,11 +186,12 @@ object PullOutGenerateProjectHelper extends PullOutProjectHelper {
             // NOTE: DO NOT use eliminateProjectList to create the project list because
             // newGeneratorChild can be a duplicated Attribute in generate.child.output. The native
             // side identifies the last field of projection as generator's input.
-            val newGeneratorChildren = Seq(expressionMap.values.head)
+            val aliasExpr = expressionMap.values.head
             generate.copy(
-              generator =
-                generate.generator.withNewChildren(newGeneratorChildren).asInstanceOf[Generator],
-              child = ProjectExec(generate.child.output ++ newGeneratorChildren, generate.child)
+              generator = generate.generator
+                .withNewChildren(Seq(aliasExpr.toAttribute))
+                .asInstanceOf[Generator],
+              child = ProjectExec(generate.child.output ++ Seq(aliasExpr), generate.child)
             )
           } else {
             // generator.child is Attribute, no need to introduce a Project.

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.shuffle.GlutenShuffleUtils
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanHelper, AQEShuffleReadExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.execution.joins.BaseJoinExec
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.functions._
@@ -2276,6 +2277,43 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
       codec =>
         val conf = spark.sparkContext.getConf.clone().set("spark.io.compression.codec", codec)
         assert(GlutenShuffleUtils.getCompressionCodec(conf) === codec)
+    }
+  }
+
+  test("exchange reuse with CTE lateral view explode") {
+    // This test verifies the fix for Generate pre-project canonicalization.
+    // When explode(split(col)) is used, a pre-project is inserted to compute the
+    // split expression as an Alias before feeding it to the generator. Before the
+    // fix, the generator use an alias expression as its sub-expression, but Spark's
+    // doCanonicalize does not cope with it.
+    // This caused structurally identical plans from different query
+    // parts to have different canonicalized forms, preventing ReuseExchangeExec
+    // from reusing exchanges.
+    // With AQE on and shuffle partitions > 1, the self-join on the CTE produces
+    // two identical shuffle exchanges that should be reused.
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true",
+      SQLConf.SHUFFLE_PARTITIONS.key -> "2") {
+      runQueryAndCompare("""
+                           |WITH exploded AS (
+                           |  SELECT l_orderkey, word
+                           |  FROM lineitem
+                           |  LATERAL VIEW explode(split(l_comment, ' ')) t AS word
+                           |  WHERE l_orderkey < 10
+                           |)
+                           |SELECT count(*), sum(t1.l_orderkey + t2.l_orderkey)
+                           |FROM exploded t1
+                           |JOIN exploded t2 ON t1.word = t2.word
+                           |""".stripMargin) {
+        df =>
+          val plan = df.queryExecution.executedPlan
+          assert(
+            collect(plan) { case p: GenerateExecTransformer => p }.nonEmpty,
+            "Expected GenerateExecTransformer in the plan")
+          assert(
+            collect(plan) { case re: ReusedExchangeExec => re }.nonEmpty,
+            "Expected ReusedExchangeExec in the plan")
+      }
     }
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1147,14 +1147,14 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
           }
         }
 
-        // Fallback for array(struct(...), null) literal.
+        // array(struct(...), null) literal is not a sub-expression of generator.
         runQueryAndCompare(s"""
                               |SELECT $func(array(
                               |  named_struct('c1', 0, 'c2', 1),
                               |  named_struct('c1', 2, 'c2', null),
                               |  null));
                               |""".stripMargin) {
-          checkSparkPlan[GenerateExec]
+          checkGlutenPlan[GenerateExecTransformer]
         }
     }
   }


### PR DESCRIPTION
Fix https://github.com/apache/gluten/issues/12413.
After the fix, the plan is:
```
== Physical Plan ==
VeloxColumnarToRow
+- ^(6) BroadcastHashJoinExecTransformer [emp_id#19], [emp_id#27], Inner, BuildRight, false
   :- ^(6) HashAggregateTransformer(keys=[emp_id#19, emp_name#20], functions=[count(1)], isStreamingAgg=false)
   :  +- ^(6) InputIteratorTransformer[emp_id#19, emp_name#20, count#42L]
   :     +- ColumnarExchange hashpartitioning(emp_id#19, emp_name#20, 2000), ENSURE_REQUIREMENTS, [emp_id#19, emp_name#20, count#42L], [plan_id=2005], [shuffle_writer_type=hash], [OUTPUT] List(emp_id:IntegerType, emp_name:StringType, count:LongType)
   :        +- VeloxResizeBatches 1024, 2147483647, 10485760
   :           +- ^(2) ProjectExecTransformer [hash(emp_id#19, emp_name#20, 42) AS hash_partition_key#70, emp_id#19, emp_name#20, count#42L]
   :              +- ^(2) FlushableHashAggregateTransformer(keys=[emp_id#19, emp_name#20], functions=[partial_count(1)], isStreamingAgg=false)
   :                 +- ^(2) ProjectExecTransformer [emp_id#19, emp_name#20]
   :                    +- ^(2) HashAggregateTransformer(keys=[emp_id#19, emp_name#20, dept_names#21, sale#22], functions=[], isStreamingAgg=false)
   :                       +- ^(2) InputIteratorTransformer[emp_id#19, emp_name#20, dept_names#21, sale#22]
   :                          +- ColumnarExchange hashpartitioning(emp_id#19, emp_name#20, dept_names#21, sale#22, 2000), ENSURE_REQUIREMENTS, [emp_id#19, emp_name#20, dept_names#21, sale#22], [plan_id=1996], [shuffle_writer_type=hash], [OUTPUT] List(emp_id:IntegerType, emp_name:StringType, dept_names:StringType, sale:IntegerType)
   :                             +- VeloxResizeBatches 1024, 2147483647, 10485760
   :                                +- ^(1) ProjectExecTransformer [hash(emp_id#19, emp_name#20, dept_names#21, sale#22, 42) AS hash_partition_key#69, emp_id#19, emp_name#20, dept_names#21, sale#22]
   :                                   +- ^(1) FlushableHashAggregateTransformer(keys=[emp_id#19, emp_name#20, dept_names#21, sale#22], functions=[], isStreamingAgg=false)
   :                                      +- ^(1) ProjectExecTransformer [emp_id#19, emp_name#20, dept_names#21, sale#22]
   :                                         +- ^(1) GenerateExecTransformer explode(_pre_0#45), [emp_id#19, emp_name#20, dept_names#21, sale#22], false, [dept_name#36]
   :                                            +- ^(1) ProjectExecTransformer [emp_id#19, emp_name#20, dept_names#21, sale#22, split(dept_names#21, ,, -1) AS _pre_0#45]
   :                                               +- ^(1) InputIteratorTransformer[emp_id#19, emp_name#20, dept_names#21, sale#22]
   :                                                  +- RowToVeloxColumnar
   :                                                     +- LocalTableScan [emp_id#19, emp_name#20, dept_names#21, sale#22]
   +- ^(6) InputIteratorTransformer[emp_id#27, sum(sale)#40L]
      +- ColumnarBroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2116]
         +- ^(5) HashAggregateTransformer(keys=[emp_id#27], functions=[sum(sale#30)], isStreamingAgg=false)
            +- ^(5) InputIteratorTransformer[emp_id#27, sum#44L]
               +- ColumnarExchange hashpartitioning(emp_id#27, 2000), ENSURE_REQUIREMENTS, [emp_id#27, sum#44L], [plan_id=2097], [shuffle_writer_type=hash], [OUTPUT] List(emp_id:IntegerType, sum:LongType)
                  +- VeloxResizeBatches 1024, 2147483647, 10485760
                     +- ^(4) ProjectExecTransformer [hash(emp_id#27, 42) AS hash_partition_key#72, emp_id#27, sum#44L]
                        +- ^(4) FlushableHashAggregateTransformer(keys=[emp_id#27], functions=[partial_sum(sale#30)], isStreamingAgg=false)
                           +- ^(4) ProjectExecTransformer [emp_id#27, sale#30]
                              +- ^(4) HashAggregateTransformer(keys=[emp_id#27, emp_name#28, dept_names#29, sale#30], functions=[], isStreamingAgg=false)
                                 +- ^(4) InputIteratorTransformer[emp_id#27, emp_name#28, dept_names#29, sale#30]
                                    +- ReusedExchange [emp_id#27, emp_name#28, dept_names#29, sale#30], ColumnarExchange hashpartitioning(emp_id#19, emp_name#20, dept_names#21, sale#22, 2000), ENSURE_REQUIREMENTS, [emp_id#19, emp_name#20, dept_names#21, sale#22], [plan_id=1996], [shuffle_writer_type=hash], [OUTPUT] List(emp_id:IntegerType, emp_name:StringType, dept_names:StringType, sale:IntegerType)
```
There is a `ReusedExchange` in the plan, which is in expectation.

**Side effect:** after this PR, `GenerateExec` with generator offloadable will not fallback because the child of generator is `Alias` and its validation will always succeed.