### PR TITLE
[GLUTEN-12479][CORE] Log error when -Xms equals -Xmx makes JVM heap shrinking ineffective

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/DynamicOffHeapSizingMemoryTarget.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/DynamicOffHeapSizingMemoryTarget.java
@@ -105,6 +105,18 @@ public class DynamicOffHeapSizingMemoryTarget implements MemoryTarget, KnownName
     ORIGINAL_MIN_HEAP_FREE_RATIO = originalMinHeapFreeRatio;
     ORIGINAL_MAX_HEAP_FREE_RATIO = originalMaxHeapFreeRatio;
 
+    long maxMem = Runtime.getRuntime().maxMemory();
+    long initTotalMem = Runtime.getRuntime().totalMemory();
+    if (initTotalMem >= maxMem * 0.95) {
+      LOG.error(
+          "JVM heap appears fixed or nearly fixed (totalMemory={}, maxMemory={}). "
+              + "This typically means -Xms is equal or close to -Xmx. "
+              + "Explicit JVM shrinking will not be effective because the JVM "
+              + "cannot return committed heap to the OS.",
+          initTotalMem,
+          maxMem);
+    }
+
     if (!isJava9OrLater()) {
       // For JDK 8, we cannot change MaxHeapFreeRatio programmatically at runtime.
       LOG.error("Dynamic off-heap sizing is not supported before JDK 9.");


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Add a check in `DynamicOffHeapSizingMemoryTarget` static initializer to detect when -Xms equals or is very close to -Xmx. In this scenario, the JVM heap size is fixed and System.gc() cannot shrink totalMemory (return committed pages to OS), making the shrinkOnHeapMemory mechanism ineffective. An error log is emitted to alert users, consistent with the existing checks for `-XX:+ExplicitGCInvokesConcurrent` and `-XX:+DisableExplicitGC`.

fix:#12479
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
Existing unit tests.

