### PR TITLE
[GLUTEN-12394][CORE] Consolidate JniLibLoader.load() as a thin delegate of loadAndCreateLink()

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
+++ b/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
@@ -95,8 +95,9 @@ public class JniLibLoader {
 
   /**
    * Same contract as {@link #load(String)}, with the addition of creating a symbolic link named
-   * {@code linkName} in {@code workDir} pointing at the extracted library. Passing a null {@code
-   * linkName} skips the link creation.
+   * {@code linkName} in {@code workDir} pointing at the extracted library. Returns immediately if
+   * {@code libPath} was already loaded by this instance. Passing a null {@code linkName} skips the
+   * link creation.
    */
   public synchronized void loadAndCreateLink(String libPath, String linkName) {
     try {

--- a/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
+++ b/gluten-core/src/main/java/org/apache/gluten/jni/JniLibLoader.java
@@ -85,25 +85,18 @@ public class JniLibLoader {
     loadFromPath0(file.getAbsolutePath());
   }
 
+  /**
+   * Extracts the library resource {@code libPath} to {@code workDir} and loads it. Returns
+   * immediately if {@code libPath} was already loaded by this instance.
+   */
   public synchronized void load(String libPath) {
-    try {
-      if (loadedLibraries.contains(libPath)) {
-        LOG.debug("Library {} has already been loaded, skipping", libPath);
-        return;
-      }
-      File file = moveToWorkDir(workDir, libPath);
-      loadWithLink(file.getAbsolutePath(), null);
-      loadedLibraries.add(libPath);
-      LOG.info("Successfully loaded library {}", libPath);
-    } catch (IOException e) {
-      throw new GlutenException(e);
-    }
+    loadAndCreateLink(libPath, null);
   }
 
   /**
    * Same contract as {@link #load(String)}, with the addition of creating a symbolic link named
-   * {@code linkName} in {@code workDir} pointing at the extracted library. Returns immediately if
-   * {@code libPath} was already loaded by this instance.
+   * {@code linkName} in {@code workDir} pointing at the extracted library. Passing a null {@code
+   * linkName} skips the link creation.
    */
   public synchronized void loadAndCreateLink(String libPath, String linkName) {
     try {


### PR DESCRIPTION
## What changes are proposed in this pull request?

After #12393, `JniLibLoader.load(libPath)` and `JniLibLoader.loadAndCreateLink(libPath, null)` are behaviorally identical: same already-loaded dedup check, same extraction to the work dir, same load call, same logging, same exception wrapping. The only difference is the `linkName` argument, and `loadWithLink` already skips the symlink branch when `linkName == null`.

This PR removes the duplication by making `load()` a one-line delegate of `loadAndCreateLink(libPath, null)`, so there is a single copy of the loading sequence to evolve, and updates the Javadoc of both methods accordingly.

No behavior change.

Fixes #12394

## How was this patch tested?

Existing `JniLibLoaderTest` passes (`mvn test -pl gluten-core -Pspark-3.5 -Dtest=JniLibLoaderTest`).

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code