### PR TITLE
[MINOR][CORE] Avoid O(n^2) stack walk in CallerInfo.inBloomFilterStatFunctionCall

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/caller/CallerInfo.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/caller/CallerInfo.scala
@@ -79,10 +79,14 @@ object CallerInfo {
   }
 
   private def inBloomFilterStatFunctionCall(stack: Seq[StackTraceElement]): Boolean = {
-    val res = stack.exists(
-      _.getClassName.equals("org.apache.spark.sql.DataFrameStatFunctions")
-        && stack.exists(_.getMethodName.equals("bloomFilter")))
-    res
+    // Two independent existence checks over the stack. The previous shape used a nested
+    // `stack.exists(_.getMethodName.equals(...))` inside the outer predicate, which re-walked
+    // the whole stack for every candidate frame - O(n^2) in stack depth. Splitting the checks
+    // makes each a single pass. `&&` short-circuits, so the bloomFilter scan only runs when a
+    // DataFrameStatFunctions frame is present.
+    val hasStatFunctionsClass =
+      stack.exists(_.getClassName.equals("org.apache.spark.sql.DataFrameStatFunctions"))
+    hasStatFunctionsClass && stack.exists(_.getMethodName.equals("bloomFilter"))
   }
 
   /** For testing only. */


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CallerInfo.inBloomFilterStatFunctionCall` used a nested `stack.exists` inside the outer predicate:

```scala
stack.exists(
  _.getClassName.equals("org.apache.spark.sql.DataFrameStatFunctions")
    && stack.exists(_.getMethodName.equals("bloomFilter")))
```

The inner `stack.exists` does not depend on the outer element and re-walks the whole stack for every candidate frame, making the check O(n^2) in stack depth. Split it into two independent single-pass checks that combine with `&&`; the resulting predicate is "the stack contains both a `DataFrameStatFunctions` frame and a `bloomFilter` frame," identical to the original.

### Why are the changes needed?

`CallerInfo.create()` is invoked once per columnar rule application, so this predicate runs on every planned query. The change is a straight refactor with no behavior difference; the value is that the stack scan drops from quadratic to linear.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

`mvn -pl gluten-core -Pspark-3.5 spotless:check` and `compile` pass. No behavior change, no new test.