### PR TITLE
[GLUTEN-12466][CORE] Expose ColumnarBatches.isLightBatch/ensureOffloaded as public

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/columnarbatch/ColumnarBatches.java
@@ -95,8 +95,7 @@ public final class ColumnarBatches {
    * Light batch: Data is not readable from JVM, a long int handle (which is a pointer usually) is
    * used to bind the batch to a native side implementation.
    */
-  @VisibleForTesting
-  static boolean isLightBatch(ColumnarBatch batch) {
+  public static boolean isLightBatch(ColumnarBatch batch) {
     return identifyBatchType(batch) == BatchType.LIGHT;
   }
 
@@ -128,7 +127,7 @@ public final class ColumnarBatches {
    * Ensure the input batch is offloaded as native-based columnar batch (See {@link IndicatorVector}
    * and {@link PlaceholderVector}). This method will close the input column batch after offloaded.
    */
-  static ColumnarBatch ensureOffloaded(BufferAllocator allocator, ColumnarBatch batch) {
+  public static ColumnarBatch ensureOffloaded(BufferAllocator allocator, ColumnarBatch batch) {
     if (ColumnarBatches.isLightBatch(batch)) {
       return batch;
     }


### PR DESCRIPTION
### Background

One of a small series of common-code changes to introduce a new backend — **Bolt** (ByteDance’s unified lakehouse analytics acceleration engine) — into the Gluten community. The series minimizes the delta to Gluten common code so Bolt can plug in cleanly, while leaving Velox and ClickHouse backends unaffected. It is part of plan in https://github.com/apache/gluten/issues/12456, close https://github.com/apache/gluten/issues/12466

### This PR

Promote two `ColumnarBatches` helpers from package-private to `public`:

- `isLightBatch(ColumnarBatch)` — was `@VisibleForTesting` package-private.
- `ensureOffloaded(BufferAllocator, ColumnarBatch)` — was package-private.

They are needed by out-of-package callers in the Bolt backend that produce or consume native-based columnar batches (e.g. a custom parquet batch writer under `org.apache.spark.sql.execution.datasources`), which cannot reach the package-private methods. Exposing them lets backends reuse the batch-type check and offload logic without duplicating it.