### PR TITLE
[GLUTEN-12447] Add Arrow large var types support

### DIFF
--- a/backends-velox/src-iceberg/main/scala/org/apache/gluten/connector/write/IcebergDataWriteFactory.scala
+++ b/backends-velox/src-iceberg/main/scala/org/apache/gluten/connector/write/IcebergDataWriteFactory.scala
@@ -24,9 +24,8 @@ import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.utils.ArrowAbiUtil
 
 import org.apache.spark.sql.connector.write.DataWriter
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.utils.SparkArrowUtil
+import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.arrow.c.ArrowSchema
@@ -101,7 +100,7 @@ case class IcebergDataWriteFactory(
       partitionSpec: IcebergPartitionSpec,
       field: IcebergNestedField,
       icebergProperties: util.HashMap[String, String]): (Long, IcebergWriteJniWrapper) = {
-    val schema = SparkArrowUtil.toArrowSchema(localSchema, SQLConf.get.sessionLocalTimeZone)
+    val schema = SparkSchemaUtil.toArrowSchema(localSchema)
     val arrowAlloc = ArrowBufferAllocators.contextInstance()
     val cSchema = ArrowSchema.allocateNew(arrowAlloc)
     ArrowAbiUtil.exportSchema(arrowAlloc, schema, cSchema)

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/RowToVeloxColumnarExec.scala
@@ -31,9 +31,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.{BroadcastUtils, SparkPlan}
 import org.apache.spark.sql.execution.metric.SQLMetric
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.utils.SparkArrowUtil
+import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.task.TaskResources
 import org.apache.spark.unsafe.Platform
@@ -128,8 +127,7 @@ object RowToVeloxColumnarExec {
       return Iterator.empty
     }
 
-    val arrowSchema =
-      SparkArrowUtil.toArrowSchema(schema, SQLConf.get.sessionLocalTimeZone)
+    val arrowSchema = SparkSchemaUtil.toArrowSchema(schema)
     val runtime = Runtimes.contextInstance(BackendsApiManager.getBackendName, "RowToColumnar")
     val jniWrapper = NativeRowToColumnarJniWrapper.create(runtime)
     val arrowAllocator = ArrowBufferAllocators.contextInstance()

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -262,9 +262,8 @@ case class ColumnarBuildSideRelation(
         val serializeHandle: Long = {
           val allocator = ArrowBufferAllocators.globalInstance()
           val cSchema = ArrowSchema.allocateNew(allocator)
-          val arrowSchema = SparkArrowUtil.toArrowSchema(
-            SparkShimLoader.getSparkShims.structFromAttributes(output),
-            SQLConf.get.sessionLocalTimeZone)
+          val arrowSchema = SparkSchemaUtil.toArrowSchema(
+            SparkShimLoader.getSparkShims.structFromAttributes(output))
           ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
           val handle = jniWrapper
             .init(cSchema.memoryAddress())

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarBuildSideRelation.scala
@@ -32,8 +32,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSeq, BindReferences, BoundReference, Expression, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.joins.{BuildSideRelation, HashedRelationBroadcastMode}
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.utils.SparkArrowUtil
+import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.task.TaskResources
 import org.apache.spark.util.KnownSizeEstimation
@@ -117,9 +116,8 @@ case class ColumnarBuildSideRelation(
     val serializeHandle: Long = {
       val allocator = ArrowBufferAllocators.contextInstance()
       val cSchema = ArrowSchema.allocateNew(allocator)
-      val arrowSchema = SparkArrowUtil.toArrowSchema(
-        SparkShimLoader.getSparkShims.structFromAttributes(output),
-        SQLConf.get.sessionLocalTimeZone)
+      val arrowSchema = SparkSchemaUtil.toArrowSchema(
+        SparkShimLoader.getSparkShims.structFromAttributes(output))
       ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
       val handle = jniWrapper
         .init(cSchema.memoryAddress())
@@ -170,9 +168,8 @@ case class ColumnarBuildSideRelation(
         val serializeHandle: Long = {
           val allocator = ArrowBufferAllocators.contextInstance()
           val cSchema = ArrowSchema.allocateNew(allocator)
-          val arrowSchema = SparkArrowUtil.toArrowSchema(
-            SparkShimLoader.getSparkShims.structFromAttributes(output),
-            SQLConf.get.sessionLocalTimeZone)
+          val arrowSchema = SparkSchemaUtil.toArrowSchema(
+            SparkShimLoader.getSparkShims.structFromAttributes(output))
           ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
           val handle = jniWrapper
             .init(cSchema.memoryAddress())
@@ -362,9 +359,8 @@ case class ColumnarBuildSideRelation(
     val serializeHandle = {
       val allocator = ArrowBufferAllocators.contextInstance()
       val cSchema = ArrowSchema.allocateNew(allocator)
-      val arrowSchema = SparkArrowUtil.toArrowSchema(
-        SparkShimLoader.getSparkShims.structFromAttributes(output),
-        SQLConf.get.sessionLocalTimeZone)
+      val arrowSchema = SparkSchemaUtil.toArrowSchema(
+        SparkShimLoader.getSparkShims.structFromAttributes(output))
       ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
       val handle = serializerJniWrapper.init(cSchema.memoryAddress())
       cSchema.close()

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/ColumnarCachedBatchSerializer.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.columnar.SimpleMetricsCachedBatchSerializer
 import org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.utils.SparkArrowUtil
+import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.UTF8String
@@ -953,7 +953,6 @@ class ColumnarCachedBatchSerializer extends SimpleMetricsCachedBatchSerializer
       }
       val shouldSelectAttributes = cacheAttributes != selectedAttributes
       val localSchema = toStructType(cacheAttributes)
-      val timezoneId = SQLConf.get.sessionLocalTimeZone
       input.mapPartitions {
         it =>
           val runtime = Runtimes.contextInstance(
@@ -961,7 +960,7 @@ class ColumnarCachedBatchSerializer extends SimpleMetricsCachedBatchSerializer
             "ColumnarCachedBatchSerializer#read")
           val jniWrapper = ColumnarBatchSerializerJniWrapper
             .create(runtime)
-          val schema = SparkArrowUtil.toArrowSchema(localSchema, timezoneId)
+          val schema = SparkSchemaUtil.toArrowSchema(localSchema)
           val arrowAlloc = ArrowBufferAllocators.contextInstance()
           val cSchema = ArrowSchema.allocateNew(arrowAlloc)
           ArrowAbiUtil.exportSchema(arrowAlloc, schema, cSchema)

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxFormatWriterInjects.scala
@@ -29,9 +29,8 @@ import org.apache.gluten.utils.ArrowAbiUtil
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.utils.SparkArrowUtil
+import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.arrow.c.ArrowSchema
@@ -56,8 +55,7 @@ trait VeloxFormatWriterInjects extends GlutenFormatWriterInjectsBase {
       }
     }
 
-    val arrowSchema =
-      SparkArrowUtil.toArrowSchema(dataSchema, SQLConf.get.sessionLocalTimeZone)
+    val arrowSchema = SparkSchemaUtil.toArrowSchema(dataSchema)
     val cSchema = ArrowSchema.allocateNew(ArrowBufferAllocators.contextInstance())
     var dsHandle = -1L
     val runtime = Runtimes.contextInstance(BackendsApiManager.getBackendName, "VeloxWriter")

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
@@ -34,8 +34,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSeq, BindR
 import org.apache.spark.sql.catalyst.plans.physical.BroadcastMode
 import org.apache.spark.sql.execution.{BroadcastModeUtils, HashExprSafeBroadcastMode, HashSafeBroadcastMode, IdentitySafeBroadcastMode, SafeBroadcastMode}
 import org.apache.spark.sql.execution.joins.{BuildSideRelation, HashedRelationBroadcastMode}
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.utils.SparkArrowUtil
+import org.apache.spark.sql.utils.SparkSchemaUtil
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.task.TaskResources
 import org.apache.spark.util.{KnownSizeEstimation, Utils}
@@ -141,9 +140,8 @@ class UnsafeColumnarBuildSideRelation(
         val serializeHandle: Long = {
           val allocator = ArrowBufferAllocators.contextInstance()
           val cSchema = ArrowSchema.allocateNew(allocator)
-          val arrowSchema = SparkArrowUtil.toArrowSchema(
-            SparkShimLoader.getSparkShims.structFromAttributes(output),
-            SQLConf.get.sessionLocalTimeZone)
+          val arrowSchema = SparkSchemaUtil.toArrowSchema(
+            SparkShimLoader.getSparkShims.structFromAttributes(output))
           ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
           val handle = jniWrapper
             .init(cSchema.memoryAddress())
@@ -381,9 +379,8 @@ class UnsafeColumnarBuildSideRelation(
     val serializerHandle: Long = {
       val allocator = ArrowBufferAllocators.contextInstance()
       val cSchema = ArrowSchema.allocateNew(allocator)
-      val arrowSchema = SparkArrowUtil.toArrowSchema(
-        SparkShimLoader.getSparkShims.structFromAttributes(output),
-        SQLConf.get.sessionLocalTimeZone)
+      val arrowSchema = SparkSchemaUtil.toArrowSchema(
+        SparkShimLoader.getSparkShims.structFromAttributes(output))
       ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
       val handle = jniWrapper
         .init(cSchema.memoryAddress())
@@ -430,9 +427,8 @@ class UnsafeColumnarBuildSideRelation(
     val serializerHandle = {
       val allocator = ArrowBufferAllocators.contextInstance()
       val cSchema = ArrowSchema.allocateNew(allocator)
-      val arrowSchema = SparkArrowUtil.toArrowSchema(
-        SparkShimLoader.getSparkShims.structFromAttributes(output),
-        SQLConf.get.sessionLocalTimeZone)
+      val arrowSchema = SparkSchemaUtil.toArrowSchema(
+        SparkShimLoader.getSparkShims.structFromAttributes(output))
       ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
       val handle = serializerJniWrapper.init(cSchema.memoryAddress())
       cSchema.close()

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/unsafe/UnsafeColumnarBuildSideRelation.scala
@@ -235,9 +235,8 @@ class UnsafeColumnarBuildSideRelation(
         val serializeHandle: Long = {
           val allocator = ArrowBufferAllocators.globalInstance()
           val cSchema = ArrowSchema.allocateNew(allocator)
-          val arrowSchema = SparkArrowUtil.toArrowSchema(
-            SparkShimLoader.getSparkShims.structFromAttributes(output),
-            SQLConf.get.sessionLocalTimeZone)
+          val arrowSchema = SparkSchemaUtil.toArrowSchema(
+            SparkShimLoader.getSparkShims.structFromAttributes(output))
           ArrowAbiUtil.exportSchema(allocator, arrowSchema, cSchema)
           val handle = jniWrapper
             .init(cSchema.memoryAddress())

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -158,8 +158,13 @@ class UDFPartialProjectSuite extends WholeStageTransformerSuite {
   }
 
   test("test concat with string") {
-    runQueryAndCompare("SELECT concat_concat(l_comment), hash(l_partkey) from lineitem") {
-      checkGlutenPlan[ColumnarPartialProjectExec]
+    Seq("false", "true").foreach {
+      useLargeVarTypes =>
+        withSQLConf("spark.sql.execution.arrow.useLargeVarTypes" -> useLargeVarTypes) {
+          runQueryAndCompare("SELECT concat_concat(l_comment), hash(l_partkey) from lineitem") {
+            checkGlutenPlan[ColumnarPartialProjectExec]
+          }
+        }
     }
   }
 

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowColumnVector.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowColumnVector.java
@@ -20,6 +20,7 @@ import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.holders.NullableLargeVarCharHolder;
 import org.apache.arrow.vector.holders.NullableVarCharHolder;
 import org.apache.spark.annotation.DeveloperApi;
 import org.apache.spark.sql.types.DataType;
@@ -166,8 +167,12 @@ public class ArrowColumnVector extends ColumnVector {
       accessor = new DecimalAccessor((DecimalVector) vector);
     } else if (vector instanceof VarCharVector) {
       accessor = new StringAccessor((VarCharVector) vector);
+    } else if (vector instanceof LargeVarCharVector) {
+      accessor = new LargeStringAccessor((LargeVarCharVector) vector);
     } else if (vector instanceof VarBinaryVector) {
       accessor = new BinaryAccessor((VarBinaryVector) vector);
+    } else if (vector instanceof LargeVarBinaryVector) {
+      accessor = new LargeBinaryAccessor((LargeVarBinaryVector) vector);
     } else if (vector instanceof DateDayVector) {
       accessor = new DateAccessor((DateDayVector) vector);
     } else if (vector instanceof TimeStampMicroTZVector) {
@@ -414,11 +419,51 @@ public class ArrowColumnVector extends ColumnVector {
     }
   }
 
+  static class LargeStringAccessor extends ArrowVectorAccessor {
+
+    private final LargeVarCharVector accessor;
+    private final NullableLargeVarCharHolder stringResult = new NullableLargeVarCharHolder();
+
+    LargeStringAccessor(LargeVarCharVector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final UTF8String getUTF8String(int rowId) {
+      accessor.get(rowId, stringResult);
+      if (stringResult.isSet == 0) {
+        return null;
+      } else {
+        return UTF8String.fromAddress(
+            null,
+            stringResult.buffer.memoryAddress() + stringResult.start,
+            // A single string cannot be larger than the max integer size, so the conversion is safe
+            (int) (stringResult.end - stringResult.start));
+      }
+    }
+  }
+
   static class BinaryAccessor extends ArrowVectorAccessor {
 
     private final VarBinaryVector accessor;
 
     BinaryAccessor(VarBinaryVector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final byte[] getBinary(int rowId) {
+      return accessor.getObject(rowId);
+    }
+  }
+
+  static class LargeBinaryAccessor extends ArrowVectorAccessor {
+
+    private final LargeVarBinaryVector accessor;
+
+    LargeBinaryAccessor(LargeVarBinaryVector vector) {
       super(vector);
       this.accessor = vector;
     }

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
@@ -207,11 +207,7 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     super(capacity, dataType);
     vectorCount.getAndIncrement();
     refCnt.getAndIncrement();
-    String timeZoneId = SparkSchemaUtil.getLocalTimezoneID();
-    boolean useLargeVarTypes = SparkSchemaUtil.enableLargeVarTypes();
-    List<Field> fields =
-        Arrays.asList(
-            SparkArrowUtil.toArrowField("col", dataType, true, timeZoneId, useLargeVarTypes));
+    List<Field> fields = Arrays.asList(SparkSchemaUtil.toArrowField("col", dataType, true));
     Schema arrowSchema = new Schema(fields);
     VectorSchemaRoot root =
         VectorSchemaRoot.create(arrowSchema, ArrowBufferAllocators.contextInstance());

--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
@@ -23,6 +23,8 @@ import org.apache.arrow.vector.*;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.holders.NullableLargeVarBinaryHolder;
+import org.apache.arrow.vector.holders.NullableLargeVarCharHolder;
 import org.apache.arrow.vector.holders.NullableVarBinaryHolder;
 import org.apache.arrow.vector.holders.NullableVarCharHolder;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
@@ -78,8 +80,7 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
    * elements, not number of bytes.
    */
   public static ArrowWritableColumnVector[] allocateColumns(int capacity, StructType schema) {
-    String timeZoneId = SparkSchemaUtil.getLocalTimezoneID();
-    Schema arrowSchema = SparkArrowUtil.toArrowSchema(schema, timeZoneId);
+    Schema arrowSchema = SparkSchemaUtil.toArrowSchema(schema);
     VectorSchemaRoot newRoot =
         VectorSchemaRoot.create(arrowSchema, ArrowBufferAllocators.contextInstance());
 
@@ -94,8 +95,7 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
 
   public static ArrowWritableColumnVector[] allocateColumns(
       int valueCount, long[] totalSizes, StructType schema) {
-    String timeZoneId = SparkSchemaUtil.getLocalTimezoneID();
-    Schema arrowSchema = SparkArrowUtil.toArrowSchema(schema, timeZoneId);
+    Schema arrowSchema = SparkSchemaUtil.toArrowSchema(schema);
     VectorSchemaRoot newRoot =
         VectorSchemaRoot.create(arrowSchema, ArrowBufferAllocators.contextInstance());
 
@@ -208,8 +208,10 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     vectorCount.getAndIncrement();
     refCnt.getAndIncrement();
     String timeZoneId = SparkSchemaUtil.getLocalTimezoneID();
+    boolean useLargeVarTypes = SparkSchemaUtil.enableLargeVarTypes();
     List<Field> fields =
-        Arrays.asList(SparkArrowUtil.toArrowField("col", dataType, true, timeZoneId));
+        Arrays.asList(
+            SparkArrowUtil.toArrowField("col", dataType, true, timeZoneId, useLargeVarTypes));
     Schema arrowSchema = new Schema(fields);
     VectorSchemaRoot root =
         VectorSchemaRoot.create(arrowSchema, ArrowBufferAllocators.contextInstance());
@@ -265,8 +267,12 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
       accessor = new DecimalAccessor((DecimalVector) vector);
     } else if (vector instanceof VarCharVector) {
       accessor = new StringAccessor((VarCharVector) vector);
+    } else if (vector instanceof LargeVarCharVector) {
+      accessor = new LargeStringAccessor((LargeVarCharVector) vector);
     } else if (vector instanceof VarBinaryVector) {
       accessor = new BinaryAccessor((VarBinaryVector) vector);
+    } else if (vector instanceof LargeVarBinaryVector) {
+      accessor = new LargeBinaryAccessor((LargeVarBinaryVector) vector);
     } else if (vector instanceof DateDayVector) {
       accessor = new DateAccessor((DateDayVector) vector);
     } else if (vector instanceof TimeStampMicroVector || vector instanceof TimeStampMicroTZVector) {
@@ -336,8 +342,12 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
       return new DecimalWriter((DecimalVector) vector);
     } else if (vector instanceof VarCharVector) {
       return new StringWriter((VarCharVector) vector);
+    } else if (vector instanceof LargeVarCharVector) {
+      return new LargeStringWriter((LargeVarCharVector) vector);
     } else if (vector instanceof VarBinaryVector) {
       return new BinaryWriter((VarBinaryVector) vector);
+    } else if (vector instanceof LargeVarBinaryVector) {
+      return new LargeBinaryWriter((LargeVarBinaryVector) vector);
     } else if (vector instanceof DateDayVector) {
       return new DateWriter((DateDayVector) vector);
     } else if (vector instanceof TimeStampMicroVector || vector instanceof TimeStampMicroTZVector) {
@@ -1078,6 +1088,30 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     }
   }
 
+  private static class LargeStringAccessor extends ArrowVectorAccessor {
+    private final LargeVarCharVector accessor;
+    private final NullableLargeVarCharHolder stringResult = new NullableLargeVarCharHolder();
+
+    LargeStringAccessor(LargeVarCharVector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final UTF8String getUTF8String(int rowId) {
+      accessor.get(rowId, stringResult);
+      if (stringResult.isSet == 0) {
+        return null;
+      } else {
+        return UTF8String.fromAddress(
+            null,
+            stringResult.buffer.memoryAddress() + stringResult.start,
+            // A single string cannot be larger than the max integer size, so the conversion is safe
+            (int) (stringResult.end - stringResult.start));
+      }
+    }
+  }
+
   private static class DictionaryEncodedStringAccessor extends ArrowVectorAccessor {
     private final IntVector index;
     private final VarCharVector dictionary;
@@ -1128,6 +1162,35 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
             null,
             stringResult.buffer.memoryAddress() + stringResult.start,
             stringResult.end - stringResult.start);
+      }
+    }
+  }
+
+  private static class LargeBinaryAccessor extends ArrowVectorAccessor {
+    private final LargeVarBinaryVector accessor;
+    private final NullableLargeVarBinaryHolder stringResult = new NullableLargeVarBinaryHolder();
+
+    LargeBinaryAccessor(LargeVarBinaryVector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final byte[] getBinary(int rowId) {
+      return accessor.getObject(rowId);
+    }
+
+    @Override
+    final UTF8String getUTF8String(int rowId) {
+      accessor.get(rowId, stringResult);
+      if (stringResult.isSet == 0) {
+        return null;
+      } else {
+        return UTF8String.fromAddress(
+            null,
+            stringResult.buffer.memoryAddress() + stringResult.start,
+            // A single string cannot be larger than the max integer size, so the conversion is safe
+            (int) (stringResult.end - stringResult.start));
       }
     }
   }
@@ -1977,10 +2040,94 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     }
   }
 
+  private static class LargeStringWriter extends ArrowVectorWriter {
+    private final LargeVarCharVector writer;
+    private int rowId;
+
+    LargeStringWriter(LargeVarCharVector vector) {
+      super(vector);
+      this.writer = vector;
+      this.rowId = 0;
+    }
+
+    @Override
+    final void setNull(int rowId) {
+      writer.setNull(rowId);
+    }
+
+    @Override
+    final void setNulls(int rowId, int count) {
+      for (int i = 0; i < count; i++) {
+        writer.setNull(rowId + i);
+      }
+    }
+
+    @Override
+    final void setBytes(int rowId, int count, byte[] src, int srcIndex) {
+      writer.setSafe(rowId, src, srcIndex, count);
+    }
+
+    @Override
+    final void appendBytes(byte[] value, int offset, int length) {
+      writer.setSafe(rowId, value, offset, length);
+      rowId++;
+    }
+
+    @Override
+    void setValueNullSafe(SpecializedGetters input, int ordinal) {
+      UTF8String value = input.getUTF8String(ordinal);
+      setBytes(count, value.numBytes(), value.getBytes(), 0);
+    }
+
+    @Override
+    void unsafeSetValueNullSafe(SpecializedGetters input, int ordinal) {
+      UTF8String value = input.getUTF8String(ordinal);
+      writer.set(count, value.getBytes(), 0, value.numBytes());
+    }
+  }
+
   private static class BinaryWriter extends ArrowVectorWriter {
     private final VarBinaryVector writer;
 
     BinaryWriter(VarBinaryVector vector) {
+      super(vector);
+      this.writer = vector;
+    }
+
+    @Override
+    final void setNull(int rowId) {
+      writer.setNull(rowId);
+    }
+
+    @Override
+    final void setNulls(int rowId, int count) {
+      for (int i = 0; i < count; i++) {
+        writer.setNull(rowId + i);
+      }
+    }
+
+    @Override
+    final void setBytes(int rowId, int count, byte[] src, int srcIndex) {
+      writer.setSafe(rowId, src, srcIndex, count);
+    }
+
+    @Override
+    void setValueNullSafe(SpecializedGetters input, int ordinal) {
+      byte[] value = input.getBinary(ordinal);
+      setBytes(count, value.length, value, 0);
+    }
+
+    @Override
+    void unsafeSetValueNullSafe(SpecializedGetters input, int ordinal) {
+      byte[] value = input.getBinary(ordinal);
+      writer.set(count, value, 0, value.length);
+    }
+  }
+
+  private static class LargeBinaryWriter extends ArrowVectorWriter {
+    private final LargeVarBinaryVector writer;
+
+    LargeBinaryWriter(LargeVarBinaryVector vector) {
       super(vector);
       this.writer = vector;
     }

--- a/gluten-arrow/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/gluten/utils/ArrowUtil.scala
@@ -18,42 +18,16 @@ package org.apache.gluten.utils
 
 import org.apache.gluten.vectorized.ArrowWritableColumnVector
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.utils.{SparkArrowUtil, SparkSchemaUtil}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 
 import org.apache.arrow.c.{ArrowSchema, CDataDictionaryProvider, Data}
 import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector.types.pojo.{ArrowType, Field, Schema}
+import org.apache.arrow.vector.types.pojo.{Field, Schema}
 
 import java.util
 
-import scala.collection.JavaConverters._
-
 object ArrowUtil {
-
-  private val defaultTimeZoneId = SparkSchemaUtil.getLocalTimezoneID
-
-  private def getResultType(dataType: DataType): ArrowType = {
-    getResultType(dataType, defaultTimeZoneId)
-  }
-
-  private def getResultType(dataType: DataType, timeZoneId: String): ArrowType = {
-    dataType match {
-      case other =>
-        SparkArrowUtil.toArrowType(dataType, timeZoneId)
-    }
-  }
-
-  def toArrowSchema(attributes: Seq[Attribute]): Schema = {
-    val fields = attributes.map(
-      attr => {
-        Field
-          .nullable(s"${attr.name}#${attr.exprId.id}", getResultType(attr.dataType))
-      })
-    new Schema(fields.toList.asJava)
-  }
 
   def toArrowSchema(
       cSchema: ArrowSchema,
@@ -65,8 +39,7 @@ object ArrowUtil {
     originFields.forEach {
       field =>
         val dt = SparkArrowUtil.fromArrowField(field)
-        fields.add(
-          SparkArrowUtil.toArrowField(field.getName, dt, true, SparkSchemaUtil.getLocalTimezoneID))
+        fields.add(SparkSchemaUtil.toArrowField(field.getName, dt, true))
     }
     new Schema(fields)
   }

--- a/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkArrowUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkArrowUtil.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
 object SparkArrowUtil {
 
   /** Maps data type from Spark to Arrow. NOTE: timeZoneId required for TimestampTypes */
-  def toArrowType(
+  private[utils] def toArrowType(
       dt: DataType,
       timeZoneId: String,
       largeVarTypes: Boolean = false): ArrowType = dt match {
@@ -100,7 +100,7 @@ object SparkArrowUtil {
   }
 
   /** Maps field from Spark to Arrow. NOTE: timeZoneId required for TimestampType */
-  def toArrowField(
+  private[utils] def toArrowField(
       name: String,
       dt: DataType,
       nullable: Boolean,
@@ -179,7 +179,7 @@ object SparkArrowUtil {
   }
 
   /** Maps schema from Spark to Arrow. NOTE: timeZoneId required for TimestampType in StructType */
-  def toArrowSchema(
+  private[utils] def toArrowSchema(
       schema: StructType,
       timeZoneId: String,
       largeVarTypes: Boolean = false): Schema = {

--- a/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkArrowUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkArrowUtil.scala
@@ -31,7 +31,10 @@ import scala.collection.JavaConverters._
 object SparkArrowUtil {
 
   /** Maps data type from Spark to Arrow. NOTE: timeZoneId required for TimestampTypes */
-  def toArrowType(dt: DataType, timeZoneId: String): ArrowType = dt match {
+  def toArrowType(
+      dt: DataType,
+      timeZoneId: String,
+      largeVarTypes: Boolean = false): ArrowType = dt match {
     case BooleanType => ArrowType.Bool.INSTANCE
     case ByteType => new ArrowType.Int(8, true)
     case ShortType => new ArrowType.Int(8 * 2, true)
@@ -39,8 +42,10 @@ object SparkArrowUtil {
     case LongType => new ArrowType.Int(8 * 8, true)
     case FloatType => new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
     case DoubleType => new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)
-    case StringType => ArrowType.Utf8.INSTANCE
-    case BinaryType => ArrowType.Binary.INSTANCE
+    case StringType if !largeVarTypes => ArrowType.Utf8.INSTANCE
+    case BinaryType if !largeVarTypes => ArrowType.Binary.INSTANCE
+    case StringType if largeVarTypes => ArrowType.LargeUtf8.INSTANCE
+    case BinaryType if largeVarTypes => ArrowType.LargeBinary.INSTANCE
     case DecimalType.Fixed(precision, scale) => new ArrowType.Decimal(precision, scale, 128)
     case DateType => new ArrowType.Date(DateUnit.DAY)
     case TimestampType =>
@@ -72,6 +77,8 @@ object SparkArrowUtil {
       DoubleType
     case ArrowType.Utf8.INSTANCE => StringType
     case ArrowType.Binary.INSTANCE => BinaryType
+    case ArrowType.LargeUtf8.INSTANCE => StringType
+    case ArrowType.LargeBinary.INSTANCE => BinaryType
     case d: ArrowType.Decimal => DecimalType(d.getPrecision, d.getScale)
     case date: ArrowType.Date if date.getUnit == DateUnit.DAY => DateType
     case ts: ArrowType.Timestamp if ts.getUnit == TimeUnit.MICROSECOND && ts.getTimezone == null =>
@@ -93,14 +100,19 @@ object SparkArrowUtil {
   }
 
   /** Maps field from Spark to Arrow. NOTE: timeZoneId required for TimestampType */
-  def toArrowField(name: String, dt: DataType, nullable: Boolean, timeZoneId: String): Field = {
+  def toArrowField(
+      name: String,
+      dt: DataType,
+      nullable: Boolean,
+      timeZoneId: String,
+      largeVarTypes: Boolean = false): Field = {
     dt match {
       case ArrayType(elementType, containsNull) =>
         val fieldType = new FieldType(nullable, ArrowType.List.INSTANCE, null)
         new Field(
           name,
           fieldType,
-          Seq(toArrowField("element", elementType, containsNull, timeZoneId)).asJava)
+          Seq(toArrowField("element", elementType, containsNull, timeZoneId, largeVarTypes)).asJava)
       case StructType(fields) =>
         val fieldType = new FieldType(nullable, ArrowType.Struct.INSTANCE, null)
         new Field(
@@ -113,7 +125,8 @@ object SparkArrowUtil {
                   normalizeColName(field.name),
                   field.dataType,
                   field.nullable,
-                  timeZoneId))
+                  timeZoneId,
+                  largeVarTypes))
             .toSeq
             .asJava
         )
@@ -130,11 +143,15 @@ object SparkArrowUtil {
                 .add(MapVector.KEY_NAME, keyType, nullable = false)
                 .add(MapVector.VALUE_NAME, valueType, nullable = valueContainsNull),
               nullable = false,
-              timeZoneId
+              timeZoneId,
+              largeVarTypes
             )).asJava
         )
+      case udt: UserDefinedType[_] =>
+        toArrowField(name, udt.sqlType, nullable, timeZoneId, largeVarTypes)
       case dataType =>
-        val fieldType = new FieldType(nullable, toArrowType(dataType, timeZoneId), null)
+        val fieldType =
+          new FieldType(nullable, toArrowType(dataType, timeZoneId, largeVarTypes), null)
         new Field(name, fieldType, Seq.empty[Field].asJava)
     }
   }
@@ -162,9 +179,12 @@ object SparkArrowUtil {
   }
 
   /** Maps schema from Spark to Arrow. NOTE: timeZoneId required for TimestampType in StructType */
-  def toArrowSchema(schema: StructType, timeZoneId: String): Schema = {
+  def toArrowSchema(
+      schema: StructType,
+      timeZoneId: String,
+      largeVarTypes: Boolean = false): Schema = {
     new Schema(schema.map {
-      field => toArrowField(field.name, field.dataType, field.nullable, timeZoneId)
+      field => toArrowField(field.name, field.dataType, field.nullable, timeZoneId, largeVarTypes)
     }.asJava)
   }
 

--- a/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkSchemaUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkSchemaUtil.scala
@@ -30,11 +30,11 @@ object SparkSchemaUtil {
   }
 
   def toArrowSchema(schema: StructType): Schema = {
-    SparkArrowUtil.toArrowSchema(schema, getLocalTimezoneID)
+    SparkArrowUtil.toArrowSchema(schema, getLocalTimezoneID, enableLargeVarTypes)
   }
 
   def toArrowSchema(schema: StructType, timeZoneId: String): Schema = {
-    SparkArrowUtil.toArrowSchema(schema, timeZoneId)
+    SparkArrowUtil.toArrowSchema(schema, timeZoneId, enableLargeVarTypes)
   }
 
   def isTimeZoneIDEquivalentToUTC(zoneId: String): Boolean = {
@@ -43,6 +43,10 @@ object SparkSchemaUtil {
 
   def getLocalTimezoneID: String = {
     SQLConf.get.sessionLocalTimeZone
+  }
+
+  def enableLargeVarTypes: Boolean = {
+    SQLConf.get.getConfString("spark.sql.execution.arrow.useLargeVarTypes", "false").toBoolean
   }
 
   def timeZoneIDEquals(one: String, other: String): Boolean = {

--- a/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkSchemaUtil.scala
+++ b/gluten-arrow/src/main/scala/org/apache/spark/sql/utils/SparkSchemaUtil.scala
@@ -17,13 +17,17 @@
 package org.apache.spark.sql.utils
 
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType}
 
-import org.apache.arrow.vector.types.pojo.Schema
+import org.apache.arrow.vector.types.pojo.{Field, Schema}
 
 import java.util.{Objects, TimeZone}
 
 object SparkSchemaUtil {
+
+  def toArrowField(name: String, dt: DataType, nullable: Boolean): Field = {
+    SparkArrowUtil.toArrowField(name, dt, nullable, getLocalTimezoneID, enableLargeVarTypes)
+  }
 
   def fromArrowSchema(schema: Schema): StructType = {
     SparkArrowUtil.fromArrowSchema(schema)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Support Spark conf `spark.sql.execution.arrow.useLargeVarTypes` when building arrow vectors to avoid `OversizedAllocationException` for very large string/binary columns.

Fix https://github.com/apache/gluten/issues/12447.

## How was this patch tested?
UT.

## Was this patch authored or co-authored using generative AI tooling?
No.
