### PR TITLE
[GLUTEN-12436][VL] Map ORC files with all-`_col*` physical names by position even when orcUseColumnNames is true

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -54,9 +54,16 @@ class VeloxIteratorApi extends IteratorApi with Logging {
       localFilesNode: LocalFilesNode,
       fileSchema: StructType,
       fileFormat: ReadFileFormat): LocalFilesNode = {
+    // For ORC/DWRF, always attach the table schema so the native reader can
+    // decide the column-mapping mode per file: files whose physical schema is
+    // all Hive placeholder names (_col0, ...) must be mapped by position even
+    // when orcUseColumnNames is true, matching vanilla Spark's per-file
+    // behavior in OrcUtils.requestedColumnIds. Without the table schema the
+    // native reader has nothing to remap file columns to.
+    // For Parquet, keep the previous behavior (only attach when mapping by
+    // position).
     if (
-      ((fileFormat == ReadFileFormat.OrcReadFormat || fileFormat == ReadFileFormat.DwrfReadFormat)
-        && !VeloxConfig.get.orcUseColumnNames)
+      (fileFormat == ReadFileFormat.OrcReadFormat || fileFormat == ReadFileFormat.DwrfReadFormat)
       || (fileFormat == ReadFileFormat.ParquetReadFormat && !VeloxConfig.get.parquetUseColumnNames)
     ) {
       localFilesNode.setFileSchema(fileSchema)

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -167,6 +167,68 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
     }
   }
 
+  testGluten(
+    "GLUTEN: Hive ORC files with _col* names read by position without positional flag") {
+    // Regression for the case where two ORC tables must use OPPOSITE column
+    // mapping modes in the same query: one with real column names (by name) and
+    // one written by old Hive with placeholder _col* names (by position). The
+    // native reader must decide the mode per file (matching vanilla Spark's
+    // OrcUtils.requestedColumnIds), so a _col* file reads correctly even though
+    // orc.force.positional.evolution is NOT set (the default, orcUseColumnNames
+    // stays true). Without the fix the _col* columns would read back as NULL.
+    val hiveClient: HiveClient =
+      spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
+
+    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+      withTempDir {
+        dir =>
+          val colStarLoc = s"file:///$dir/test_orc_colstar"
+          val namedLoc = s"file:///$dir/test_orc_named"
+          withTable("test_orc_colstar", "test_orc_colstar_renamed", "test_orc_named") {
+            // Naming the columns literally _col0/_col1 guarantees the physical
+            // ORC field names are placeholders, independent of the Hive
+            // version (mirrors Spark's SPARK-34897 setup).
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar(_col0 int, _col1 string) " +
+                s"stored as orc location '$colStarLoc'")
+            hiveClient.runSqlHive("insert into test_orc_colstar select 7, 'a'")
+
+            // A second table over the SAME files but with real names. By name,
+            // id/name are absent from the _col* files; only position mapping
+            // can read them -- and it must happen WITHOUT the positional flag.
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar_renamed(id int, name string) " +
+                s"stored as orc location '$colStarLoc'")
+
+            // A table with real physical column names, read by name.
+            hiveClient.runSqlHive(
+              s"create table test_orc_named(uid int, label string) " +
+                s"stored as orc location '$namedLoc'")
+            hiveClient.runSqlHive("insert into test_orc_named select 7, 'b'")
+
+            // No positional flag set. The _col* table read via real names must
+            // still return the values (positional fallback).
+            val colStar = sql("select id, name from test_orc_colstar_renamed")
+            checkAnswer(colStar, Seq(Row(7, "a")))
+            checkOperatorMatch[HiveTableScanExecTransformer](colStar)
+
+            // The real-name table still reads correctly by name in the same
+            // session (opposite mapping mode).
+            val named = sql("select uid, label from test_orc_named")
+            checkAnswer(named, Seq(Row(7, "b")))
+            checkOperatorMatch[HiveTableScanExecTransformer](named)
+
+            // Both in one query (the original failure folded the join to an
+            // empty LocalTableScan). The join must return a non-empty result.
+            val joined = sql(
+              "select c.name, n.label from test_orc_colstar_renamed c " +
+                "join test_orc_named n on c.id = n.uid")
+            checkAnswer(joined, Seq(Row("a", "b")))
+          }
+      }
+    }
+  }
+
   test("GLUTEN-11062: Supports mixed input format for partitioned Hive table") {
     val hiveClient: HiveClient =
       spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -79,6 +79,68 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
     }
   }
 
+  testGluten(
+    "GLUTEN: Hive ORC files with _col* names read by position without positional flag") {
+    // Regression for the case where two ORC tables must use OPPOSITE column
+    // mapping modes in the same query: one with real column names (by name) and
+    // one written by old Hive with placeholder _col* names (by position). The
+    // native reader must decide the mode per file (matching vanilla Spark's
+    // OrcUtils.requestedColumnIds), so a _col* file reads correctly even though
+    // orc.force.positional.evolution is NOT set (the default, orcUseColumnNames
+    // stays true). Without the fix the _col* columns would read back as NULL.
+    val hiveClient: HiveClient =
+      spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
+
+    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+      withTempDir {
+        dir =>
+          val colStarLoc = s"file:///$dir/test_orc_colstar"
+          val namedLoc = s"file:///$dir/test_orc_named"
+          withTable("test_orc_colstar", "test_orc_colstar_renamed", "test_orc_named") {
+            // Naming the columns literally _col0/_col1 guarantees the physical
+            // ORC field names are placeholders, independent of the Hive
+            // version (mirrors Spark's SPARK-34897 setup).
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar(_col0 int, _col1 string) " +
+                s"stored as orc location '$colStarLoc'")
+            hiveClient.runSqlHive("insert into test_orc_colstar select 7, 'a'")
+
+            // A second table over the SAME files but with real names. By name,
+            // id/name are absent from the _col* files; only position mapping
+            // can read them -- and it must happen WITHOUT the positional flag.
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar_renamed(id int, name string) " +
+                s"stored as orc location '$colStarLoc'")
+
+            // A table with real physical column names, read by name.
+            hiveClient.runSqlHive(
+              s"create table test_orc_named(uid int, label string) " +
+                s"stored as orc location '$namedLoc'")
+            hiveClient.runSqlHive("insert into test_orc_named select 7, 'b'")
+
+            // No positional flag set. The _col* table read via real names must
+            // still return the values (positional fallback).
+            val colStar = sql("select id, name from test_orc_colstar_renamed")
+            checkAnswer(colStar, Seq(Row(7, "a")))
+            checkOperatorMatch[HiveTableScanExecTransformer](colStar)
+
+            // The real-name table still reads correctly by name in the same
+            // session (opposite mapping mode).
+            val named = sql("select uid, label from test_orc_named")
+            checkAnswer(named, Seq(Row(7, "b")))
+            checkOperatorMatch[HiveTableScanExecTransformer](named)
+
+            // Both in one query (the original failure folded the join to an
+            // empty LocalTableScan). The join must return a non-empty result.
+            val joined = sql(
+              "select c.name, n.label from test_orc_colstar_renamed c " +
+                "join test_orc_named n on c.id = n.uid")
+            checkAnswer(joined, Seq(Row("a", "b")))
+          }
+      }
+    }
+  }
+
   test("GLUTEN-11062: Supports mixed input format for partitioned Hive table") {
     val hiveClient: HiveClient =
       spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -149,6 +149,68 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
     }
   }
 
+  testGluten(
+    "GLUTEN: Hive ORC files with _col* names read by position without positional flag") {
+    // Regression for the case where two ORC tables must use OPPOSITE column
+    // mapping modes in the same query: one with real column names (by name) and
+    // one written by old Hive with placeholder _col* names (by position). The
+    // native reader must decide the mode per file (matching vanilla Spark's
+    // OrcUtils.requestedColumnIds), so a _col* file reads correctly even though
+    // orc.force.positional.evolution is NOT set (the default, orcUseColumnNames
+    // stays true). Without the fix the _col* columns would read back as NULL.
+    val hiveClient: HiveClient =
+      spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
+
+    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+      withTempDir {
+        dir =>
+          val colStarLoc = s"file:///$dir/test_orc_colstar"
+          val namedLoc = s"file:///$dir/test_orc_named"
+          withTable("test_orc_colstar", "test_orc_colstar_renamed", "test_orc_named") {
+            // Naming the columns literally _col0/_col1 guarantees the physical
+            // ORC field names are placeholders, independent of the Hive
+            // version (mirrors Spark's SPARK-34897 setup).
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar(_col0 int, _col1 string) " +
+                s"stored as orc location '$colStarLoc'")
+            hiveClient.runSqlHive("insert into test_orc_colstar select 7, 'a'")
+
+            // A second table over the SAME files but with real names. By name,
+            // id/name are absent from the _col* files; only position mapping
+            // can read them -- and it must happen WITHOUT the positional flag.
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar_renamed(id int, name string) " +
+                s"stored as orc location '$colStarLoc'")
+
+            // A table with real physical column names, read by name.
+            hiveClient.runSqlHive(
+              s"create table test_orc_named(uid int, label string) " +
+                s"stored as orc location '$namedLoc'")
+            hiveClient.runSqlHive("insert into test_orc_named select 7, 'b'")
+
+            // No positional flag set. The _col* table read via real names must
+            // still return the values (positional fallback).
+            val colStar = sql("select id, name from test_orc_colstar_renamed")
+            checkAnswer(colStar, Seq(Row(7, "a")))
+            checkOperatorMatch[HiveTableScanExecTransformer](colStar)
+
+            // The real-name table still reads correctly by name in the same
+            // session (opposite mapping mode).
+            val named = sql("select uid, label from test_orc_named")
+            checkAnswer(named, Seq(Row(7, "b")))
+            checkOperatorMatch[HiveTableScanExecTransformer](named)
+
+            // Both in one query (the original failure folded the join to an
+            // empty LocalTableScan). The join must return a non-empty result.
+            val joined = sql(
+              "select c.name, n.label from test_orc_colstar_renamed c " +
+                "join test_orc_named n on c.id = n.uid")
+            checkAnswer(joined, Seq(Row("a", "b")))
+          }
+      }
+    }
+  }
+
   test("GLUTEN-11062: Supports mixed input format for partitioned Hive table") {
     val hiveClient: HiveClient =
       spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -149,6 +149,68 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
     }
   }
 
+  testGluten(
+    "GLUTEN: Hive ORC files with _col* names read by position without positional flag") {
+    // Regression for the case where two ORC tables must use OPPOSITE column
+    // mapping modes in the same query: one with real column names (by name) and
+    // one written by old Hive with placeholder _col* names (by position). The
+    // native reader must decide the mode per file (matching vanilla Spark's
+    // OrcUtils.requestedColumnIds), so a _col* file reads correctly even though
+    // orc.force.positional.evolution is NOT set (the default, orcUseColumnNames
+    // stays true). Without the fix the _col* columns would read back as NULL.
+    val hiveClient: HiveClient =
+      spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
+
+    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+      withTempDir {
+        dir =>
+          val colStarLoc = s"file:///$dir/test_orc_colstar"
+          val namedLoc = s"file:///$dir/test_orc_named"
+          withTable("test_orc_colstar", "test_orc_colstar_renamed", "test_orc_named") {
+            // Naming the columns literally _col0/_col1 guarantees the physical
+            // ORC field names are placeholders, independent of the Hive
+            // version (mirrors Spark's SPARK-34897 setup).
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar(_col0 int, _col1 string) " +
+                s"stored as orc location '$colStarLoc'")
+            hiveClient.runSqlHive("insert into test_orc_colstar select 7, 'a'")
+
+            // A second table over the SAME files but with real names. By name,
+            // id/name are absent from the _col* files; only position mapping
+            // can read them -- and it must happen WITHOUT the positional flag.
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar_renamed(id int, name string) " +
+                s"stored as orc location '$colStarLoc'")
+
+            // A table with real physical column names, read by name.
+            hiveClient.runSqlHive(
+              s"create table test_orc_named(uid int, label string) " +
+                s"stored as orc location '$namedLoc'")
+            hiveClient.runSqlHive("insert into test_orc_named select 7, 'b'")
+
+            // No positional flag set. The _col* table read via real names must
+            // still return the values (positional fallback).
+            val colStar = sql("select id, name from test_orc_colstar_renamed")
+            checkAnswer(colStar, Seq(Row(7, "a")))
+            checkOperatorMatch[HiveTableScanExecTransformer](colStar)
+
+            // The real-name table still reads correctly by name in the same
+            // session (opposite mapping mode).
+            val named = sql("select uid, label from test_orc_named")
+            checkAnswer(named, Seq(Row(7, "b")))
+            checkOperatorMatch[HiveTableScanExecTransformer](named)
+
+            // Both in one query (the original failure folded the join to an
+            // empty LocalTableScan). The join must return a non-empty result.
+            val joined = sql(
+              "select c.name, n.label from test_orc_colstar_renamed c " +
+                "join test_orc_named n on c.id = n.uid")
+            checkAnswer(joined, Seq(Row("a", "b")))
+          }
+      }
+    }
+  }
+
   test("GLUTEN-11062: Supports mixed input format for partitioned Hive table") {
     val hiveClient: HiveClient =
       spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/hive/execution/GlutenHiveSQLQuerySuite.scala
@@ -149,6 +149,68 @@ class GlutenHiveSQLQuerySuite extends GlutenHiveSQLQuerySuiteBase {
     }
   }
 
+  testGluten(
+    "GLUTEN: Hive ORC files with _col* names read by position without positional flag") {
+    // Regression for the case where two ORC tables must use OPPOSITE column
+    // mapping modes in the same query: one with real column names (by name) and
+    // one written by old Hive with placeholder _col* names (by position). The
+    // native reader must decide the mode per file (matching vanilla Spark's
+    // OrcUtils.requestedColumnIds), so a _col* file reads correctly even though
+    // orc.force.positional.evolution is NOT set (the default, orcUseColumnNames
+    // stays true). Without the fix the _col* columns would read back as NULL.
+    val hiveClient: HiveClient =
+      spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client
+
+    withSQLConf("spark.sql.hive.convertMetastoreOrc" -> "false") {
+      withTempDir {
+        dir =>
+          val colStarLoc = s"file:///$dir/test_orc_colstar"
+          val namedLoc = s"file:///$dir/test_orc_named"
+          withTable("test_orc_colstar", "test_orc_colstar_renamed", "test_orc_named") {
+            // Naming the columns literally _col0/_col1 guarantees the physical
+            // ORC field names are placeholders, independent of the Hive
+            // version (mirrors Spark's SPARK-34897 setup).
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar(_col0 int, _col1 string) " +
+                s"stored as orc location '$colStarLoc'")
+            hiveClient.runSqlHive("insert into test_orc_colstar select 7, 'a'")
+
+            // A second table over the SAME files but with real names. By name,
+            // id/name are absent from the _col* files; only position mapping
+            // can read them -- and it must happen WITHOUT the positional flag.
+            hiveClient.runSqlHive(
+              s"create table test_orc_colstar_renamed(id int, name string) " +
+                s"stored as orc location '$colStarLoc'")
+
+            // A table with real physical column names, read by name.
+            hiveClient.runSqlHive(
+              s"create table test_orc_named(uid int, label string) " +
+                s"stored as orc location '$namedLoc'")
+            hiveClient.runSqlHive("insert into test_orc_named select 7, 'b'")
+
+            // No positional flag set. The _col* table read via real names must
+            // still return the values (positional fallback).
+            val colStar = sql("select id, name from test_orc_colstar_renamed")
+            checkAnswer(colStar, Seq(Row(7, "a")))
+            checkOperatorMatch[HiveTableScanExecTransformer](colStar)
+
+            // The real-name table still reads correctly by name in the same
+            // session (opposite mapping mode).
+            val named = sql("select uid, label from test_orc_named")
+            checkAnswer(named, Seq(Row(7, "b")))
+            checkOperatorMatch[HiveTableScanExecTransformer](named)
+
+            // Both in one query (the original failure folded the join to an
+            // empty LocalTableScan). The join must return a non-empty result.
+            val joined = sql(
+              "select c.name, n.label from test_orc_colstar_renamed c " +
+                "join test_orc_named n on c.id = n.uid")
+            checkAnswer(joined, Seq(Row("a", "b")))
+          }
+      }
+    }
+  }
+
   test("GLUTEN-11062: Supports mixed input format for partitioned Hive table") {
     val hiveClient: HiveClient =
       spark.sharedState.externalCatalog.unwrapped.asInstanceOf[HiveExternalCatalog].client


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixies https://github.com/apache/gluten/issues/12436. This PR is related to https://github.com/facebookincubator/velox/pull/18021.

Gluten decides the ORC column-mapping mode from a single global config:
`spark.hadoop.orc.force.positional.evolution` flips `orcUseColumnNames`, which selects
name-based vs position-based mapping for the whole query. This breaks any query that reads a
**mix** of ORC tables where some files carry real physical column names and some carry Hive
placeholder names (`_col0`, `_col1`, …):

- With `orcUseColumnNames=true` (default): the `_col*` files have no real names to match, so every
  column reads back **null** → a filtered join side becomes empty and AQE folds the plan to
  `LocalTableScan rows=0` (silently wrong result).
- With `orcUseColumnNames=false` (positional): the real-name files are mapped by ordinal and land on
  the wrong column, failing with `SCHEMA_MISMATCH` (`From Kind: INTEGER, To Kind: VARCHAR`) or, when
  a string filter is pushed down, `Filter(BytesValues, ...): testInt64Range() is not supported`.

No single global value can read both tables correctly in one query.

Vanilla Spark makes this decision **per file** in `OrcUtils.requestedColumnIds`:

```scala
if (forcePositionalEvolution || orcFieldNames.forall(_.startsWith("_col"))) {
  // map physical schema -> data schema by INDEX
} else {
  // map by NAME
}
```

Gluten already honors the `forcePositionalEvolution` half (#12234). The missing half is
`orcFieldNames.forall(_.startsWith("_col"))`: even in name mode, an ORC file whose physical schema
is entirely `_col*` must be mapped by position, because those placeholder names carry no identity —
the real names live only in the table schema. That per-file decision can only be made in the native
reader, which is the only layer that sees each file's physical field names.

This PR contains the Gluten-side change; the native-reader change is submitted separately to Velox
(`facebookincubator/velox`, see: https://github.com/facebookincubator/velox/pull/18021), which adds the `_col*` detection to `DwrfReader` and falls back to positional mapping in name mode.

**Gluten change** — `VeloxIteratorApi.setFileSchemaForLocalFiles`:
Always attach the table (data) schema to the split for ORC/DWRF, instead of only when
`orcUseColumnNames=false`. The native reader needs the table schema in name mode too, so it can
remap the `_col*` file columns to the real names by position. Parquet behavior is unchanged (still
only attached when mapping by position). This is additive: the existing positional path and the
explicit `orc.force.positional.evolution=true` behavior are unaffected.

## How was this patch tested?

Added a regression test to `GlutenHiveSQLQuerySuite` for all supported Spark shims
(spark33/34/35/40/41). The test:

- Creates a Hive ORC table with columns literally named `_col0`/`_col1` so the physical ORC field
  names are guaranteed to be placeholders (independent of the embedded Hive version; mirrors Spark's
  SPARK-34897 setup), plus a second metastore table with real names over the same files, and a
  separate real-name ORC table.
- **Without** setting `spark.hadoop.orc.force.positional.evolution` (default `orcUseColumnNames=true`),
  asserts that the `_col*` table reads correct values via the real column names, that the real-name
  table still reads correctly by name in the same session, and that a join of the two returns a
  non-empty result (the original failure folded it to an empty `LocalTableScan`).
- Confirms the scans stay native via `checkOperatorMatch[HiveTableScanExecTransformer]`.

Note: the test passes end-to-end only together with the corresponding Velox change; the Gluten-side
change alone attaches the schema but relies on the native reader to perform the `_col*` positional
fallback.

## Was this patch authored or co-authored using generative AI tooling?

co-authored with Claude Code (Claude Opus 4.8)
