### PR TITLE
[VL] Test-only draft: GlutenDeltaVariantWriteSuite fails without the fix (validates #12444)

### DIFF
--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/GlutenDeltaVariantWriteSuite.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/GlutenDeltaVariantWriteSuite.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Velox has no Arrow representation for VariantType, so a Delta write that Gluten offloads to the
+ * native columnar writer (DataFrameWriter.save, UPDATE, ...) used to throw
+ * `UnsupportedOperationException: Unsupported data type: variant` at runtime.
+ * GlutenOptimisticTransaction now detects a variant column and delegates such writes to the vanilla
+ * Delta write path. These tests use offloaded writes (save and UPDATE) so they exercise that path;
+ * with INSERT INTO the write is not offloaded and would pass regardless of the fix.
+ */
+class GlutenDeltaVariantWriteSuite
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  test("write and read a top-level variant column") {
+    withTempDir {
+      dir =>
+        val path = dir.getCanonicalPath
+        spark
+          .range(3)
+          .selectExpr("'foo' AS s", "parse_json(cast(id + 99 AS string)) AS v")
+          .write
+          .format("delta")
+          .mode("overwrite")
+          .save(path)
+        checkAnswer(
+          spark.read.format("delta").load(path).selectExpr("s", "to_json(v)"),
+          Seq(Row("foo", "99"), Row("foo", "100"), Row("foo", "101")))
+    }
+  }
+
+  test("write and read a variant nested in a struct") {
+    withTempDir {
+      dir =>
+        val path = dir.getCanonicalPath
+        spark
+          .range(2)
+          .selectExpr(
+            "'foo' AS s",
+            "named_struct('inner', parse_json(cast(id + 99 AS string))) AS v")
+          .write
+          .format("delta")
+          .mode("overwrite")
+          .save(path)
+        checkAnswer(
+          spark.read.format("delta").load(path).selectExpr("s", "to_json(v.inner)"),
+          Seq(Row("foo", "99"), Row("foo", "100")))
+    }
+  }
+
+  test("update a table with a variant column") {
+    withTempDir {
+      dir =>
+        val path = dir.getCanonicalPath
+        spark
+          .range(3)
+          .selectExpr("cast(id AS int) AS id", "parse_json(cast(id AS string)) AS v")
+          .write
+          .format("delta")
+          .mode("overwrite")
+          .save(path)
+        sql(s"UPDATE delta.`$path` SET v = parse_json('123') WHERE id = 1")
+        checkAnswer(
+          spark.read.format("delta").load(path).selectExpr("id", "to_json(v)"),
+          Seq(Row(0, "0"), Row(1, "123"), Row(2, "2")))
+    }
+  }
+}


### PR DESCRIPTION
> [!WARNING]
> **Draft — do not merge.** This PR intentionally contains **only the test, without the fix**, to
> validate that the test fails on an unpatched `main`. The actual fix lives in
> apache/gluten#12444.

## What changes are proposed in this pull request?

This PR adds **only** `GlutenDeltaVariantWriteSuite` (backends-velox, delta-4.0) — the regression
test from #12444 — **without** the accompanying `GlutenOptimisticTransaction` guard. Its sole
purpose is to prove the test is an effective regression test: on an unpatched `main`, with the
native Delta write path enabled, writing a variant column throws
`UnsupportedOperationException: Unsupported data type: variant`, so the suite is expected to **fail**
on this branch.

The `spark-test-spark40` job in `velox_backend_x86.yml` runs
`-Pspark-4.0 -Pscala-2.13 -Pbackends-velox -Pdelta -Pspark-ut` (no suite tags exclude it), so it
includes this suite. That job is expected to fail here and to pass once #12444's fix is applied.

## How was this patch tested?

Not applicable — this branch is expected to fail CI by design. See #12444 for the fix together with
the passing tests.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI (Claude Opus 4.8)
