### PR TITLE
[GLUTEN-12474][CORE] Preserve V1 write ordering for dynamic partition writes

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
@@ -17,10 +17,12 @@
 package org.apache.gluten.extension.columnar
 
 import org.apache.gluten.extension.columnar.heuristic.HeuristicTransform
+import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.execution.{SortExec, SparkPlan}
+import org.apache.spark.sql.execution.{ColumnarWriteFilesExec, SortExec, SparkPlan}
+import org.apache.spark.sql.execution.datasources.WriteFilesExec
 
 /**
  * This rule is similar with `EnsureRequirements` but only handle local `SortExec`.
@@ -33,6 +35,24 @@ import org.apache.spark.sql.execution.{SortExec, SparkPlan}
 object EnsureLocalSortRequirements extends Rule[SparkPlan] {
   private lazy val transform: HeuristicTransform = HeuristicTransform.static()
 
+  private def requiredChildOrdering(plan: SparkPlan): Seq[Seq[SortOrder]] = {
+    plan match {
+      // V1Writes assumes that the logical ordering it prepared is preserved in the physical plan,
+      // so WriteFilesExec does not expose requiredChildOrdering itself. Gluten may invalidate that
+      // ordering when it replaces a SortAggregateExec with a hash aggregate.
+      case writeFiles: WriteFilesExec
+          if ColumnarWriteFilesExec.OnNoopLeafPath.unapply(writeFiles).isEmpty =>
+        Seq(
+          SparkShimLoader.getSparkShims.getV1WriteRequiredOrdering(
+            writeFiles.child.output,
+            writeFiles.partitionColumns,
+            writeFiles.bucketSpec,
+            writeFiles.options,
+            writeFiles.staticPartitions.size))
+      case _ => plan.requiredChildOrdering
+    }
+  }
+
   private def addLocalSort(
       originalChild: SparkPlan,
       requiredOrdering: Seq[SortOrder]): SparkPlan = {
@@ -44,7 +64,7 @@ object EnsureLocalSortRequirements extends Rule[SparkPlan] {
   override def apply(plan: SparkPlan): SparkPlan = {
     plan.transformUp {
       case p =>
-        val newChildren = p.children.zip(p.requiredChildOrdering).map {
+        val newChildren = p.children.zip(requiredChildOrdering(p)).map {
           case (child, requiredOrdering) =>
             // If child.outputOrdering already satisfies the requiredOrdering,
             // we do not need to sort.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
@@ -42,8 +42,7 @@ object EnsureLocalSortRequirements extends Rule[SparkPlan] {
     val resolver = SQLConf.get.resolver
     val staticPartitionNames = writeFiles.staticPartitions.keys
     writeFiles.partitionColumns.takeWhile {
-      partitionColumn =>
-        staticPartitionNames.exists(resolver(_, partitionColumn.name))
+      partitionColumn => staticPartitionNames.exists(resolver(_, partitionColumn.name))
     }.size
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarWriteFilesExec, SortExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.WriteFilesExec
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * This rule is similar with `EnsureRequirements` but only handle local `SortExec`.
@@ -34,6 +35,17 @@ import org.apache.spark.sql.execution.datasources.WriteFilesExec
  */
 object EnsureLocalSortRequirements extends Rule[SparkPlan] {
   private lazy val transform: HeuristicTransform = HeuristicTransform.static()
+
+  private def numStaticPartitionCols(writeFiles: WriteFilesExec): Int = {
+    // HadoopFs writes include static partition columns in partitionColumns, while Hive writes may
+    // only include the partition columns that are present in the write query.
+    val resolver = SQLConf.get.resolver
+    val staticPartitionNames = writeFiles.staticPartitions.keys
+    writeFiles.partitionColumns.takeWhile {
+      partitionColumn =>
+        staticPartitionNames.exists(resolver(_, partitionColumn.name))
+    }.size
+  }
 
   private def requiredChildOrdering(plan: SparkPlan): Seq[Seq[SortOrder]] = {
     plan match {
@@ -48,7 +60,7 @@ object EnsureLocalSortRequirements extends Rule[SparkPlan] {
             writeFiles.partitionColumns,
             writeFiles.bucketSpec,
             writeFiles.options,
-            writeFiles.staticPartitions.size))
+            numStaticPartitionCols(writeFiles)))
       case _ => plan.requiredChildOrdering
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.gluten.extension.columnar
 
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.heuristic.HeuristicTransform
 import org.apache.gluten.sql.shims.SparkShimLoader
 
@@ -65,11 +66,19 @@ object EnsureLocalSortRequirements extends Rule[SparkPlan] {
   }
 
   private def addLocalSort(
+      plan: SparkPlan,
       originalChild: SparkPlan,
       requiredOrdering: Seq[SortOrder]): SparkPlan = {
     // FIXME: HeuristicTransform is costly. Re-applying it may cause performance issues.
     val newChild = SortExec(requiredOrdering, global = false, child = originalChild)
-    transform.apply(newChild)
+    (plan, originalChild) match {
+      case (_, child: GlutenPlan) if child.supportsColumnar =>
+        transform.apply(newChild)
+      case (parent: GlutenPlan, _) if parent.supportsColumnar =>
+        transform.apply(newChild)
+      case _ =>
+        newChild
+    }
   }
 
   override def apply(plan: SparkPlan): SparkPlan = {
@@ -82,7 +91,7 @@ object EnsureLocalSortRequirements extends Rule[SparkPlan] {
             if (SortOrder.orderingSatisfies(child.outputOrdering, requiredOrdering)) {
               child
             } else {
-              addLocalSort(child, requiredOrdering)
+              addLocalSort(p, child, requiredOrdering)
             }
         }
         p.withNewChildren(newChildren)

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
@@ -98,6 +98,41 @@ class GlutenV1WriteCommandSuite
   with GlutenV1WriteCommandSuiteBase
   with GlutenSQLTestsBaseTrait {
 
+  testGluten("GLUTEN-12474: preserve ordering for dynamic partition writes") {
+    withSQLConf(
+      "spark.sql.maxConcurrentOutputFileWriters" -> "0",
+      "spark.sql.sources.partitionOverwriteMode" -> "DYNAMIC") {
+      withTable("gluten_12474_src", "gluten_12474_tgt") {
+        sql(
+          """
+            |CREATE TABLE gluten_12474_src USING ORC AS
+            |SELECT concat('k', id) AS k, format_string('v%02d', id) AS v,
+            |  if(id % 2 = 1, '2026-06-01', '2026-06-02') AS day
+            |FROM range(0, 10)
+            |""".stripMargin)
+
+        sql(
+          """
+            |CREATE TABLE gluten_12474_tgt (k STRING, m STRING)
+            |USING ORC
+            |PARTITIONED BY (day STRING)
+            |""".stripMargin)
+
+        sql(
+          """
+            |INSERT OVERWRITE TABLE gluten_12474_tgt PARTITION (day)
+            |SELECT k, max(v) AS m, day
+            |FROM gluten_12474_src
+            |GROUP BY day, k
+            |""".stripMargin)
+
+        checkAnswer(
+          sql("SELECT k, m, day FROM gluten_12474_tgt"),
+          sql("SELECT k, v, day FROM gluten_12474_src"))
+      }
+    }
+  }
+
   testGluten(
     "SPARK-41914: v1 write with AQE and in-partition sorted - non-string partition column") {
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
@@ -100,6 +100,41 @@ class GlutenV1WriteCommandSuite
   with GlutenSQLTestsBaseTrait
   with GlutenColumnarWriteTestSupport {
 
+  testGluten("GLUTEN-12474: preserve ordering for dynamic partition writes") {
+    withSQLConf(
+      "spark.sql.maxConcurrentOutputFileWriters" -> "0",
+      "spark.sql.sources.partitionOverwriteMode" -> "DYNAMIC") {
+      withTable("gluten_12474_src", "gluten_12474_tgt") {
+        sql(
+          """
+            |CREATE TABLE gluten_12474_src USING ORC AS
+            |SELECT concat('k', id) AS k, format_string('v%02d', id) AS v,
+            |  if(id % 2 = 1, '2026-06-01', '2026-06-02') AS day
+            |FROM range(0, 10)
+            |""".stripMargin)
+
+        sql(
+          """
+            |CREATE TABLE gluten_12474_tgt (k STRING, m STRING)
+            |USING ORC
+            |PARTITIONED BY (day STRING)
+            |""".stripMargin)
+
+        sql(
+          """
+            |INSERT OVERWRITE TABLE gluten_12474_tgt PARTITION (day)
+            |SELECT k, max(v) AS m, day
+            |FROM gluten_12474_src
+            |GROUP BY day, k
+            |""".stripMargin)
+
+        checkAnswer(
+          sql("SELECT k, m, day FROM gluten_12474_tgt"),
+          sql("SELECT k, v, day FROM gluten_12474_src"))
+      }
+    }
+  }
+
   testGluten(
     "SPARK-41914: v1 write with AQE and in-partition sorted - non-string partition column") {
     withSQLConf(SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "true") {

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
@@ -100,6 +100,41 @@ class GlutenV1WriteCommandSuite
   with GlutenSQLTestsBaseTrait
   with GlutenColumnarWriteTestSupport {
 
+  testGluten("GLUTEN-12474: preserve ordering for dynamic partition writes") {
+    withSQLConf(
+      "spark.sql.maxConcurrentOutputFileWriters" -> "0",
+      "spark.sql.sources.partitionOverwriteMode" -> "DYNAMIC") {
+      withTable("gluten_12474_src", "gluten_12474_tgt") {
+        sql(
+          """
+            |CREATE TABLE gluten_12474_src USING ORC AS
+            |SELECT concat('k', id) AS k, format_string('v%02d', id) AS v,
+            |  if(id % 2 = 1, '2026-06-01', '2026-06-02') AS day
+            |FROM range(0, 10)
+            |""".stripMargin)
+
+        sql(
+          """
+            |CREATE TABLE gluten_12474_tgt (k STRING, m STRING)
+            |USING ORC
+            |PARTITIONED BY (day STRING)
+            |""".stripMargin)
+
+        sql(
+          """
+            |INSERT OVERWRITE TABLE gluten_12474_tgt PARTITION (day)
+            |SELECT k, max(v) AS m, day
+            |FROM gluten_12474_src
+            |GROUP BY day, k
+            |""".stripMargin)
+
+        checkAnswer(
+          sql("SELECT k, m, day FROM gluten_12474_tgt"),
+          sql("SELECT k, v, day FROM gluten_12474_src"))
+      }
+    }
+  }
+
   // TODO: fix in Spark-4.0
   ignoreGluten(
     "SPARK-41914: v1 write with AQE and in-partition sorted - non-string partition column") {

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/datasources/GlutenV1WriteCommandSuite.scala
@@ -100,6 +100,41 @@ class GlutenV1WriteCommandSuite
   with GlutenSQLTestsBaseTrait
   with GlutenColumnarWriteTestSupport {
 
+  testGluten("GLUTEN-12474: preserve ordering for dynamic partition writes") {
+    withSQLConf(
+      "spark.sql.maxConcurrentOutputFileWriters" -> "0",
+      "spark.sql.sources.partitionOverwriteMode" -> "DYNAMIC") {
+      withTable("gluten_12474_src", "gluten_12474_tgt") {
+        sql(
+          """
+            |CREATE TABLE gluten_12474_src USING ORC AS
+            |SELECT concat('k', id) AS k, format_string('v%02d', id) AS v,
+            |  if(id % 2 = 1, '2026-06-01', '2026-06-02') AS day
+            |FROM range(0, 10)
+            |""".stripMargin)
+
+        sql(
+          """
+            |CREATE TABLE gluten_12474_tgt (k STRING, m STRING)
+            |USING ORC
+            |PARTITIONED BY (day STRING)
+            |""".stripMargin)
+
+        sql(
+          """
+            |INSERT OVERWRITE TABLE gluten_12474_tgt PARTITION (day)
+            |SELECT k, max(v) AS m, day
+            |FROM gluten_12474_src
+            |GROUP BY day, k
+            |""".stripMargin)
+
+        checkAnswer(
+          sql("SELECT k, m, day FROM gluten_12474_tgt"),
+          sql("SELECT k, v, day FROM gluten_12474_src"))
+      }
+    }
+  }
+
   // TODO: fix in Spark-4.0
   ignoreGluten(
     "SPARK-41914: v1 write with AQE and in-partition sorted - non-string partition column") {

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -24,7 +24,8 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BinaryArithmetic, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, RaiseError, UnBase64}
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BinaryArithmetic, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, RaiseError, SortOrder, UnBase64}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -128,6 +129,16 @@ trait SparkShims {
   }
 
   def enableNativeWriteFilesByDefault(): Boolean = false
+
+  // Planned V1 writes were introduced in Spark 3.4. Older versions do not expose a required
+  // ordering utility and keep the default empty ordering.
+  // TODO: Remove this shim after dropping Spark 3.3 support.
+  def getV1WriteRequiredOrdering(
+      outputColumns: Seq[Attribute],
+      partitionColumns: Seq[Attribute],
+      bucketSpec: Option[BucketSpec],
+      options: Map[String, String],
+      numStaticPartitionCols: Int): Seq[SortOrder] = Seq.empty
 
   def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
     // Since Spark 3.4, the `sc.broadcast` has been optimized to use `sc.broadcastInternal`.

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -27,6 +27,7 @@ import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
@@ -207,6 +208,20 @@ class Spark34Shims extends SparkShims {
   }
 
   override def enableNativeWriteFilesByDefault(): Boolean = true
+
+  override def getV1WriteRequiredOrdering(
+      outputColumns: Seq[Attribute],
+      partitionColumns: Seq[Attribute],
+      bucketSpec: Option[BucketSpec],
+      options: Map[String, String],
+      numStaticPartitionCols: Int): Seq[SortOrder] = {
+    V1WritesUtils.getSortOrder(
+      outputColumns,
+      partitionColumns,
+      bucketSpec,
+      options,
+      numStaticPartitionCols)
+  }
 
   override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
     SparkContextUtils.broadcastInternal(sc, value)

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -27,6 +27,7 @@ import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
@@ -248,6 +249,20 @@ class Spark35Shims extends SparkShims {
   }
 
   override def enableNativeWriteFilesByDefault(): Boolean = true
+
+  override def getV1WriteRequiredOrdering(
+      outputColumns: Seq[Attribute],
+      partitionColumns: Seq[Attribute],
+      bucketSpec: Option[BucketSpec],
+      options: Map[String, String],
+      numStaticPartitionCols: Int): Seq[SortOrder] = {
+    V1WritesUtils.getSortOrder(
+      outputColumns,
+      partitionColumns,
+      bucketSpec,
+      options,
+      numStaticPartitionCols)
+  }
 
   override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
     SparkContextUtils.broadcastInternal(sc, value)

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -27,6 +27,7 @@ import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
@@ -253,6 +254,20 @@ class Spark40Shims extends SparkShims {
   }
 
   override def enableNativeWriteFilesByDefault(): Boolean = true
+
+  override def getV1WriteRequiredOrdering(
+      outputColumns: Seq[Attribute],
+      partitionColumns: Seq[Attribute],
+      bucketSpec: Option[BucketSpec],
+      options: Map[String, String],
+      numStaticPartitionCols: Int): Seq[SortOrder] = {
+    V1WritesUtils.getSortOrder(
+      outputColumns,
+      partitionColumns,
+      bucketSpec,
+      options,
+      numStaticPartitionCols)
+  }
 
   override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
     SparkContextUtils.broadcastInternal(sc, value)

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -27,6 +27,7 @@ import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
+import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
@@ -252,6 +253,20 @@ class Spark41Shims extends SparkShims {
   }
 
   override def enableNativeWriteFilesByDefault(): Boolean = true
+
+  override def getV1WriteRequiredOrdering(
+      outputColumns: Seq[Attribute],
+      partitionColumns: Seq[Attribute],
+      bucketSpec: Option[BucketSpec],
+      options: Map[String, String],
+      numStaticPartitionCols: Int): Seq[SortOrder] = {
+    V1WritesUtils.getSortOrder(
+      outputColumns,
+      partitionColumns,
+      bucketSpec,
+      options,
+      numStaticPartitionCols)
+  }
 
   override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
     SparkContextUtils.broadcastInternal(sc, value)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #12474.

Spark V1 writes prepare an ordering for partition and bucket columns before physical planning. `WriteFilesExec` assumes this ordering is preserved and therefore does not expose it through `requiredChildOrdering`.

Gluten may replace `SortAggregateExec` with a hash aggregate, which invalidates the ordering prepared by Spark. For dynamic partition writes using a single output writer, rows from the same partition may then become non-contiguous. This can cause the writer to reopen an existing output file and fail with `FileAlreadyExistsException`.

This PR:

- derives the required V1 write ordering for `WriteFilesExec` in `EnsureLocalSortRequirements`;
- inserts a local sort when the transformed child no longer satisfies that ordering;
- handles static partition columns for both Hadoop filesystem and Hive writes;
- adds Spark-version shims around `V1WritesUtils.getSortOrder` for Spark 3.4 through 4.1, while retaining empty ordering for Spark 3.3;
- avoids unnecessarily applying the columnar heuristic transform when both the parent and child use the row path.

## How was this patch tested?

Added a regression test to `GlutenV1WriteCommandSuite` for Spark 3.4, 3.5, 4.0, and 4.1.

The test performs a dynamic partition overwrite after an aggregation with:

- `spark.sql.maxConcurrentOutputFileWriters=0`
- `spark.sql.sources.partitionOverwriteMode=DYNAMIC`

It verifies that the write completes successfully and that the target table contains the expected rows. The test was also confirmed to reproduce the original write failure before applying the fix.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)