### PR TITLE
[VL] Add hash table memory usage metric when enabling spark.gluten.velox.buildHashTableOncePerExecutor.enabled

### DIFF
--- a/backends-velox/src/main/java/org/apache/gluten/vectorized/HashJoinBuilder.java
+++ b/backends-velox/src/main/java/org/apache/gluten/vectorized/HashJoinBuilder.java
@@ -48,6 +48,8 @@ public class HashJoinBuilder implements RuntimeAware {
 
   public static native long getHashTableBloomFilterBlocksByteSize(long hashTableHandle);
 
+  public static native long getHashTableMemoryUsage(long hashTableHandle);
+
   public static native long serializedHashTableSizeDirect(long hashTableHandle);
 
   public static native void serializeHashTableDirect(long hashTableHandle, long address, long size);

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxMetricsApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxMetricsApi.scala
@@ -727,7 +727,10 @@ class VeloxMetricsApi extends MetricsApi with Logging {
         "time to build hash table"),
       "deserializeHashTableTime" -> SQLMetrics.createTimingMetric(
         sparkContext,
-        "time to deserialize hash table")
+        "time to deserialize hash table"),
+      "hashTableMemorySize" -> SQLMetrics.createSizeMetric(
+        sparkContext,
+        "hash table memory size")
     )
 
   override def genHashJoinTransformerMetricsUpdater(

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/HashJoinExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/HashJoinExecTransformer.scala
@@ -181,7 +181,8 @@ case class BroadcastHashJoinExecTransformer(
         metrics.get("buildHashTableTime"),
         metrics.get("serializeHashTableTime"),
         metrics.get("deserializeHashTableTime"),
-        metrics.get("serializedHashTableSize")
+        metrics.get("serializedHashTableSize"),
+        metrics.get("hashTableMemorySize")
       )
 
     // Check the type of broadcast relation to determine the approach
@@ -265,7 +266,8 @@ case class BroadcastHashJoinContext(
     buildHashTableTimeMetric: Option[SQLMetric] = None,
     serializeHashTableTimeMetric: Option[SQLMetric] = None,
     deserializeHashTableTimeMetric: Option[SQLMetric] = None,
-    serializedHashTableSizeMetric: Option[SQLMetric] = None) {
+    serializedHashTableSizeMetric: Option[SQLMetric] = None,
+    hashTableMemorySizeMetric: Option[SQLMetric] = None) {
   def droppedDuplicates: Boolean = {
     !hasMixedFiltCondition && (
       substraitJoinType == JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI ||

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxBroadcastBuildSideCache.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/VeloxBroadcastBuildSideCache.scala
@@ -98,6 +98,9 @@ object VeloxBroadcastBuildSideCache
               unsafe.buildHashTable(broadcastContext)
           }
 
+          broadcastContext.hashTableMemorySizeMetric.foreach(
+            _ += HashJoinBuilder.getHashTableMemoryUsage(pointer))
+
           BroadcastHashTable(pointer, relation, droppedDuplicates)
         }
       )

--- a/cpp/velox/jni/JniHashTable.cc
+++ b/cpp/velox/jni/JniHashTable.cc
@@ -180,6 +180,11 @@ size_t serializedHashTableSize(std::shared_ptr<HashTableBuilder> builder) {
   return HashTableSerializer::serializedSize<true>(hashTableTrue);
 }
 
+int64_t hashTableMemoryUsage(std::shared_ptr<HashTableBuilder> builder) {
+  VELOX_CHECK_NOT_NULL(builder, "Hash table builder cannot be null");
+  return builder->hashTableMemoryUsage();
+}
+
 void serializeHashTableTo(std::shared_ptr<HashTableBuilder> builder, uint8_t* data, size_t size) {
   VELOX_CHECK_NOT_NULL(builder, "Hash table builder cannot be null");
   VELOX_CHECK_NOT_NULL(data, "Serialized buffer cannot be null");

--- a/cpp/velox/jni/JniHashTable.h
+++ b/cpp/velox/jni/JniHashTable.h
@@ -94,6 +94,9 @@ long getJoin(const std::string& hashTableId);
 // Return the exact serialized hash table size for direct buffer allocation.
 size_t serializedHashTableSize(std::shared_ptr<HashTableBuilder> builder);
 
+// Return retained bytes for the hash table, including parallel-build subtables.
+int64_t hashTableMemoryUsage(std::shared_ptr<HashTableBuilder> builder);
+
 // Serialize hash table directly to a caller-provided buffer.
 void serializeHashTableTo(std::shared_ptr<HashTableBuilder> builder, uint8_t* data, size_t size);
 

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -1054,6 +1054,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_HashJoinBuilder_native
         builder->dropDuplicates(),
         nullptr);
     builder->setHashTable(std::move(mainTable));
+    builder->setHashTableMemoryUsage(builder->hashTable()->allocatedBytes());
 
     auto* cache = facebook::velox::exec::HashTableCache::instance();
 
@@ -1122,6 +1123,10 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_HashJoinBuilder_native
   for (int i = 1; i < numThreads; ++i) {
     tables.push_back(std::move(otherTables[i]));
   }
+  int64_t otherTablesMemoryUsage = 0;
+  for (const auto& table : tables) {
+    otherTablesMemoryUsage += table->allocatedBytes();
+  }
 
   // TODO: Get accurate signal if parallel join build is going to be applied
   //  from hash table. Currently there is still a chance inside hash table that
@@ -1143,6 +1148,8 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_HashJoinBuilder_native
   }
 
   hashTableBuilders[0]->setHashTable(std::move(mainTable));
+  hashTableBuilders[0]->setHashTableMemoryUsage(
+      hashTableBuilders[0]->hashTable()->allocatedBytes() + otherTablesMemoryUsage);
 
   auto* cache = facebook::velox::exec::HashTableCache::instance();
   if (!cache->exist(hashTableId)) {
@@ -1257,6 +1264,16 @@ Java_org_apache_gluten_vectorized_HashJoinBuilder_getHashTableBloomFilterBlocksB
     }
   }
   return static_cast<jlong>(bloomFilterBlocksByteSize);
+  JNI_METHOD_END(0L)
+}
+
+JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_HashJoinBuilder_getHashTableMemoryUsage( // NOLINT
+    JNIEnv* env,
+    jclass,
+    jlong hashTableHandle) {
+  JNI_METHOD_START
+  auto builder = ObjectStore::retrieve<gluten::HashTableBuilder>(hashTableHandle);
+  return static_cast<jlong>(gluten::hashTableMemoryUsage(builder));
   JNI_METHOD_END(0L)
 }
 

--- a/cpp/velox/operators/hashjoin/HashTableBuilder.h
+++ b/cpp/velox/operators/hashjoin/HashTableBuilder.h
@@ -75,6 +75,14 @@ class HashTableBuilder {
     return noMoreInput_;
   }
 
+  void setHashTableMemoryUsage(int64_t hashTableMemoryUsage) {
+    hashTableMemoryUsage_ = hashTableMemoryUsage;
+  }
+
+  int64_t hashTableMemoryUsage() const {
+    return hashTableMemoryUsage_;
+  }
+
   uint32_t joinBuildVectorHasherMaxNumDistinct() const {
     return joinBuildVectorHasherMaxNumDistinct_;
   }
@@ -150,6 +158,7 @@ class HashTableBuilder {
   uint32_t abandonHashBuildDedupMinRows_{100'000};
   uint32_t abandonHashBuildDedupMinPct_{0};
   bool filterPropagatesNulls_{false};
+  int64_t hashTableMemoryUsage_{0};
 };
 
 } // namespace gluten


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

Add hash table memory usage metric when enabling spark.gluten.velox.buildHashTableOncePerExecutor.enabled.

<img width="416" height="278" alt="image" src="https://github.com/user-attachments/assets/5924631f-5aee-4ce3-82ef-390889dea06d" />


## How was this patch tested?
local verified
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
