### PR TITLE
[GLUTEN-12449] Remove unsupported functions in ArrowWritableColumnVector

### DIFF
--- a/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
+++ b/gluten-arrow/src/main/java/org/apache/gluten/vectorized/ArrowWritableColumnVector.java
@@ -497,13 +497,6 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     return accessor.getBoolean(rowId);
   }
 
-  @Override
-  public boolean[] getBooleans(int rowId, int count) {
-    return accessor.getBooleans(rowId, count);
-  }
-
-  //
-
   //
   // APIs dealing with Bytes
   //
@@ -536,11 +529,6 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
   @Override
   public byte getByte(int rowId) {
     return accessor.getByte(rowId);
-  }
-
-  @Override
-  public byte[] getBytes(int rowId, int count) {
-    return accessor.getBytes(rowId, count);
   }
 
   @Override
@@ -577,11 +565,6 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     return accessor.getShort(rowId);
   }
 
-  @Override
-  public short[] getShorts(int rowId, int count) {
-    return accessor.getShorts(rowId, count);
-  }
-
   //
   // APIs dealing with Ints
   //
@@ -614,11 +597,6 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
   @Override
   public int getInt(int rowId) {
     return accessor.getInt(rowId);
-  }
-
-  @Override
-  public int[] getInts(int rowId, int count) {
-    return accessor.getInts(rowId, count);
   }
 
   /**
@@ -665,11 +643,6 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     return accessor.getLong(rowId);
   }
 
-  @Override
-  public long[] getLongs(int rowId, int count) {
-    return accessor.getLongs(rowId, count);
-  }
-
   //
   // APIs dealing with floats
   //
@@ -702,11 +675,6 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
     return accessor.getFloat(rowId);
   }
 
-  @Override
-  public float[] getFloats(int rowId, int count) {
-    return accessor.getFloats(rowId, count);
-  }
-
   //
   // APIs dealing with doubles
   //
@@ -737,11 +705,6 @@ public final class ArrowWritableColumnVector extends WritableColumnVectorShim {
   @Override
   public double getDouble(int rowId) {
     return accessor.getDouble(rowId);
-  }
-
-  @Override
-  public double[] getDoubles(int rowId, int count) {
-    return accessor.getDoubles(rowId, count);
   }
 
   //

--- a/gluten-arrow/src/test/java/org/apache/gluten/vectorized/ArrowWritableColumnVectorTest.java
+++ b/gluten-arrow/src/test/java/org/apache/gluten/vectorized/ArrowWritableColumnVectorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.vectorized;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.task.TaskResources$;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class ArrowWritableColumnVectorTest {
+  @Test
+  public void getBooleansOnStructBackedVectorReturnsExpectedBooleans() {
+    TaskResources$.MODULE$.runUnsafe(
+        () -> {
+          try (ArrowWritableColumnVector vector =
+              new ArrowWritableColumnVector(1, DataTypes.BooleanType)) {
+            vector.putBoolean(0, false);
+            assertArrayEquals(new boolean[] {false}, vector.getBooleans(0, 1));
+          }
+          return null;
+        });
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
`ArrowWritableColumnVector` overwrite `getXXXs()` functions by `accessor.getXXXs()`, but no accessor implement such functions, so it would cause `UnsupportedOperationException`.

In this PR we remove these unsupported functions to fix https://github.com/apache/gluten/issues/12449.

## How was this patch tested?
Add UT.

## Was this patch authored or co-authored using generative AI tooling?
No.
