### PR TITLE
[MINOR] Fix Scala test cache invalidation for suffixed source roots

### DIFF
--- a/dev/run-scala-test.sh
+++ b/dev/run-scala-test.sh
@@ -459,7 +459,7 @@ can_skip_maven() {
        -o -path "*/.profiler" -o -path "*/.mvn" \) -prune -o \
     -newer "$BUILD_SENTINEL" \( \
       -name "pom.xml" -o \
-      \( -path "*/src/*" \( -name "*.scala" -o -name "*.java" \) \) \
+      \( -path "*/src*/*" \( -name "*.scala" -o -name "*.java" \) \) \
     \) -print 2>/dev/null | head -1)
 
   [[ -z "$changed" ]]


### PR DESCRIPTION
## What changes are proposed in this pull request?

The Scala test runner's Maven cache invalidation only matched source files under directories named exactly `src`. Changes under profile-specific source roots such as `src-paimon` and `src-delta` could therefore reuse stale compiled classes.

Expand the path match to `src*` so both standard and profile-specific source roots invalidate the cache.

## How was this patch tested?

- `bash -n dev/run-scala-test.sh`
- `git diff --check`
- Verified that the updated `find` pattern matches source files under `gluten-paimon/src-paimon` and `backends-velox/src-delta`

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex GPT-5
