### PR TITLE
[GLUTEN-12463][CORE] Add backend hooks for native config forwarding

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -168,4 +168,16 @@ trait BackendSettingsApi {
 
   /** Whether the backend supports columnar shuffle with empty schema. */
   def supportEmptySchemaColumnarShuffle(): Boolean = true
+
+  /**
+   * Backend-specific non-prefixed session configs that should be forwarded to native runtime /
+   * memory manager creation.
+   */
+  def extraNativeSessionConfKeys(): Set[String] = Set.empty
+
+  /**
+   * Backend-specific non-prefixed backend initialization configs that should be forwarded during
+   * native backend initialization.
+   */
+  def extraNativeBackendConfKeys(): Set[String] = Set.empty
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.config
 
+import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.shuffle.SupportsColumnarShuffle
 
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
@@ -532,10 +533,18 @@ object GlutenConfig extends ConfigRegistry {
     "spark.gluten.sql.columnar.backend.velox.columnarBatchSerializerCompression"
   )
 
+  private def backendSettings(backendName: String) = {
+    // Only one backend is loaded in a running Gluten session. Use backend settings hooks to avoid
+    // hard-coding backend-specific configs in common code.
+    BackendsApiManager.getSettings
+  }
+
   /** Get dynamic configs. */
   def getNativeSessionConf(backendName: String, conf: Map[String, String]): Map[String, String] = {
+    val settings = backendSettings(backendName)
     val nativeConfMap = mutable.Map[String, String](conf.filter {
-      case (key, _) => nativeKeys.contains(key)
+      case (key, _) =>
+        nativeKeys.contains(key) || settings.extraNativeSessionConfKeys().contains(key)
     }.toSeq: _*)
 
     Seq(
@@ -649,6 +658,7 @@ object GlutenConfig extends ConfigRegistry {
       (SQLConf.SESSION_LOCAL_TIMEZONE.key, SQLConf.SESSION_LOCAL_TIMEZONE.defaultValueString)
     ).foreach { case (k, defaultValue) => nativeConfMap.put(k, conf.getOrElse(k, defaultValue)) }
 
+    val settings = backendSettings(backendName)
     val keys = Set(
       DEBUG_ENABLED.key,
       // datasource config
@@ -666,7 +676,9 @@ object GlutenConfig extends ConfigRegistry {
       COLUMNAR_CUDF_ENABLED.key
     )
 
-    nativeConfMap ++= conf.filter { case (k, _) => keys.contains(k) }
+    nativeConfMap ++= conf.filter {
+      case (k, _) => keys.contains(k) || settings.extraNativeBackendConfKeys().contains(k)
+    }
 
     val confPrefix = prefixOf(backendName)
     val s3Prefix = HADOOP_PREFIX + S3A_PREFIX


### PR DESCRIPTION
## What changes are proposed in this PR?


The main goal is to let common code remain compatible with multiple backends without hard-coding backend-specific behavior into shared paths that are also used by Velox and ClickHouse. It is part of plan in https://github.com/apache/gluten/issues/12456, close https://github.com/apache/gluten/issues/12463

Concretely, this patch adds backend hooks for forwarding extra non-prefixed native config keys:

- `BackendSettingsApi.extraNativeSessionConfKeys()` allows a backend to declare additional non-prefixed session configs that should be forwarded to native runtime / memory manager creation.
- `BackendSettingsApi.extraNativeBackendConfKeys()` allows a backend to declare additional non-prefixed configs that should be forwarded during native backend initialization.
- `GlutenConfig.getNativeSessionConf(...)` now consults these hooks instead of relying only on a hard-coded common key list.




## Why are the changes needed?

Before this change, extending native config forwarding for a backend required adding more backend-specific entries directly into `GlutenConfig`, which makes common code gradually accumulate backend-specific knowledge.

This patch provides that extension point in common code, and leaves existing backends unaffected because the new hooks default to empty sets.

## How was this patch tested?

- Verified the patch applies cleanly on top of `origin/main`.
- Confirmed the new hooks default to no-op behavior, so existing backends keep the previous config forwarding path unless they override the hooks.