### PR TITLE
[MINOR][CORE] Fix self-suppress in TaskResources.runUnsafe error handler

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/task/TaskResources.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/task/TaskResources.scala
@@ -104,8 +104,8 @@ object TaskResources extends TaskListener with Logging {
             try {
               context.markTaskFailed(t)
             } catch {
-              case t: Throwable =>
-                t.addSuppressed(t)
+              case markFailure: Throwable =>
+                t.addSuppressed(markFailure)
             }
             context.markTaskCompleted(Some(t))
             throw t


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the inner `catch (t: Throwable)` binding in `TaskResources.runUnsafe` so it no longer shadows the outer `t`. The inner catch handles a failure of `context.markTaskFailed(t)`; the intent is to attach that follow-up as a suppressed exception to the original body failure, but the shared name currently makes `t.addSuppressed(t)` attach the follow-up to itself.

### Why are the changes needed?

Pure diagnostic. On a task where the body throws and `markTaskFailed` also throws, the original exception loses the reference to why cleanup failed. The task still fails with the correct root cause because `throw t` re-raises the outer `t` two lines below.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

`mvn -pl gluten-core -Pspark-3.5 spotless:check` and `compile` pass. Behavior change is limited to the error-suppression chain on a rare double-failure path; no test added.