### PR TITLE
[MINOR][CORE] Remove residual Spark 3.2 compatibility code in gluten-core

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenPlan.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/execution/GlutenPlan.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.gluten.execution
 
-import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 
 import org.apache.spark.sql.execution.SparkPlan
@@ -26,7 +25,7 @@ import org.apache.spark.sql.execution.SparkPlan
  *
  * The following Spark APIs are marked final so forbidden from overriding:
  *   - supportsColumnar
- *   - supportsRowBased (Spark version >= 3.3)
+ *   - supportsRowBased
  *
  * Instead, subclasses are expected to implement the following APIs:
  *   - batchType
@@ -46,7 +45,6 @@ trait GlutenPlan
   extends SparkPlan
   with Convention.KnownBatchType
   with Convention.KnownRowType
-  with GlutenPlan.SupportsRowBasedCompatible
   with ConventionReq.KnownChildConvention {
 
   final override val supportsColumnar: Boolean = {
@@ -75,14 +73,5 @@ trait GlutenPlan
       _ => {
         childReq
       })
-  }
-}
-
-object GlutenPlan {
-  // To be compatible with Spark (version < 3.3)
-  trait SupportsRowBasedCompatible {
-    def supportsRowBased(): Boolean = {
-      throw new GlutenException("Illegal state: The method is not expected to be called")
-    }
   }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AQEShuffleReadExec
 import org.apache.spark.sql.execution.debug.DebugExec
-import org.apache.spark.util.SparkVersionUtil
 
 package object transition {
 
@@ -35,8 +34,7 @@ package object transition {
   // Extend this list in shim layer once Spark has more.
   def canPropagateConvention(plan: SparkPlan): Boolean = plan match {
     case p: DebugExec => true
-    case p: UnionExec if SparkVersionUtil.gteSpark33 =>
-      true
+    case p: UnionExec => true
     case p: AQEShuffleReadExec => true
     case p: InputAdapter => true
     case p: WholeStageCodegenExec => true

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkPlanUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkPlanUtil.scala
@@ -23,8 +23,7 @@ import org.apache.spark.sql.internal.SQLConf
 object SparkPlanUtil {
 
   def supportsRowBased(plan: SparkPlan): Boolean = {
-    val m = classOf[SparkPlan].getMethod("supportsRowBased")
-    m.invoke(plan).asInstanceOf[Boolean]
+    plan.supportsRowBased
   }
 
   def isPlannedV1Write(plan: DataWritingCommandExec): Boolean = {

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkVersionUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkVersionUtil.scala
@@ -20,7 +20,6 @@ object SparkVersionUtil {
   private val comparedWithSpark33 = compareMajorMinorVersion((3, 3))
   private val comparedWithSpark35 = compareMajorMinorVersion((3, 5))
   val eqSpark33: Boolean = comparedWithSpark33 == 0
-  val gteSpark33: Boolean = comparedWithSpark33 >= 0
   val gteSpark35: Boolean = comparedWithSpark35 >= 0
   val gteSpark40: Boolean = compareMajorMinorVersion((4, 0)) >= 0
   val gteSpark41: Boolean = compareMajorMinorVersion((4, 1)) >= 0

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -220,7 +220,6 @@ case class ColumnarInputAdapter(child: SparkPlan)
   extends InputAdapterGenerateTreeStringShim
   with Convention.KnownBatchType
   with Convention.KnownRowType
-  with GlutenPlan.SupportsRowBasedCompatible
   with ConventionReq.KnownChildConvention {
   override def output: Seq[Attribute] = child.output
   final override val supportsColumnar: Boolean = true


### PR DESCRIPTION
### What changes were proposed in this pull request?

Spark 3.2 support was removed in prior PRs (#11351, #11687, #11731, #11887); currently supported versions are Spark 3.3, 3.4, 3.5, 4.0, 4.1. A few symbols that existed only as pre-Spark-3.3 shims are still around and dead code today.

1. `GlutenPlan.SupportsRowBasedCompatible` trait

   Introduced to provide `def supportsRowBased(): Boolean` for Spark < 3.3 where `SparkPlan.supportsRowBased` did not exist yet. The default body was `throw new GlutenException("Illegal state: The method is not expected to be called")`. On Spark 3.3+, `SparkPlan.supportsRowBased` is native and every concrete `GlutenPlan` / `ColumnarInputAdapter` overrides it directly, so the trait's default was already unreachable. Drop the trait and its two mixin sites.

2. `SparkVersionUtil.gteSpark33`

   Always true after Spark 3.2 was dropped. Also drop the single caller guard in `canPropagateConvention` (Transitions), which no longer needs to skip `UnionExec` on Spark 3.2. `eqSpark33` and `comparedWithSpark33` are kept: they distinguish Spark 3.3 from 3.4+ (different `TaskContextImpl` ctor signature and different write planning API), which is unrelated to the Spark 3.2 residual concern.

3. `SparkPlanUtil.supportsRowBased` reflection

   The reflection was needed on Spark 3.2 because `SparkPlan.supportsRowBased` did not exist as a member yet; the same compiled artifact ran on 3.2 and 3.3+ only by resolving the method reflectively at call time. Now that Spark 3.2 is dropped, a direct call `plan.supportsRowBased` compiles on all supported profiles and is strictly better (primitive `Boolean` instead of boxed, no per-call `getMethod` lookup, no `InvocationTargetException` wrapping). The 3 callers in `ConventionFunc` are on the planning hot path.

### How was this patch tested?

Verified via compile on Spark 3.3, 3.5, and 4.1 (scala-2.13) profiles, plus `gluten-core` and `gluten-substrait` tests on Spark 3.5. All 27 + 45 unit tests pass. `scalastyle` and `spotless` clean.