### PR TITLE
[VL] Update Velox build to look for Thrift in ${CMAKE_PREFIX_PATH}/lib

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -411,17 +411,24 @@ if(DEFINED VCPKG_INSTALLED_DIR
     PRIVATE ${VCPKG_INSTALLED_DIR}/${VCPKG_TRIPLET_DIR}/lib/libthriftcpp2.a
             ${VCPKG_INSTALLED_DIR}/${VCPKG_TRIPLET_DIR}/lib/libthriftprotocol.a)
 else()
-  message(STATUS "Using system thrift libraries from /usr/local/lib")
+  # fbthrift is installed either into the Velox dependency prefix (e.g. on macOS
+  # where deps are isolated under deps-install, passed via CMAKE_PREFIX_PATH) or
+  # into a system location such as /usr/local (Linux). Search CMAKE_PREFIX_PATH
+  # in addition to /usr/local/lib rather than hardcoding the latter.
+  message(
+    STATUS
+      "Using thrift libraries from CMAKE_PREFIX_PATH (${CMAKE_PREFIX_PATH}) or /usr/local/lib"
+  )
   find_library(
     THRIFTCPP2_LIB
     NAMES thriftcpp2
-    PATHS /usr/local/lib
-    NO_DEFAULT_PATH)
+    PATHS ${CMAKE_PREFIX_PATH} /usr/local
+    PATH_SUFFIXES lib)
   find_library(
     THRIFTPROTOCOL_LIB
     NAMES thriftprotocol
-    PATHS /usr/local/lib
-    NO_DEFAULT_PATH)
+    PATHS ${CMAKE_PREFIX_PATH} /usr/local
+    PATH_SUFFIXES lib)
 
   if(THRIFTCPP2_LIB AND THRIFTPROTOCOL_LIB)
     target_link_libraries(velox PRIVATE ${THRIFTCPP2_LIB} ${THRIFTPROTOCOL_LIB})


### PR DESCRIPTION
## What changes are proposed in this pull request?

At least on Mac, Velox installs its dependencies in a directory local to the checkout, with Gluten this is typically incubator-gluten/ep/build-velox/build/velox_ep/deps-install. One of these dependencies is fbthrift.

Currently the CMakeLists.txt file in cpp/velox is hard coded to look for Thrift in /usr/local/lib, which is inconsistent and results in an error building Gluten.

  ```
CMake Error at velox/CMakeLists.txt:431 (message):
    Could not find thrift libraries.  Please install them or use vcpkg.
```

The fix is to update the CMakeLists.txt file to look for Thrift in the directory Velox installs its dependencies ${CMAKE_PREFIX_PATH} and if it can't find it there fall back to /usr/local/lib to preserve the existing behavior.

## How was this patch tested?

Ran `./dev/builddeps-veloxbe.sh build_gluten_cpp` on a Mac without Thrift installed in /usr/local/lib and verified it could find Thrift in the directory Velox installed the dependencies.

## Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude Opus 4.8

Generated-by: Claude Opus 4.8
