### PR TITLE
[VL] Include headers from INSTALL_PREFIX as system includes on Mac

### DIFF
--- a/ep/build-velox/src/build-velox.sh
+++ b/ep/build-velox/src/build-velox.sh
@@ -115,9 +115,12 @@ function compile {
   if [[ "$(uname)" == "Darwin" ]]; then
     CXX_FLAGS="$CXX_FLAGS -Wno-inconsistent-missing-override -Wno-macro-redefined"
     if [[ -n "${INSTALL_PREFIX:-}" && "${INSTALL_PREFIX:-}" != "/usr/local" && "${INSTALL_PREFIX:-}" != /usr/local/* ]]; then
-      # Some prefix-installed deps only publish loose headers (e.g. xsimd), so
-      # keep the prefix include dir on the compiler command line.
-      CXX_FLAGS="$CXX_FLAGS -I${INSTALL_PREFIX}/include"
+      # Add the dependency prefix as a system include: this finds deps that only
+      # publish loose headers (e.g. xsimd) and demotes warnings in vendored
+      # dependency headers (abseil's __is_trivially_relocatable, arrow's vendored
+      # date.h literal operators) to non-fatal system-header warnings under
+      # -Werror on recent clang.
+      CXX_FLAGS="$CXX_FLAGS -isystem ${INSTALL_PREFIX}/include"
     fi
   fi
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

https://github.com/apache/gluten/pull/12105 introduced the flag -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON to Velox builds. This has the unintended side effect of including dependencies' header files as non-system includes which means that warnings in the build are promoted to errors, e.g.

```
  In file included from t.cc:1:
  In file included from …/deps-install/include/re2/re2.h:220:
  In file included from …/deps-install/include/absl/base/call_once.h:40:
  In file included from …/deps-install/include/absl/base/nullability.h:153:
  In file included from …/deps-install/include/absl/base/internal/nullability_impl.h:22:
  …/deps-install/include/absl/meta/type_traits.h:511:36: error: builtin __is_trivially_relocatable is deprecated; use __builtin_is_cpp_trivially_relocatable instead
  [-Werror,-Wdeprecated-builtins]
    511 |     : std::integral_constant<bool, __is_trivially_relocatable(T)> {};
        |                                    ^
  1 error generated.
```

To fix this, this PR proposes explicitly including the header files under ${INSTALL_PREFIX}/include from dependencies as system includes, suppressing these errors which we have limited control over.

## How was this patch tested?

Executed ./dev/builddeps-veloxbe.sh on a Mac with Clang 21, verified we no longer got errors from warnings in dependencies. Combined with my other recent changes 
https://github.com/apache/gluten/pull/12421
https://github.com/apache/gluten/pull/12422
I was able to successfully run ./dev/builddeps-veloxbe.sh on an otherwise fresh checkout. 

## Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude Opus 4.8

Generated-by: Claude Opus 4.8
