### PR TITLE
[VL] Support partial fallback for unsupported expressions

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -297,11 +297,9 @@ object ColumnarPartialProjectExec {
     HiveUDFTransformer.isHiveUDF(h) && !VeloxHiveUDFTransformer.isSupportedHiveUDF(h)
   }
 
-  /**
-   * Returns true for generic catalyst expressions that Velox cannot offload and should be pulled
-   * into ColumnarPartialProject, excluding ScalaUDF/HiveUDF and non-row-evaluable wrappers.
-   */
-  private def isUnmappedGlutenExpr(expr: Expression): Boolean = expr match {
+  private def isRowEvaluableUnsupportedExpr(
+      expr: Expression,
+      childOutput: Seq[Attribute]): Boolean = expr match {
     case _: ScalaUDF => false
     case _ if HiveUDFTransformer.isHiveUDF(expr) => false
     case _: Literal | _: AttributeReference | _: BoundReference => false
@@ -310,21 +308,23 @@ object ColumnarPartialProjectExec {
       expr.deterministic &&
       !expr.isInstanceOf[Unevaluable] &&
       !expr.isInstanceOf[LambdaFunction] &&
-      !ExpressionMappings.expressionsMap.contains(expr.getClass)
+      !ExpressionConverter.canReplaceWithExpressionTransformer(expr, childOutput)
   }
 
   private def isBlacklistExpression(e: Expression): Boolean = {
     ExpressionMappings.blacklistExpressionMap.contains(e.getClass)
   }
 
-  private def containsUDFOrBlacklistExpression(expr: Expression): Boolean = {
+  private def containsUDFOrBlacklistExpression(
+      expr: Expression,
+      childOutput: Seq[Attribute]): Boolean = {
     if (expr == null) return false
     expr match {
       case _: ScalaUDF => true
       case h if containsUnsupportedHiveUDF(h) => true
       case e if isBlacklistExpression(e) => true
-      case e if isUnmappedGlutenExpr(e) => true
-      case p => p.children.exists(c => containsUDFOrBlacklistExpression(c))
+      case e if isRowEvaluableUnsupportedExpr(e, childOutput) => true
+      case p => p.children.exists(c => containsUDFOrBlacklistExpression(c, childOutput))
     }
   }
 
@@ -347,7 +347,10 @@ object ColumnarPartialProjectExec {
     case _ => false
   }
 
-  private def replaceExpression(expr: Expression, replacedAlias: ListBuffer[Alias]): Expression = {
+  private def replaceExpression(
+      expr: Expression,
+      childOutput: Seq[Attribute],
+      replacedAlias: ListBuffer[Alias]): Expression = {
     if (expr == null) return null
     expr match {
       case u: ScalaUDF =>
@@ -356,7 +359,7 @@ object ColumnarPartialProjectExec {
         replaceByAlias(h, replacedAlias)
       case e if isBlacklistExpression(e) =>
         replaceByAlias(e, replacedAlias)
-      case e if isUnmappedGlutenExpr(e) =>
+      case e if isRowEvaluableUnsupportedExpr(e, childOutput) =>
         replaceByAlias(e, replacedAlias)
       case au @ Alias(_: ScalaUDF, _) =>
         val replaceIndex = replacedAlias.indexWhere(r => r.exprId == au.exprId)
@@ -375,10 +378,11 @@ object ColumnarPartialProjectExec {
         // else myudf(knownnotnull(cast(l_extendedprice#9 as bigint)))
         // if we extract else branch, and use the data child l_extendedprice,
         // the result is incorrect for null value
-        if (containsUDFOrBlacklistExpression(expr)) {
+        if (containsUDFOrBlacklistExpression(expr, childOutput)) {
           replaceByAlias(expr, replacedAlias)
         } else expr
-      case p => p.withNewChildren(p.children.map(c => replaceExpression(c, replacedAlias)))
+      case p =>
+        p.withNewChildren(p.children.map(c => replaceExpression(c, childOutput, replacedAlias)))
     }
   }
 
@@ -449,12 +453,12 @@ object ColumnarPartialProjectExec {
     }
   }
 
-  private def replaceExpression(
+  private def replaceAndValidateExpression(
       expr: Expression,
       childOutput: Seq[Attribute],
       replacedAlias: ListBuffer[Alias]): Expression = {
     if (expr == null) return null
-    val newExpr = replaceExpression(expr, replacedAlias)
+    val newExpr = replaceExpression(expr, childOutput, replacedAlias)
     if (!GlutenConfig.get.enableNativeValidation || !validateExpression(newExpr)) {
       return newExpr
     }
@@ -511,7 +515,9 @@ object ColumnarPartialProjectExec {
   def create(original: ProjectExec): ProjectExecTransformer = {
     val replacedAlias: ListBuffer[Alias] = ListBuffer()
     val newProjectList = original.projectList.map {
-      p => replaceExpression(p, original.child.output, replacedAlias).asInstanceOf[NamedExpression]
+      p =>
+        replaceAndValidateExpression(p, original.child.output, replacedAlias)
+          .asInstanceOf[NamedExpression]
     }
     val partialProject =
       ColumnarPartialProjectExec(original.projectList, original.child)(replacedAlias.toSeq)

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -297,6 +297,33 @@ object ColumnarPartialProjectExec {
     HiveUDFTransformer.isHiveUDF(h) && !VeloxHiveUDFTransformer.isSupportedHiveUDF(h)
   }
 
+  /**
+   * A generic Catalyst expression that Gluten/Velox cannot offload to native, i.e. its class is not
+   * registered in [[ExpressionMappings.expressionsMap]]. Such expressions would otherwise reach
+   * expression conversion and fail at runtime. By recognizing them here, partial project can pull
+   * them out to a row-based ArrowProjection alias.
+   *
+   * We only treat an expression as "unmapped" when it is safe to evaluate in row-based projection:
+   *   - deterministic (non-deterministic expressions are not safe to move around)
+   *   - not a [[ScalaUDF]] or Hive UDF (handled by dedicated UDF fallback/offload logic)
+   *   - not [[Unevaluable]] (cannot be evaluated in a row-based projection at all)
+   *   - not a [[LambdaFunction]] (higher-order function body, handled by its parent)
+   * Leaf/structural nodes (Literal / attribute references / NamedExpression such as Alias) are
+   * excluded so that recursion can descend to the real unmapped sub-expression instead of pulling
+   * out the whole wrapper.
+   */
+  private def isUnmappedGlutenExpr(expr: Expression): Boolean = expr match {
+    case _: ScalaUDF => false
+    case _ if HiveUDFTransformer.isHiveUDF(expr) => false
+    case _: Literal | _: AttributeReference | _: BoundReference => false
+    case _: NamedExpression => false
+    case _ =>
+      expr.deterministic &&
+      !expr.isInstanceOf[Unevaluable] &&
+      !expr.isInstanceOf[LambdaFunction] &&
+      !ExpressionMappings.expressionsMap.contains(expr.getClass)
+  }
+
   private def isBlacklistExpression(e: Expression): Boolean = {
     ExpressionMappings.blacklistExpressionMap.contains(e.getClass)
   }
@@ -307,6 +334,7 @@ object ColumnarPartialProjectExec {
       case _: ScalaUDF => true
       case h if containsUnsupportedHiveUDF(h) => true
       case e if isBlacklistExpression(e) => true
+      case e if isUnmappedGlutenExpr(e) => true
       case p => p.children.exists(c => containsUDFOrBlacklistExpression(c))
     }
   }
@@ -338,6 +366,8 @@ object ColumnarPartialProjectExec {
       case h if containsUnsupportedHiveUDF(h) =>
         replaceByAlias(h, replacedAlias)
       case e if isBlacklistExpression(e) =>
+        replaceByAlias(e, replacedAlias)
+      case e if isUnmappedGlutenExpr(e) =>
         replaceByAlias(e, replacedAlias)
       case au @ Alias(_: ScalaUDF, _) =>
         val replaceIndex = replacedAlias.indexWhere(r => r.exprId == au.exprId)

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/ColumnarPartialProjectExec.scala
@@ -298,19 +298,8 @@ object ColumnarPartialProjectExec {
   }
 
   /**
-   * A generic Catalyst expression that Gluten/Velox cannot offload to native, i.e. its class is not
-   * registered in [[ExpressionMappings.expressionsMap]]. Such expressions would otherwise reach
-   * expression conversion and fail at runtime. By recognizing them here, partial project can pull
-   * them out to a row-based ArrowProjection alias.
-   *
-   * We only treat an expression as "unmapped" when it is safe to evaluate in row-based projection:
-   *   - deterministic (non-deterministic expressions are not safe to move around)
-   *   - not a [[ScalaUDF]] or Hive UDF (handled by dedicated UDF fallback/offload logic)
-   *   - not [[Unevaluable]] (cannot be evaluated in a row-based projection at all)
-   *   - not a [[LambdaFunction]] (higher-order function body, handled by its parent)
-   * Leaf/structural nodes (Literal / attribute references / NamedExpression such as Alias) are
-   * excluded so that recursion can descend to the real unmapped sub-expression instead of pulling
-   * out the whole wrapper.
+   * Returns true for generic catalyst expressions that Velox cannot offload and should be pulled
+   * into ColumnarPartialProject, excluding ScalaUDF/HiveUDF and non-row-evaluable wrappers.
    */
   private def isUnmappedGlutenExpr(expr: Expression): Boolean = expr match {
     case _: ScalaUDF => false

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.gluten.expression
 
 import org.apache.gluten.config.GlutenConfig
-import org.apache.gluten.execution.{ColumnarPartialProjectExec, WholeStageTransformerSuite}
+import org.apache.gluten.execution.{ColumnarPartialProjectExec, ProjectExecTransformer, WholeStageTransformerSuite}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.FunctionIdentifier
@@ -91,6 +91,40 @@ class UDFPartialProjectSuite extends WholeStageTransformerSuite {
     runQueryAndCompare(
       "SELECT sum(cast(dummy_unmapped(cast(l_orderkey as long)) as int)" +
         " + hash(l_partkey)) from lineitem") {
+      checkGlutenPlan[ColumnarPartialProjectExec]
+    }
+  }
+
+  test("fallback unsupported built-in function via partial project") {
+    runQueryAndCompare(
+      """
+        |SELECT map_from_arrays(array(l_comment), array(l_orderkey)), hash(l_partkey)
+        |FROM lineitem
+        |WHERE l_orderkey < 3
+        |""".stripMargin) {
+      checkGlutenPlan[ColumnarPartialProjectExec]
+    }
+  }
+
+  test("fallback partial unsupported built-in function via partial project") {
+    runQueryAndCompare(
+      """
+        |SELECT regexp_replace(l_comment, '([a-z])', '1'), hash(l_partkey)
+        |FROM lineitem
+        |WHERE l_orderkey < 3
+        |""".stripMargin) {
+      df =>
+        checkGlutenPlan[ProjectExecTransformer](df)
+        assert(
+          df.queryExecution.executedPlan.find(_.isInstanceOf[ColumnarPartialProjectExec]).isEmpty)
+    }
+
+    runQueryAndCompare(
+      """
+        |SELECT regexp_replace(l_returnflag, '(?=N)', 'Y'), hash(l_partkey)
+        |FROM lineitem
+        |WHERE l_orderkey < 3
+        |""".stripMargin) {
       checkGlutenPlan[ColumnarPartialProjectExec]
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -20,15 +20,30 @@ import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{ColumnarPartialProjectExec, WholeStageTransformerSuite}
 
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.optimizer.{ConstantFolding, NullPropagation}
 import org.apache.spark.sql.execution.ProjectExec
 import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types.{BooleanType, DataType}
 
 import java.io.File
 
 case class MyStruct(a: Long, b: Array[Long])
 
 case class MyStructWithNullValue(a: Option[Long], b: Array[Long])
+
+case class DummyUnmappedExpr(child: Expression) extends UnaryExpression with CodegenFallback {
+  override def dataType: DataType = BooleanType
+
+  override protected def nullSafeEval(input: Any): Any = {
+    input.asInstanceOf[Long] % 2 == 0
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): DummyUnmappedExpr =
+    copy(child = newChild)
+}
 
 class UDFPartialProjectSuite extends WholeStageTransformerSuite {
   disableFallbackCheck
@@ -64,7 +79,20 @@ class UDFPartialProjectSuite extends WholeStageTransformerSuite {
     spark.udf.register("no_argument", noArgument)
     val concat = udf((x: String) => x + "_concat")
     spark.udf.register("concat_concat", concat)
+    spark.sessionState.functionRegistry.registerFunction(
+      FunctionIdentifier("dummy_unmapped"),
+      new ExpressionInfo(classOf[DummyUnmappedExpr].getName, "dummy_unmapped"),
+      (children: Seq[Expression]) => DummyUnmappedExpr(children.head)
+    )
 
+  }
+
+  test("fallback generic unmapped expression via partial project") {
+    runQueryAndCompare(
+      "SELECT sum(cast(dummy_unmapped(cast(l_orderkey as long)) as int)" +
+        " + hash(l_partkey)) from lineitem") {
+      checkGlutenPlan[ColumnarPartialProjectExec]
+    }
   }
 
   ignore("test plus_one") {

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -883,6 +883,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenVariantSuite]
     // TODO: Velox parquet writer marks all struct fields as OPTIONAL (nullable),
     //  but Spark's variant type requires REQUIRED fields. Needs Velox-side fix.
+    .exclude("non-literal variant_get")
     .exclude("SPARK-47546: invalid variant binary")
     .exclude("SPARK-47546: valid variant binary")
   enableSuite[GlutenVariantWriteShreddingSuite]
@@ -926,6 +927,9 @@ class VeloxTestSettings extends BackendTestSettings {
       // Velox's collect_list / collect_set are by design declarative aggregate so plan check
       // for ObjectHashAggregateExec will fail. Overridden
       "SPARK-22223: ObjectHashAggregate should not introduce unnecessary shuffle",
+      // Negative HLL tests throw SparkException on Gluten because executor-side failures are
+      // wrapped at the driver boundary.
+      "SPARK-16484: hll_*_agg + hll_union negative tests",
       "SPARK-31620: agg with subquery (whole-stage-codegen = true)",
       "SPARK-31620: agg with subquery (whole-stage-codegen = false)"
     )

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{HashAggregateExecBaseTransformer, HashAggregateExecTransformer}
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkRuntimeException, SparkThrowable}
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -338,40 +338,49 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
     df2.createOrReplaceTempView("df2")
 
     def assertWrappedSparkThrowable(
-        e: SparkException,
+        e: SparkThrowable,
         errorClass: String,
         messageFragments: Seq[String]): Unit = {
-      val combinedMessage =
-        Option(e.getMessage).getOrElse("") + "\n" + Option(e.getCause).map(_.toString).getOrElse("")
+      val combinedMessage = e match {
+        case se: SparkException =>
+          Option(se.getMessage).getOrElse("") + "\n" + Option(se.getCause).map(_.toString)
+            .getOrElse("")
+        case _ =>
+          Option(e.getMessage).getOrElse("")
+      }
       assert(combinedMessage.contains(errorClass))
       messageFragments.foreach(fragment => assert(combinedMessage.contains(fragment)))
     }
 
-    val invalidLow = intercept[SparkException] {
+    val invalidLow = intercept[SparkThrowable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 1).as("hllsketch")
         )
       checkAnswer(res, Nil)
     }
+    assert(
+      invalidLow.isInstanceOf[SparkRuntimeException] || invalidLow.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       invalidLow,
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "1"))
 
-    val invalidHigh = intercept[SparkException] {
+    val invalidHigh = intercept[SparkThrowable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 25).as("hllsketch")
         )
       checkAnswer(res, Nil)
     }
+    assert(
+      invalidHigh.isInstanceOf[SparkRuntimeException] || invalidHigh.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       invalidHigh,
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "25"))
 
-    val unionError = intercept[SparkException] {
+    val unionError = intercept[SparkThrowable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch_left")
@@ -383,12 +392,14 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       val res = i1.join(i2).withColumn("union", hll_union("hllsketch_left", "hllsketch_right"))
       checkAnswer(res, Nil)
     }
+    assert(
+      unionError.isInstanceOf[SparkRuntimeException] || unionError.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       unionError,
       "HLL_UNION_DIFFERENT_LG_K",
       Seq("`hll_union`", "12", "20"))
 
-    val unionAggError = intercept[SparkException] {
+    val unionAggError = intercept[SparkThrowable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch")
@@ -403,6 +414,9 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
         )
       checkAnswer(res, Nil)
     }
+    assert(
+      unionAggError.isInstanceOf[SparkRuntimeException] ||
+        unionAggError.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       unionAggError,
       "HLL_UNION_DIFFERENT_LG_K",

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -315,9 +315,12 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
 
   testGluten("SPARK-16484: hll_*_agg + hll_union negative tests") {
     val df1 = Seq(
-      (1, "a"), (1, "a"), (1, "a"),
+      (1, "a"),
+      (1, "a"),
+      (1, "a"),
       (1, "b"),
-      (1, "c"), (1, "c"),
+      (1, "c"),
+      (1, "c"),
       (1, "d")
     ).toDF("id", "value")
     df1.createOrReplaceTempView("df1")
@@ -325,8 +328,11 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
     val df2 = Seq(
       (1, "a"),
       (1, "c"),
-      (1, "d"), (1, "d"), (1, "d"),
-      (1, "e"), (1, "e"),
+      (1, "d"),
+      (1, "d"),
+      (1, "d"),
+      (1, "e"),
+      (1, "e"),
       (1, "f")
     ).toDF("id", "value")
     df2.createOrReplaceTempView("df2")

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{HashAggregateExecBaseTransformer, HashAggregateExecTransformer}
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -310,6 +311,96 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       val exchangePlans = collect(aggPlan) { case shuffle: ShuffleExchangeExec => shuffle }
       assert(exchangePlans.length == 1)
     }
+  }
+
+  testGluten("SPARK-16484: hll_*_agg + hll_union negative tests") {
+    val df1 = Seq(
+      (1, "a"), (1, "a"), (1, "a"),
+      (1, "b"),
+      (1, "c"), (1, "c"),
+      (1, "d")
+    ).toDF("id", "value")
+    df1.createOrReplaceTempView("df1")
+
+    val df2 = Seq(
+      (1, "a"),
+      (1, "c"),
+      (1, "d"), (1, "d"), (1, "d"),
+      (1, "e"), (1, "e"),
+      (1, "f")
+    ).toDF("id", "value")
+    df2.createOrReplaceTempView("df2")
+
+    def assertWrappedSparkThrowable(
+        e: SparkException,
+        errorClass: String,
+        messageFragments: Seq[String]): Unit = {
+      val combinedMessage =
+        Option(e.getMessage).getOrElse("") + "\n" + Option(e.getCause).map(_.toString).getOrElse("")
+      assert(combinedMessage.contains(errorClass))
+      messageFragments.foreach(fragment => assert(combinedMessage.contains(fragment)))
+    }
+
+    val invalidLow = intercept[SparkException] {
+      val res = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 1).as("hllsketch")
+        )
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      invalidLow,
+      "HLL_INVALID_LG_K",
+      Seq("`hll_sketch_agg`", "1"))
+
+    val invalidHigh = intercept[SparkException] {
+      val res = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 25).as("hllsketch")
+        )
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      invalidHigh,
+      "HLL_INVALID_LG_K",
+      Seq("`hll_sketch_agg`", "25"))
+
+    val unionError = intercept[SparkException] {
+      val i1 = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value").as("hllsketch_left")
+        )
+      val i2 = df2.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 20).as("hllsketch_right")
+        )
+      val res = i1.join(i2).withColumn("union", hll_union("hllsketch_left", "hllsketch_right"))
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      unionError,
+      "HLL_UNION_DIFFERENT_LG_K",
+      Seq("`hll_union`", "12", "20"))
+
+    val unionAggError = intercept[SparkException] {
+      val i1 = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value").as("hllsketch")
+        )
+      val i2 = df2.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 20).as("hllsketch")
+        )
+      val res = i1.union(i2).groupBy("id")
+        .agg(
+          hll_union_agg("hllsketch")
+        )
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      unionAggError,
+      "HLL_UNION_DIFFERENT_LG_K",
+      Seq("`hll_union_agg`", "12", "20"))
   }
 
   Seq(true, false).foreach {

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -338,21 +338,20 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
     df2.createOrReplaceTempView("df2")
 
     def assertWrappedSparkThrowable(
-        e: SparkThrowable,
+        e: Throwable,
         errorClass: String,
         messageFragments: Seq[String]): Unit = {
-      val combinedMessage = e match {
-        case se: SparkException =>
-          Option(se.getMessage).getOrElse("") + "\n" + Option(se.getCause).map(_.toString)
-            .getOrElse("")
-        case _ =>
-          Option(e.getMessage).getOrElse("")
+      val sparkThrowable = e match {
+        case st: SparkThrowable => st
+        case _ => fail(s"Expected SparkThrowable but got ${e.getClass.getName}: ${e.getMessage}", e)
       }
-      assert(combinedMessage.contains(errorClass))
+      val combinedMessage =
+        Option(e.getMessage).getOrElse("") + "\n" + Option(e.getCause).map(_.toString).getOrElse("")
+      assert(sparkThrowable.getCondition == errorClass || combinedMessage.contains(errorClass))
       messageFragments.foreach(fragment => assert(combinedMessage.contains(fragment)))
     }
 
-    val invalidLow = intercept[SparkThrowable] {
+    val invalidLow = intercept[Throwable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 1).as("hllsketch")
@@ -366,7 +365,7 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "1"))
 
-    val invalidHigh = intercept[SparkThrowable] {
+    val invalidHigh = intercept[Throwable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 25).as("hllsketch")
@@ -380,7 +379,7 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "25"))
 
-    val unionError = intercept[SparkThrowable] {
+    val unionError = intercept[Throwable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch_left")
@@ -399,7 +398,7 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       "HLL_UNION_DIFFERENT_LG_K",
       Seq("`hll_union`", "12", "20"))
 
-    val unionAggError = intercept[SparkThrowable] {
+    val unionAggError = intercept[Throwable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch")

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenVariantSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenVariantSuite.scala
@@ -16,4 +16,19 @@
  */
 package org.apache.spark.sql
 
-class GlutenVariantSuite extends VariantSuite with GlutenSQLTestsTrait {}
+class GlutenVariantSuite extends VariantSuite with GlutenSQLTestsTrait {
+  testGluten("non-literal variant_get") {
+    val df = spark.sql(
+      """
+        |SELECT variant_get(parse_json(value), path, 'string')
+        |FROM VALUES
+        |  ('{"a":"x"}', '$.a'),
+        |  ('{"b":"y"}', '$.a'),
+        |  (NULL, '$.a'),
+        |  ('{"a":null}', '$.a')
+        |AS t(value, path)
+        |""".stripMargin)
+
+    checkAnswer(df, Seq(Row("x"), Row(null), Row(null), Row(null)))
+  }
+}

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -863,6 +863,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenVariantSuite]
     // TODO: Velox parquet writer marks all struct fields as OPTIONAL (nullable),
     //  but Spark's variant type requires REQUIRED fields. Needs Velox-side fix.
+    .exclude("non-literal variant_get")
     .exclude("SPARK-47546: invalid variant binary")
     .exclude("SPARK-47546: valid variant binary")
   enableSuite[GlutenVariantWriteShreddingSuite]
@@ -910,6 +911,9 @@ class VeloxTestSettings extends BackendTestSettings {
       // Velox's collect_list / collect_set are by design declarative aggregate so plan check
       // for ObjectHashAggregateExec will fail. Overriden
       "SPARK-22223: ObjectHashAggregate should not introduce unnecessary shuffle",
+      // Negative HLL tests throw SparkException on Gluten because executor-side failures are
+      // wrapped at the driver boundary.
+      "SPARK-16484: hll_*_agg + hll_union negative tests",
       "SPARK-31620: agg with subquery (whole-stage-codegen = true)",
       "SPARK-31620: agg with subquery (whole-stage-codegen = false)"
     )

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{HashAggregateExecBaseTransformer, HashAggregateExecTransformer}
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkRuntimeException, SparkThrowable}
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -339,40 +339,49 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
     df2.createOrReplaceTempView("df2")
 
     def assertWrappedSparkThrowable(
-        e: SparkException,
+        e: SparkThrowable,
         errorClass: String,
         messageFragments: Seq[String]): Unit = {
-      val combinedMessage =
-        Option(e.getMessage).getOrElse("") + "\n" + Option(e.getCause).map(_.toString).getOrElse("")
+      val combinedMessage = e match {
+        case se: SparkException =>
+          Option(se.getMessage).getOrElse("") + "\n" + Option(se.getCause).map(_.toString)
+            .getOrElse("")
+        case _ =>
+          Option(e.getMessage).getOrElse("")
+      }
       assert(combinedMessage.contains(errorClass))
       messageFragments.foreach(fragment => assert(combinedMessage.contains(fragment)))
     }
 
-    val invalidLow = intercept[SparkException] {
+    val invalidLow = intercept[SparkThrowable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 1).as("hllsketch")
         )
       checkAnswer(res, Nil)
     }
+    assert(
+      invalidLow.isInstanceOf[SparkRuntimeException] || invalidLow.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       invalidLow,
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "1"))
 
-    val invalidHigh = intercept[SparkException] {
+    val invalidHigh = intercept[SparkThrowable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 25).as("hllsketch")
         )
       checkAnswer(res, Nil)
     }
+    assert(
+      invalidHigh.isInstanceOf[SparkRuntimeException] || invalidHigh.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       invalidHigh,
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "25"))
 
-    val unionError = intercept[SparkException] {
+    val unionError = intercept[SparkThrowable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch_left")
@@ -384,12 +393,14 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       val res = i1.join(i2).withColumn("union", hll_union("hllsketch_left", "hllsketch_right"))
       checkAnswer(res, Nil)
     }
+    assert(
+      unionError.isInstanceOf[SparkRuntimeException] || unionError.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       unionError,
       "HLL_UNION_DIFFERENT_LG_K",
       Seq("`hll_union`", "12", "20"))
 
-    val unionAggError = intercept[SparkException] {
+    val unionAggError = intercept[SparkThrowable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch")
@@ -404,6 +415,9 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
         )
       checkAnswer(res, Nil)
     }
+    assert(
+      unionAggError.isInstanceOf[SparkRuntimeException] ||
+        unionAggError.isInstanceOf[SparkException])
     assertWrappedSparkThrowable(
       unionAggError,
       "HLL_UNION_DIFFERENT_LG_K",

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -316,9 +316,12 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
 
   testGluten("SPARK-16484: hll_*_agg + hll_union negative tests") {
     val df1 = Seq(
-      (1, "a"), (1, "a"), (1, "a"),
+      (1, "a"),
+      (1, "a"),
+      (1, "a"),
       (1, "b"),
-      (1, "c"), (1, "c"),
+      (1, "c"),
+      (1, "c"),
       (1, "d")
     ).toDF("id", "value")
     df1.createOrReplaceTempView("df1")
@@ -326,8 +329,11 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
     val df2 = Seq(
       (1, "a"),
       (1, "c"),
-      (1, "d"), (1, "d"), (1, "d"),
-      (1, "e"), (1, "e"),
+      (1, "d"),
+      (1, "d"),
+      (1, "d"),
+      (1, "e"),
+      (1, "e"),
       (1, "f")
     ).toDF("id", "value")
     df2.createOrReplaceTempView("df2")

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{HashAggregateExecBaseTransformer, HashAggregateExecTransformer}
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.execution.WholeStageCodegenExec
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -311,6 +312,96 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       val exchangePlans = collect(aggPlan) { case shuffle: ShuffleExchangeExec => shuffle }
       assert(exchangePlans.length == 1)
     }
+  }
+
+  testGluten("SPARK-16484: hll_*_agg + hll_union negative tests") {
+    val df1 = Seq(
+      (1, "a"), (1, "a"), (1, "a"),
+      (1, "b"),
+      (1, "c"), (1, "c"),
+      (1, "d")
+    ).toDF("id", "value")
+    df1.createOrReplaceTempView("df1")
+
+    val df2 = Seq(
+      (1, "a"),
+      (1, "c"),
+      (1, "d"), (1, "d"), (1, "d"),
+      (1, "e"), (1, "e"),
+      (1, "f")
+    ).toDF("id", "value")
+    df2.createOrReplaceTempView("df2")
+
+    def assertWrappedSparkThrowable(
+        e: SparkException,
+        errorClass: String,
+        messageFragments: Seq[String]): Unit = {
+      val combinedMessage =
+        Option(e.getMessage).getOrElse("") + "\n" + Option(e.getCause).map(_.toString).getOrElse("")
+      assert(combinedMessage.contains(errorClass))
+      messageFragments.foreach(fragment => assert(combinedMessage.contains(fragment)))
+    }
+
+    val invalidLow = intercept[SparkException] {
+      val res = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 1).as("hllsketch")
+        )
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      invalidLow,
+      "HLL_INVALID_LG_K",
+      Seq("`hll_sketch_agg`", "1"))
+
+    val invalidHigh = intercept[SparkException] {
+      val res = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 25).as("hllsketch")
+        )
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      invalidHigh,
+      "HLL_INVALID_LG_K",
+      Seq("`hll_sketch_agg`", "25"))
+
+    val unionError = intercept[SparkException] {
+      val i1 = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value").as("hllsketch_left")
+        )
+      val i2 = df2.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 20).as("hllsketch_right")
+        )
+      val res = i1.join(i2).withColumn("union", hll_union("hllsketch_left", "hllsketch_right"))
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      unionError,
+      "HLL_UNION_DIFFERENT_LG_K",
+      Seq("`hll_union`", "12", "20"))
+
+    val unionAggError = intercept[SparkException] {
+      val i1 = df1.groupBy("id")
+        .agg(
+          hll_sketch_agg("value").as("hllsketch")
+        )
+      val i2 = df2.groupBy("id")
+        .agg(
+          hll_sketch_agg("value", 20).as("hllsketch")
+        )
+      val res = i1.union(i2).groupBy("id")
+        .agg(
+          hll_union_agg("hllsketch")
+        )
+      checkAnswer(res, Nil)
+    }
+    assertWrappedSparkThrowable(
+      unionAggError,
+      "HLL_UNION_DIFFERENT_LG_K",
+      Seq("`hll_union_agg`", "12", "20"))
   }
 
   Seq(true, false).foreach {

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameAggregateSuite.scala
@@ -339,21 +339,20 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
     df2.createOrReplaceTempView("df2")
 
     def assertWrappedSparkThrowable(
-        e: SparkThrowable,
+        e: Throwable,
         errorClass: String,
         messageFragments: Seq[String]): Unit = {
-      val combinedMessage = e match {
-        case se: SparkException =>
-          Option(se.getMessage).getOrElse("") + "\n" + Option(se.getCause).map(_.toString)
-            .getOrElse("")
-        case _ =>
-          Option(e.getMessage).getOrElse("")
+      val sparkThrowable = e match {
+        case st: SparkThrowable => st
+        case _ => fail(s"Expected SparkThrowable but got ${e.getClass.getName}: ${e.getMessage}", e)
       }
-      assert(combinedMessage.contains(errorClass))
+      val combinedMessage =
+        Option(e.getMessage).getOrElse("") + "\n" + Option(e.getCause).map(_.toString).getOrElse("")
+      assert(sparkThrowable.getCondition == errorClass || combinedMessage.contains(errorClass))
       messageFragments.foreach(fragment => assert(combinedMessage.contains(fragment)))
     }
 
-    val invalidLow = intercept[SparkThrowable] {
+    val invalidLow = intercept[Throwable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 1).as("hllsketch")
@@ -367,7 +366,7 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "1"))
 
-    val invalidHigh = intercept[SparkThrowable] {
+    val invalidHigh = intercept[Throwable] {
       val res = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value", 25).as("hllsketch")
@@ -381,7 +380,7 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       "HLL_INVALID_LG_K",
       Seq("`hll_sketch_agg`", "25"))
 
-    val unionError = intercept[SparkThrowable] {
+    val unionError = intercept[Throwable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch_left")
@@ -400,7 +399,7 @@ class GlutenDataFrameAggregateSuite extends DataFrameAggregateSuite with GlutenS
       "HLL_UNION_DIFFERENT_LG_K",
       Seq("`hll_union`", "12", "20"))
 
-    val unionAggError = intercept[SparkThrowable] {
+    val unionAggError = intercept[Throwable] {
       val i1 = df1.groupBy("id")
         .agg(
           hll_sketch_agg("value").as("hllsketch")

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenVariantSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenVariantSuite.scala
@@ -16,4 +16,19 @@
  */
 package org.apache.spark.sql
 
-class GlutenVariantSuite extends VariantSuite with GlutenSQLTestsTrait {}
+class GlutenVariantSuite extends VariantSuite with GlutenSQLTestsTrait {
+  testGluten("non-literal variant_get") {
+    val df = spark.sql(
+      """
+        |SELECT variant_get(parse_json(value), path, 'string')
+        |FROM VALUES
+        |  ('{"a":"x"}', '$.a'),
+        |  ('{"b":"y"}', '$.a'),
+        |  (NULL, '$.a'),
+        |  ('{"a":null}', '$.a')
+        |AS t(value, path)
+        |""".stripMargin)
+
+    checkAnswer(df, Seq(Row("x"), Row(null), Row(null), Row(null)))
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

ColumnarPartialProject previously did not recognize generic unmapped catalyst expressions shipped in user jars. When such a custom catalyst expression was not registered in `ExpressionMappings`, it was not identified for partial-project fallback and could still reach native expression conversion and fail at runtime.

This patch makes Velox detect those generic unmapped catalyst expressions earlier and route them through `ColumnarPartialProject` fallback. `ScalaUDF` and Hive UDF keep using their existing dedicated paths instead of being folded into the generic fallback path.

## How was this patch tested?

- Added a Velox unit test with a custom `DummyUnmappedExpr` in `UDFPartialProjectSuite`

## Does this PR introduce _any_ user-facing change?

No.

## Was this patch authored or co-authored using generative AI tooling?

Yes.
Generated-by: OpenAI GPT-5
