### PR TITLE
[WIP][FLINK] Support Kafka source checkpoint state restore

### DIFF
--- a/gluten-flink/planner/src/main/java/org/apache/gluten/velox/KafkaSourceSinkFactory.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/velox/KafkaSourceSinkFactory.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import java.util.UUID;
 
 public class KafkaSourceSinkFactory implements VeloxSourceSinkFactory {
+  public static final String GLUTEN_KAFKA_SOURCE_UID = "gluten-kafka-source";
 
   @SuppressWarnings("rawtypes")
   @Override
@@ -101,6 +102,7 @@ public class KafkaSourceSinkFactory implements VeloxSourceSinkFactory {
           startupMode.equals("LATEST")
               ? "latest-offsets"
               : startupMode.equals("EARLIEST") ? "earliest-offsets" : "group-offsets");
+      String autoResetOffset = startupMode.equals("LATEST") ? "latest" : "earliest";
       kafkaTableParameters.put("enable.auto.commit", checkpointEnabled ? "false" : "true");
       kafkaTableParameters.put(
           "client.id",
@@ -116,7 +118,7 @@ public class KafkaSourceSinkFactory implements VeloxSourceSinkFactory {
               kafkaTableParameters.get("group.id"),
               format,
               Boolean.valueOf(kafkaTableParameters.getOrDefault("enable.auto.commit", "false")),
-              "latest",
+              autoResetOffset,
               List.of());
 
       PlanNode kafkaScan =
@@ -134,13 +136,16 @@ public class KafkaSourceSinkFactory implements VeloxSourceSinkFactory {
                   RowData.class),
               "KafkaSource");
       SourceTransformation sourceTransformation = (SourceTransformation) transformation;
-      return new LegacySourceTransformation<RowData>(
-          sourceTransformation.getName(),
-          sourceOp,
-          transformation.getOutputType(),
-          sourceTransformation.getParallelism(),
-          sourceTransformation.getBoundedness(),
-          false);
+      LegacySourceTransformation<RowData> transformationWithNativeSource =
+          new LegacySourceTransformation<RowData>(
+              sourceTransformation.getName(),
+              sourceOp,
+              transformation.getOutputType(),
+              sourceTransformation.getParallelism(),
+              sourceTransformation.getBoundedness(),
+              false);
+      transformationWithNativeSource.setUid(GLUTEN_KAFKA_SOURCE_UID);
+      return transformationWithNativeSource;
     } catch (Exception e) {
       throw new FlinkRuntimeException(e);
     }

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/config/VeloxConnectorConfig.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/config/VeloxConnectorConfig.java
@@ -39,14 +39,14 @@ public class VeloxConnectorConfig {
           "connector-from-elements",
           "connector-print");
   private static final String keyTaskIndex = "task_index";
-  private static final String keyParallelism = "parallelism";
+  private static final String keyTaskParallelism = "task_parallelism";
   private static final String keyQueryUUId = "query_uuid";
 
   public static ConnectorConfig getConfig(RuntimeContext context) {
     Map<String, String> configMap = new HashMap<>();
     TaskInfo taskInfo = context.getTaskInfo();
     configMap.put(keyTaskIndex, String.valueOf(taskInfo.getIndexOfThisSubtask()));
-    configMap.put(keyParallelism, String.valueOf(taskInfo.getNumberOfParallelSubtasks()));
+    configMap.put(keyTaskParallelism, String.valueOf(taskInfo.getNumberOfParallelSubtasks()));
     configMap.put(
         keyQueryUUId,
         UUID.nameUUIDFromBytes(context.getJobInfo().getJobId().toHexString().getBytes())

--- a/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
+++ b/gluten-flink/runtime/src/main/java/org/apache/gluten/table/runtime/operators/GlutenSourceFunction.java
@@ -33,6 +33,9 @@ import io.github.zhztheplayer.velox4j.stateful.StatefulRecord;
 import io.github.zhztheplayer.velox4j.stateful.StatefulWatermark;
 import io.github.zhztheplayer.velox4j.type.RowType;
 
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -44,6 +47,7 @@ import org.apache.flink.table.data.RowData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -65,6 +69,7 @@ public class GlutenSourceFunction<OUT> extends RichParallelSourceFunction<OUT>
   private Query query;
   private SerialTask task;
   private SourceTaskMetrics taskMetrics;
+  private transient ListState<String> checkpointedSourceState;
   private final Class<OUT> outClass;
 
   public GlutenSourceFunction(
@@ -207,15 +212,44 @@ public class GlutenSourceFunction<OUT> extends RichParallelSourceFunction<OUT>
 
   @Override
   public void snapshotState(FunctionSnapshotContext context) throws Exception {
-    // TODO: implement it
-    this.task.snapshotState(0);
+    checkpointedSourceState.clear();
+
+    snapshotNativeState(context.getCheckpointId());
+    String[] sourceState = getNativeSourceStateSnapshot();
+    if (sourceState != null) {
+      for (String record : sourceState) {
+        checkpointedSourceState.add(record);
+      }
+    }
   }
 
   @Override
   public void initializeState(FunctionInitializationContext context) throws Exception {
+    ListStateDescriptor<String> descriptor =
+        new ListStateDescriptor<>("gluten-source-checkpoint-state", StringSerializer.INSTANCE);
+    checkpointedSourceState = context.getOperatorStateStore().getListState(descriptor);
+
+    List<String> restoredRecords = new ArrayList<>();
+    if (context.isRestored()) {
+      for (String record : checkpointedSourceState.get()) {
+        restoredRecords.add(record);
+      }
+    }
+
     initSession();
-    // TODO: implement it
-    this.task.initializeState(0, null);
+    initializeNativeState(restoredRecords.toArray(new String[0]));
+  }
+
+  protected void initializeNativeState(String[] restoredRecords) {
+    this.task.initializeState(0, null, restoredRecords);
+  }
+
+  protected void snapshotNativeState(long checkpointId) {
+    this.task.snapshotState(checkpointId);
+  }
+
+  protected String[] getNativeSourceStateSnapshot() {
+    return this.task.snapshotSourceState();
   }
 
   public String[] notifyCheckpointComplete(long checkpointId) throws Exception {
@@ -228,7 +262,7 @@ public class GlutenSourceFunction<OUT> extends RichParallelSourceFunction<OUT>
     this.task.notifyCheckpointAborted(checkpointId);
   }
 
-  private void initSession() {
+  protected void initSession() {
     if (sessionResource != null) {
       return;
     }

--- a/gluten-flink/ut/pom.xml
+++ b/gluten-flink/ut/pom.xml
@@ -131,6 +131,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-state-processor-api</artifactId>
+      <version>${flink.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>2.0.7</version>

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/common/KafkaSourceCheckpointStateHelper.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/common/KafkaSourceCheckpointStateHelper.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.table.runtime.stream.common;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
+import org.apache.flink.state.api.OperatorIdentifier;
+import org.apache.flink.state.api.OperatorTransformation;
+import org.apache.flink.state.api.SavepointReader;
+import org.apache.flink.state.api.SavepointWriter;
+import org.apache.flink.state.api.StateBootstrapTransformation;
+import org.apache.flink.state.api.functions.StateBootstrapFunction;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.CloseableIterator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class KafkaSourceCheckpointStateHelper {
+  public static final String STATE_NAME = "gluten-source-checkpoint-state";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private KafkaSourceCheckpointStateHelper() {}
+
+  public static List<KafkaSourceCheckpointRecord> readLatestKafkaSourceState(
+      Path checkpointRoot, String operatorUid) throws Exception {
+    List<Path> checkpoints = findCheckpointPointers(checkpointRoot);
+    for (int i = checkpoints.size() - 1; i >= 0; i--) {
+      List<String> records = readListState(checkpoints.get(i), operatorUid);
+      if (!records.isEmpty()) {
+        List<KafkaSourceCheckpointRecord> parsed = new ArrayList<>();
+        for (String record : records) {
+          parsed.add(KafkaSourceCheckpointRecord.parse(record));
+        }
+        return parsed;
+      }
+    }
+    return List.of();
+  }
+
+  public static Path writeKafkaSourceStateSavepoint(
+      Path savepointPath, String operatorUid, List<String> records) throws Exception {
+    StreamExecutionEnvironment writerEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+    writerEnv.setParallelism(1);
+    StateBootstrapTransformation<String> transformation =
+        OperatorTransformation.bootstrapWith(writerEnv.fromData(records))
+            .transform(new KafkaSourceStateBootstrapFunction());
+
+    SavepointWriter.newSavepoint(writerEnv, new HashMapStateBackend(), 128)
+        .withOperator(OperatorIdentifier.forUid(operatorUid), transformation)
+        .write(savepointPath.toUri().toString());
+    writerEnv.execute("write-gluten-kafka-source-state-savepoint");
+    return savepointPath;
+  }
+
+  public static String kafkaSourceCheckpointRecord(
+      String topic, int partition, long offset, long checkpointId, String groupId)
+      throws IOException {
+    ObjectNode root = OBJECT_MAPPER.createObjectNode();
+    root.put("connector", "kafka");
+    root.put("checkpointId", checkpointId);
+    root.put("groupId", groupId);
+    ArrayNode topicPartitions = root.putArray("topicPartitions");
+    ObjectNode topicPartition = topicPartitions.addObject();
+    topicPartition.put("topic", topic);
+    topicPartition.put("partition", partition);
+    topicPartition.put("offset", offset);
+    return OBJECT_MAPPER.writeValueAsString(root);
+  }
+
+  private static List<Path> findCheckpointPointers(Path checkpointRoot) throws IOException {
+    if (!Files.exists(checkpointRoot)) {
+      return List.of();
+    }
+    try (Stream<Path> paths = Files.walk(checkpointRoot)) {
+      return paths
+          .filter(path -> path.getFileName().toString().equals("_metadata"))
+          .map(Path::getParent)
+          .sorted(Comparator.comparing(KafkaSourceCheckpointStateHelper::checkpointId))
+          .collect(Collectors.toList());
+    }
+  }
+
+  private static long checkpointId(Path checkpointPath) {
+    String name = checkpointPath.getFileName().toString();
+    if (!name.startsWith("chk-")) {
+      return Long.MIN_VALUE;
+    }
+    try {
+      return Long.parseLong(name.substring("chk-".length()));
+    } catch (NumberFormatException e) {
+      return Long.MIN_VALUE;
+    }
+  }
+
+  private static List<String> readListState(Path checkpointPath, String operatorUid)
+      throws Exception {
+    StreamExecutionEnvironment readerEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+    readerEnv.setParallelism(1);
+    SavepointReader reader =
+        SavepointReader.read(
+            readerEnv, checkpointPath.toUri().toString(), new HashMapStateBackend());
+    DataStream<String> state =
+        reader.readListState(
+            OperatorIdentifier.forUid(operatorUid),
+            STATE_NAME,
+            Types.STRING,
+            StringSerializer.INSTANCE);
+
+    List<String> records = new ArrayList<>();
+    try (CloseableIterator<String> iterator = state.executeAndCollect()) {
+      while (iterator.hasNext()) {
+        records.add(iterator.next());
+      }
+    }
+    return records;
+  }
+
+  public static final class KafkaSourceCheckpointRecord {
+    private final String connector;
+    private final String planNodeId;
+    private final long checkpointId;
+    private final String groupId;
+    private final List<TopicPartitionOffset> topicPartitions;
+
+    private KafkaSourceCheckpointRecord(
+        String connector,
+        String planNodeId,
+        long checkpointId,
+        String groupId,
+        List<TopicPartitionOffset> topicPartitions) {
+      this.connector = connector;
+      this.planNodeId = planNodeId;
+      this.checkpointId = checkpointId;
+      this.groupId = groupId;
+      this.topicPartitions = topicPartitions;
+    }
+
+    static KafkaSourceCheckpointRecord parse(String record) throws IOException {
+      JsonNode root = OBJECT_MAPPER.readTree(record);
+      List<TopicPartitionOffset> topicPartitions = new ArrayList<>();
+      for (JsonNode topicPartition : root.path("topicPartitions")) {
+        topicPartitions.add(
+            new TopicPartitionOffset(
+                topicPartition.path("topic").asText(),
+                topicPartition.path("partition").asInt(),
+                topicPartition.path("offset").asLong()));
+      }
+      return new KafkaSourceCheckpointRecord(
+          root.path("connector").asText(),
+          root.path("planNodeId").asText(),
+          root.path("checkpointId").asLong(),
+          root.path("groupId").asText(),
+          topicPartitions);
+    }
+
+    public String connector() {
+      return connector;
+    }
+
+    public String planNodeId() {
+      return planNodeId;
+    }
+
+    public long checkpointId() {
+      return checkpointId;
+    }
+
+    public String groupId() {
+      return groupId;
+    }
+
+    public List<TopicPartitionOffset> topicPartitions() {
+      return topicPartitions;
+    }
+
+    public long offsetSum() {
+      return topicPartitions.stream().mapToLong(TopicPartitionOffset::offset).sum();
+    }
+  }
+
+  public static final class TopicPartitionOffset {
+    private final String topic;
+    private final int partition;
+    private final long offset;
+
+    private TopicPartitionOffset(String topic, int partition, long offset) {
+      this.topic = topic;
+      this.partition = partition;
+      this.offset = offset;
+    }
+
+    public String topic() {
+      return topic;
+    }
+
+    public int partition() {
+      return partition;
+    }
+
+    public long offset() {
+      return offset;
+    }
+  }
+
+  private static final class KafkaSourceStateBootstrapFunction
+      extends StateBootstrapFunction<String> implements CheckpointedFunction {
+    private final List<String> records = new ArrayList<>();
+    private transient ListState<String> state;
+
+    @Override
+    public void processElement(String value, Context ctx) {
+      records.add(value);
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+      state.update(records);
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+      state =
+          context
+              .getOperatorStateStore()
+              .getListState(new ListStateDescriptor<>(STATE_NAME, StringSerializer.INSTANCE));
+    }
+  }
+}

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/custom/KafkaSourceCheckpointIT.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/custom/KafkaSourceCheckpointIT.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.table.runtime.stream.custom;
+
+import org.apache.gluten.table.runtime.stream.common.KafkaSourceCheckpointStateHelper;
+import org.apache.gluten.table.runtime.stream.common.KafkaSourceCheckpointStateHelper.KafkaSourceCheckpointRecord;
+import org.apache.gluten.table.runtime.stream.common.KafkaSourceCheckpointStateHelper.TopicPartitionOffset;
+import org.apache.gluten.table.runtime.stream.common.Velox4jEnvironment;
+import org.apache.gluten.velox.KafkaSourceSinkFactory;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end checkpoint restore coverage for Gluten's native Kafka source.
+ *
+ * <p>The test runs against the docker-compose Kafka broker at {@code kafka:9092}. It creates a
+ * random topic, starts a Flink MiniCluster streaming job through the Table/SQL Kafka connector
+ * path, and lets {@link org.apache.gluten.velox.KafkaSourceSinkFactory} replace the Flink source
+ * with the Gluten native source.
+ *
+ * <p>The job consumes a first batch, waits until a checkpoint is completed, and then fails once
+ * from a downstream operator. After Flink restarts the job, the test writes a second batch while
+ * the Kafka source must restore from the source offset records stored in Flink operator state.
+ * Finally, it verifies that all records from both batches are delivered, proving the snapshot and
+ * restore path for native Kafka source offsets is exercised.
+ */
+public class KafkaSourceCheckpointIT {
+  private static final String BOOTSTRAP_SERVERS =
+      System.getProperty("gluten.flink.kafka.bootstrap.servers", "kafka:9092");
+  private static final int FIRST_BATCH_SIZE = 20;
+  private static final int SECOND_BATCH_SIZE = 20;
+  private static final int RECORD_COUNT = FIRST_BATCH_SIZE + SECOND_BATCH_SIZE;
+  private static final int RESTORED_OFFSET = 10;
+
+  private static final Set<Integer> RESULTS = ConcurrentHashMap.newKeySet();
+  private static final AtomicInteger SEEN_BY_FAILING_MAP = new AtomicInteger();
+  private static final AtomicBoolean FAILED_ONCE = new AtomicBoolean();
+  private static final AtomicBoolean FIRST_BATCH_CHECKPOINTED = new AtomicBoolean();
+
+  private static MiniClusterWithClientResource miniCluster;
+
+  @BeforeAll
+  static void beforeAll() throws Exception {
+    Velox4jEnvironment.initializeOnce();
+    miniCluster =
+        new MiniClusterWithClientResource(
+            new MiniClusterResourceConfiguration.Builder()
+                .setNumberTaskManagers(1)
+                .setNumberSlotsPerTaskManager(2)
+                .build());
+    miniCluster.before();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    if (miniCluster != null) {
+      miniCluster.after();
+    }
+  }
+
+  @Test
+  void testKafkaSourceRestoresOffsetStateAfterFailure() throws Exception {
+    RESULTS.clear();
+    SEEN_BY_FAILING_MAP.set(0);
+    FAILED_ONCE.set(false);
+    FIRST_BATCH_CHECKPOINTED.set(false);
+
+    String topic = "gluten-flink-source-checkpoint-" + UUID.randomUUID();
+    String groupId = "gluten-flink-source-checkpoint-group-" + UUID.randomUUID();
+    Path checkpointDir = Files.createTempDirectory("gluten-kafka-source-checkpoint-it");
+
+    try (AdminClient admin = AdminClient.create(kafkaProperties())) {
+      admin
+          .createTopics(List.of(new NewTopic(topic, 1, (short) 1)))
+          .all()
+          .get(30, TimeUnit.SECONDS);
+    }
+
+    Configuration configuration = new Configuration();
+    configuration.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toUri().toString());
+    StreamExecutionEnvironment env =
+        StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+    env.setParallelism(1);
+    env.enableCheckpointing(200, CheckpointingMode.EXACTLY_ONCE);
+    env.getCheckpointConfig()
+        .setExternalizedCheckpointCleanup(
+            CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+    env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, Duration.ofSeconds(5)));
+
+    StreamTableEnvironment tableEnv =
+        StreamTableEnvironment.create(
+            env, EnvironmentSettings.newInstance().inStreamingMode().build());
+    tableEnv.executeSql(createKafkaSourceDdl(topic, groupId));
+
+    // Pipeline shape:
+    // Kafka topic -> Gluten native Kafka source -> gluten-calc -> TableToDataStream
+    //     -> JVM fail-once map -> JVM collecting sink.
+    // The source and calc exercise Gluten's native path, while the downstream map/sink stay in
+    // Flink JVM operators so the test can trigger a deterministic failure after checkpoint
+    // completion and collect the restored output.
+    Table table = tableEnv.sqlQuery("SELECT id FROM kafka_source");
+    DataStream<Row> rows = tableEnv.toDataStream(table);
+    // This map operator deliberately fails the task once in notifyCheckpointComplete().
+    // The failure happens after the source has produced records and Flink has completed a
+    // checkpoint, forcing the restarted job to restore the Gluten Kafka source offset state.
+    rows.map(new FailOnceAfterCheckpoint())
+        .name("fail-once-after-checkpoint")
+        .addSink(new CollectingSink())
+        .name("collect-results");
+
+    JobClient jobClient = env.executeAsync("gluten-kafka-source-checkpoint-it");
+    try {
+      Thread.sleep(2000);
+      produce(topic, 0, FIRST_BATCH_SIZE);
+      waitUntil(
+          () -> RESULTS.size() >= FIRST_BATCH_SIZE,
+          Duration.ofSeconds(30),
+          "first Kafka batch records");
+      waitUntil(
+          () -> checkpointStateContainsFirstBatchOffsets(checkpointDir, topic, groupId),
+          Duration.ofSeconds(30),
+          "checkpoint containing the first Kafka batch offsets");
+      FIRST_BATCH_CHECKPOINTED.set(true);
+      waitUntil(
+          () -> FAILED_ONCE.get(), Duration.ofSeconds(30), "first checkpoint-triggered failure");
+
+      produce(topic, FIRST_BATCH_SIZE, RECORD_COUNT);
+      waitUntil(() -> RESULTS.size() >= RECORD_COUNT, Duration.ofSeconds(60), "all Kafka records");
+
+      assertThat(RESULTS).containsExactlyInAnyOrderElementsOf(expectedIds());
+    } finally {
+      jobClient.cancel().get(30, TimeUnit.SECONDS);
+      try (AdminClient admin = AdminClient.create(kafkaProperties())) {
+        admin.deleteTopics(List.of(topic)).all().get(30, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  @Test
+  void testKafkaSourceStartsFromManuallyModifiedCheckpointState() throws Exception {
+    RESULTS.clear();
+
+    String topic = "gluten-flink-source-manual-checkpoint-" + UUID.randomUUID();
+    String groupId = "gluten-flink-source-manual-checkpoint-group-" + UUID.randomUUID();
+    Path savepointPath = Files.createTempDirectory("gluten-kafka-source-manual-savepoint");
+
+    try (AdminClient admin = AdminClient.create(kafkaProperties())) {
+      admin
+          .createTopics(List.of(new NewTopic(topic, 1, (short) 1)))
+          .all()
+          .get(30, TimeUnit.SECONDS);
+    }
+
+    produce(topic, 0, RECORD_COUNT);
+    KafkaSourceCheckpointStateHelper.writeKafkaSourceStateSavepoint(
+        savepointPath,
+        KafkaSourceSinkFactory.GLUTEN_KAFKA_SOURCE_UID,
+        List.of(
+            KafkaSourceCheckpointStateHelper.kafkaSourceCheckpointRecord(
+                topic, 0, RESTORED_OFFSET, 1, groupId)));
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+
+    StreamTableEnvironment tableEnv =
+        StreamTableEnvironment.create(
+            env, EnvironmentSettings.newInstance().inStreamingMode().build());
+    tableEnv.executeSql(createKafkaSourceDdl(topic, groupId));
+
+    Table table = tableEnv.sqlQuery("SELECT id FROM kafka_source");
+    DataStream<Row> rows = tableEnv.toDataStream(table);
+    rows.map(value -> ((Number) value.getField(0)).intValue())
+        .name("extract-id")
+        .addSink(new CollectingSink())
+        .name("collect-results");
+
+    StreamGraph streamGraph = env.getStreamGraph();
+    streamGraph.setSavepointRestoreSettings(
+        SavepointRestoreSettings.forPath(savepointPath.toUri().toString(), false));
+    streamGraph.setJobName("gluten-kafka-source-manual-checkpoint-state-it");
+
+    JobClient jobClient = env.executeAsync(streamGraph);
+    try {
+      waitUntil(
+          () -> RESULTS.size() >= RECORD_COUNT - RESTORED_OFFSET,
+          Duration.ofSeconds(60),
+          "Kafka records after the restored offset");
+
+      assertThat(RESULTS).containsExactlyInAnyOrderElementsOf(expectedIds(RESTORED_OFFSET));
+    } finally {
+      jobClient.cancel().get(30, TimeUnit.SECONDS);
+      try (AdminClient admin = AdminClient.create(kafkaProperties())) {
+        admin.deleteTopics(List.of(topic)).all().get(30, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  private static boolean checkpointStateContainsFirstBatchOffsets(
+      Path checkpointDir, String topic, String groupId) throws Exception {
+    List<KafkaSourceCheckpointRecord> records =
+        KafkaSourceCheckpointStateHelper.readLatestKafkaSourceState(
+            checkpointDir, KafkaSourceSinkFactory.GLUTEN_KAFKA_SOURCE_UID);
+    if (records.isEmpty()) {
+      return false;
+    }
+    for (KafkaSourceCheckpointRecord record : records) {
+      assertThat(record.connector()).isEqualTo("kafka");
+      assertThat(record.planNodeId()).isNotEmpty();
+      assertThat(record.checkpointId()).isGreaterThanOrEqualTo(0L);
+      assertThat(record.groupId()).isEqualTo(groupId);
+      assertThat(record.topicPartitions()).isNotEmpty();
+      for (TopicPartitionOffset topicPartition : record.topicPartitions()) {
+        assertThat(topicPartition.topic()).isEqualTo(topic);
+        assertThat(topicPartition.partition()).isGreaterThanOrEqualTo(0);
+        assertThat(topicPartition.offset()).isGreaterThanOrEqualTo(0L);
+      }
+    }
+    return records.stream().mapToLong(KafkaSourceCheckpointRecord::offsetSum).sum()
+        == FIRST_BATCH_SIZE;
+  }
+
+  private static String createKafkaSourceDdl(String topic, String groupId) {
+    return "CREATE TABLE kafka_source ("
+        + " id INT,"
+        + " payload STRING"
+        + ") WITH ("
+        + " 'connector' = 'kafka',"
+        + " 'topic' = '"
+        + topic
+        + "',"
+        + " 'properties.bootstrap.servers' = '"
+        + BOOTSTRAP_SERVERS
+        + "',"
+        + " 'properties.group.id' = '"
+        + groupId
+        + "',"
+        + " 'scan.startup.mode' = 'latest-offset',"
+        + " 'format' = 'json'"
+        + ")";
+  }
+
+  private static void produce(String topic, int startInclusive, int endExclusive) throws Exception {
+    try (KafkaProducer<String, String> producer =
+        new KafkaProducer<>(kafkaProperties(), new StringSerializer(), new StringSerializer())) {
+      for (int id = startInclusive; id < endExclusive; id++) {
+        producer.send(
+            new ProducerRecord<>(
+                topic, Integer.toString(id), "{\"id\":" + id + ",\"payload\":\"v-" + id + "\"}"));
+      }
+      producer.flush();
+    }
+  }
+
+  private static Properties kafkaProperties() {
+    Properties properties = new Properties();
+    properties.setProperty("bootstrap.servers", BOOTSTRAP_SERVERS);
+    return properties;
+  }
+
+  private static List<Integer> expectedIds() {
+    return expectedIds(0);
+  }
+
+  private static List<Integer> expectedIds(int startInclusive) {
+    List<Integer> expected = new ArrayList<>();
+    for (int id = startInclusive; id < RECORD_COUNT; id++) {
+      expected.add(id);
+    }
+    return expected;
+  }
+
+  private static void waitUntil(CheckedBooleanSupplier condition, Duration timeout, String event)
+      throws Exception {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(100);
+    }
+    throw new AssertionError("Timed out waiting for " + event + ". Current results: " + RESULTS);
+  }
+
+  private interface CheckedBooleanSupplier {
+    boolean getAsBoolean() throws Exception;
+  }
+
+  private static class FailOnceAfterCheckpoint extends RichMapFunction<Row, Integer>
+      implements CheckpointListener {
+    @Override
+    public Integer map(Row value) {
+      SEEN_BY_FAILING_MAP.incrementAndGet();
+      return ((Number) value.getField(0)).intValue();
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+      // Throwing here is the intentional task failure in this IT. Since this callback only runs
+      // after a checkpoint completes, the following restart must restore the native Kafka source
+      // offsets from Flink operator state instead of starting from the table's latest-offset mode.
+      if (FIRST_BATCH_CHECKPOINTED.get()
+          && SEEN_BY_FAILING_MAP.get() > 0
+          && FAILED_ONCE.compareAndSet(false, true)) {
+        throw new RuntimeException("Fail once after checkpoint " + checkpointId);
+      }
+    }
+  }
+
+  private static class CollectingSink implements SinkFunction<Integer> {
+    @Override
+    public void invoke(Integer value, Context context) {
+      RESULTS.add(value);
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support checkpoint/restore for Gluten Flink native Kafka source offsets:

1. **Persist native source checkpoint records**: `GlutenSourceFunction` now snapshots native source state with the real Flink checkpoint id and stores the returned records in Flink operator `ListState<String>`.

2. **Restore source offsets from operator state**: restored source checkpoint records are loaded from Flink operator state and passed back to native execution during source initialization.

3. **Kafka source restore coverage**: add a Kafka + MiniCluster IT that verifies checkpoint records are written, restored after failure, and can be manually bootstrapped to start consuming from a specified offset.

4. **Kafka source helper**: add a test helper for reading and writing Gluten Kafka source checkpoint state through Flink State Processor API.

5. **Kafka source config fixes**: align native Kafka startup offset handling with Flink startup mode and pass `task_parallelism` expected by the native Kafka connector.

Depends on:

- bigo-sg/velox4j `feature/flink-source-offset-checkpoint-state` (`7bea365`)

## How was this patch tested?

```bash
mvn spotless:apply -pl ut
mvn test -pl ut -am -Dtest=KafkaSourceCheckpointIT -DfailIfNoTests=false
```

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI gpt-5.5
