### PR TITLE
[VL] Disable useHashTableCache if the hash table is not pre-built during HashJoinNode creation

### DIFF
--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -473,6 +473,19 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
       }
     }
 
+    if (!useHashTableCache) {
+      return std::make_shared<core::HashJoinNode>(
+          nextPlanNodeId(),
+          joinType,
+          isNullAwareAntiJoin,
+          leftKeys,
+          rightKeys,
+          filter,
+          leftNode,
+          rightNode,
+          getJoinOutputType(leftNode, rightNode, joinType));
+    }
+
     // Create HashJoinNode node
     return std::make_shared<core::HashJoinNode>(
         nextPlanNodeId(),
@@ -488,7 +501,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
         false,
         false,
         nullptr,
-        useHashTableCache ? hashTableId : std::string());
+        hashTableId);
   } else {
     // Create HashJoinNode node
     return std::make_shared<core::HashJoinNode>(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -488,7 +488,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
         false,
         false,
         nullptr,
-        hashTableId);
+        useHashTableCache ? hashTableId : std::string());
   } else {
     // Create HashJoinNode node
     return std::make_shared<core::HashJoinNode>(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -458,6 +458,21 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   } else if (
       sJoin.has_advanced_extension() &&
       SubstraitParser::configSetInOptimization(sJoin.advanced_extension(), "isBHJ=")) {
+    const std::string hashTableId = sJoin.hashtableid();
+    bool useHashTableCache = false;
+    if (!hashTableId.empty()) {
+      try {
+        const auto handle = getJoin(hashTableId);
+        if (handle != 0) {
+          auto hashTableBuilder = ObjectStore::retrieve<gluten::HashTableBuilder>(handle);
+          useHashTableCache = (hashTableBuilder != nullptr);
+        }
+      } catch (const std::exception& e) {
+        LOG(WARNING) << "Failed to retrieve pre-built HashTableBuilder for cache key: " << hashTableId
+                     << ", error: " << e.what() << ". Disable hash table cache and build a new table.";
+      }
+    }
+
     // Create HashJoinNode node
     return std::make_shared<core::HashJoinNode>(
         nextPlanNodeId(),
@@ -469,11 +484,11 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
         leftNode,
         rightNode,
         getJoinOutputType(leftNode, rightNode, joinType),
-        true,
+        useHashTableCache,
         false,
         false,
         nullptr,
-        sJoin.hashtableid());
+        hashTableId);
   } else {
     // Create HashJoinNode node
     return std::make_shared<core::HashJoinNode>(


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Because Velox does not release the hash tables in `HashTableCache` upon query completion (they are only released when the executor terminates), the CI encounters the following flaky error:

```
2026-07-09T05:01:36.4980422Z E20260709 05:01:36.497267 1021214 VeloxMemoryManager.cc:446] Failed to release Velox memory manager as there are still outstanding memory resources. 
2026-07-09T05:01:36.4983663Z E20260709 05:01:36.497301 1021214 MemoryPool.cpp:481] [MEM] Memory leak (Used memory): Memory Pool[cached_table_15560717 LEAF root[root] parent[root] MALLOC track-usage thread-safe]<unlimited max capacity capacity 8.00MB used 68.00KB available 956.00KB reservation [used 68.00KB, reserved 1.00MB, min 0B] counters [allocs 3, frees 1, reserves 0, releases 0, collisions 0, external-allocs 0, external-frees 0, cumulative-external 0B])>
2026-07-09T05:01:36.4987303Z E20260709 05:01:36.497359 1021214 Exceptions.h:87] Line: /work/cpp/velox/memory/VeloxMemoryManager.cc:108, Function:removePool, Expression: pool->reservedBytes() == 0 (1048576 vs. 0), Source: RUNTIME, ErrorCode: INVALID_STATE
2026-07-09T05:01:36.4989039Z terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
2026-07-09T05:01:36.4992594Z   what():  Exception: VeloxRuntimeError
2026-07-09T05:01:36.4993041Z Error Source: RUNTIME
2026-07-09T05:01:36.4993272Z Error Code: INVALID_STATE
2026-07-09T05:01:36.4993498Z Reason: (1048576 vs. 0)
2026-07-09T05:01:36.4993711Z Retriable: False
2026-07-09T05:01:36.4994093Z Expression: pool->reservedBytes() == 0
2026-07-09T05:01:36.4994432Z Function: removePool
2026-07-09T05:01:36.4994702Z File: /work/cpp/velox/memory/VeloxMemoryManager.cc
2026-07-09T05:01:36.4995003Z Line: 108
2026-07-09T05:01:36.4995183Z Stack trace:
2026-07-09T05:01:36.4995357Z # 0  
2026-07-09T05:01:36.4995516Z # 1  
2026-07-09T05:01:36.4995671Z # 2  
2026-07-09T05:01:36.4995823Z # 3  
2026-07-09T05:01:36.4995978Z # 4  
2026-07-09T05:01:36.4996133Z # 5  
2026-07-09T05:01:36.4996290Z # 6  
2026-07-09T05:01:36.4996446Z # 7  
2026-07-09T05:01:36.4996597Z # 8  
2026-07-09T05:01:36.4996749Z # 9  
2026-07-09T05:01:36.4996901Z # 10 
2026-07-09T05:01:36.4997059Z # 11 
2026-07-09T05:01:36.4997218Z # 12 
```
This PR adds a check to determine whether the hash table is pre-built. If it is not, `useHashTableCache` will be disabled automatically.

## How was this patch tested?

Existing tests
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
