### PR TITLE
[VL] Fix arrow build with Clang 21

### DIFF
--- a/dev/build-arrow.sh
+++ b/dev/build-arrow.sh
@@ -39,13 +39,23 @@ function prepare_arrow_build() {
 function build_arrow_cpp() {
   pushd $ARROW_PREFIX/cpp
   ARROW_WITH_ZLIB=ON
+  # Major version of the compiler CMake will use, when it is clang. Non-clang
+  # compilers (e.g. gcc) do not define __clang_major__, leaving this empty.
+  clang_major_version=$(echo | ${CXX:-c++} -dM -E -x c++ - 2>/dev/null | awk '/__clang_major__/ {print $3}')
   # The zlib version bundled with arrow is not compatible with clang 17.
   # It can be removed after upgrading the arrow version.
   if [[ "$(uname)" == "Darwin" ]]; then
-    clang_major_version=$(echo | clang -dM -E - | grep __clang_major__ | awk '{print $3}')
-    if [ "${clang_major_version}" -ge 17 ]; then
+    if [ -n "${clang_major_version}" ] && [ "${clang_major_version}" -ge 17 ]; then
       ARROW_WITH_ZLIB=OFF
     fi
+  fi
+  # Clang 21 added -Wcharacter-conversion (enabled by default), which Arrow's
+  # bundled googletest trips under its own -Werror. Downgrade it to a warning on
+  # clang 21+. Not OS-specific: any clang 21+ (macOS or Linux) is affected. Can be
+  # removed once an Arrow upgrade ships a newer googletest.
+  EXTRA_CMAKE_CXX_FLAGS=""
+  if [ -n "${clang_major_version}" ] && [ "${clang_major_version}" -ge 21 ]; then
+    EXTRA_CMAKE_CXX_FLAGS="-Wno-error=character-conversion"
   fi
   cmake_install \
        -DARROW_PARQUET=OFF \

--- a/dev/build-helper-functions.sh
+++ b/dev/build-helper-functions.sh
@@ -174,7 +174,9 @@ function cmake_install {
   fi
   mkdir -p "${BINARY_DIR}"
   CPU_TARGET="${CPU_TARGET:-unknown}"
-  COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
+  # EXTRA_CMAKE_CXX_FLAGS lets a caller append dependency-specific compiler flags
+  # for a single cmake_install invocation without affecting other dependencies.
+  COMPILER_FLAGS="$(get_cxx_flags $CPU_TARGET) ${EXTRA_CMAKE_CXX_FLAGS:-}"
 
   local MACOS_ISOLATION_FLAGS=""
   if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
## What changes are proposed in this pull request?

Clang 21 introduced a new warning -Wcharacter-conversion https://releases.llvm.org/21.1.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics

It's triggered when implicitly converting between char8_t, char16_t, char32_t.

This is causing `./dev/builddeps-veloxbe.sh build_arrow` to fail, as it builds gtest as a dependency and it has an implicit conversion in one of its headers.

```
  FAILED: [code=1] _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o                                                                                   
  /Users/kevinwilfong/incubator-gluten/ep/build-velox/build/velox_ep/deps-install/bin/ccache /Library/Developer/CommandLineTools/usr/bin/c++ -DARROW_WITH_TIMING_TESTS         
  -DGTEST_CREATE_SHARED_LIBRARY=1 -Dgtest_EXPORTS -I/Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/include                    
  -fPIC -Wall -Wshadow -Werror -Wconversion -DGTEST_HAS_PTHREAD=1 -fexceptions -W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter        
  -Wcast-align -Wchar-subscripts -Winline -Wredundant-decls -MD -MT _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o -MF                              
  _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o.d -o _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o -c                  
  /Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/src/gtest-all.cc                                                             
  In file included from /Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/src/gtest-all.cc:38:                                   
  In file included from /Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/include/gtest/gtest.h:64:                              
  In file included from /Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/include/gtest/gtest-death-test.h:41:                   
  In file included from /Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/include/gtest/internal/gtest-death-test-internal.h:39: 
  In file included from /Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:44:                     
  /Users/kevinwilfong/incubator-gluten/ep/_ep/arrow_ep/cpp/_build/_deps/googletest-src/googletest/include/gtest/gtest-printers.h:478:35: error: implicit conversion from       
  'char8_t' to 'char32_t' may change the meaning of the represented code unit [-Werror,-Wcharacter-conversion]                                                                 
    478 |   PrintTo(ImplicitCast_<char32_t>(c), os);                                                                                                                           
        |           ~~~~~~~~~~~~~           ^                                                                                                                                  
  1 error generated.  
```

This PR proposes not treating those warnings as errors when building Arrow.

## How was this patch tested?

Built Arrow successfully using Apple Clang 21.

## Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude Opus 4.8

Generated-by: Claude Opus 4.8
