### PR TITLE
[GLUTEN-12439] [FLINK] Add CONCAT / CONCAT_WS expression registration

### DIFF
--- a/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/functions/RexCallConverterFactory.java
+++ b/gluten-flink/planner/src/main/java/org/apache/gluten/rexnode/functions/RexCallConverterFactory.java
@@ -110,7 +110,9 @@ public class RexCallConverterFactory {
           Map.entry("LOWER", Arrays.asList(() -> new DefaultRexCallConverter("lower"))),
           Map.entry("count_char", Arrays.asList(() -> new DefaultRexCallConverter("count_char"))),
           Map.entry("EXTRACT", Arrays.asList(() -> new DefaultRexCallConverter("extract"))),
-          Map.entry("IS TRUE", Arrays.asList(() -> new IsTrueRexCallConverter())));
+          Map.entry("IS TRUE", Arrays.asList(() -> new IsTrueRexCallConverter())),
+          Map.entry("CONCAT", Arrays.asList(() -> new DefaultRexCallConverter("concat"))),
+          Map.entry("CONCAT_WS", Arrays.asList(() -> new DefaultRexCallConverter("concat_ws"))));
 
   public static RexCallConverter getConverter(RexCall callNode, RexConversionContext context) {
     String operatorName = callNode.getOperator().getName();

--- a/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/custom/ConcatFunctionsTest.java
+++ b/gluten-flink/ut/src/test/java/org/apache/gluten/table/runtime/stream/custom/ConcatFunctionsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.table.runtime.stream.custom;
+
+import org.apache.gluten.table.runtime.stream.common.GlutenStreamingTestBase;
+
+import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+class ConcatFunctionsTest extends GlutenStreamingTestBase {
+
+  @Override
+  @BeforeEach
+  public void before() throws Exception {
+    super.before();
+  }
+
+  @Test
+  void testConcat() {
+    List<Row> rows =
+        Arrays.asList(
+            Row.of(1, "hello", "world"), Row.of(2, "foo", "bar"), Row.of(3, "abc", "xyz"));
+    createSimpleBoundedValuesTable("tblConcat", "a int, b string, c string", rows);
+
+    String query = "select CONCAT(b, c) from tblConcat where a > 0";
+    runAndCheck(query, Arrays.asList("+I[helloworld]", "+I[foobar]", "+I[abcxyz]"));
+  }
+
+  @Test
+  void testConcatWithLiteral() {
+    List<Row> rows = Arrays.asList(Row.of(1, "hello"), Row.of(2, "foo"), Row.of(3, "abc"));
+    createSimpleBoundedValuesTable("tblConcatLit", "a int, b string", rows);
+
+    String query = "select CONCAT(b, '_suffix') from tblConcatLit where a > 0";
+    runAndCheck(query, Arrays.asList("+I[hello_suffix]", "+I[foo_suffix]", "+I[abc_suffix]"));
+  }
+
+  @Test
+  void testConcatWs() {
+    List<Row> rows =
+        Arrays.asList(
+            Row.of(1, "hello", "world"), Row.of(2, "foo", "bar"), Row.of(3, "abc", "xyz"));
+    createSimpleBoundedValuesTable("tblConcatWs", "a int, b string, c string", rows);
+
+    String query = "select CONCAT_WS('-', b, c) from tblConcatWs where a > 0";
+    runAndCheck(query, Arrays.asList("+I[hello-world]", "+I[foo-bar]", "+I[abc-xyz]"));
+  }
+
+  @Test
+  void testConcatWsWithLiteral() {
+    List<Row> rows = Arrays.asList(Row.of(1, "a", "b", "c"), Row.of(2, "d", "e", "f"));
+    createSimpleBoundedValuesTable("tblConcatWsLit", "a int, b string, c string, d string", rows);
+
+    String query = "select CONCAT_WS(',', b, c, d) from tblConcatWsLit where a > 0";
+    runAndCheck(query, Arrays.asList("+I[a,b,c]", "+I[d,e,f]"));
+  }
+
+  @Test
+  void testConcatWithNull() {
+    List<Row> rows = Arrays.asList(Row.of(1, "hello", null), Row.of(2, null, "world"));
+    createSimpleBoundedValuesTable("tblConcatNull", "a int, b string, c string", rows);
+
+    // CONCAT returns null if any argument is null
+    String query = "select CONCAT(b, c) from tblConcatNull where a > 0";
+    runAndCheck(query, Arrays.asList("+I[null]", "+I[null]"));
+  }
+}


### PR DESCRIPTION
issue: https://github.com/apache/gluten/issues/12439

## What changes are proposed in this pull request?

- Add **concat / concat_ws** to RexCallConverterFactory.converters map to enable pushdown to Velox, which already implements both functions natively. 
- Both concat and concat_ws semantics (NULL handling, empty string handling) have been verified to be consistent between Velox and Flink native implementations.

## How was this patch tested?

- Added ConcatFunctionsTest with 5 test cases covering: basic CONCAT, CONCAT with literal, CONCAT_WS, CONCAT_WS with literal, and CONCAT with NULL. All tests pass.
- Also verified via Flink SQL: SELECT CONCAT('a', 'b') and SELECT CONCAT_WS('-', 'a', 'b') return expected results.