### PR TITLE
[VL] Fix macOS libvelox linking with Velox dbgen

### DIFF
--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -323,12 +323,14 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   set(GLUTEN_VELOX_LINK_SCOPE PRIVATE)
 endif()
 
-if(BUILD_TESTS)
-  add_duckdb()
-
+if(BUILD_TESTS OR CMAKE_SYSTEM_NAME MATCHES "Darwin")
   import_library(facebook::velox::dbgen
                  ${VELOX_BUILD_PATH}/velox/tpch/gen/dbgen/libdbgen.a)
   target_link_libraries(facebook::velox INTERFACE facebook::velox::dbgen)
+endif()
+
+if(BUILD_TESTS)
+  add_duckdb()
 
   import_library(
     facebook::velox::vector_test_lib


### PR DESCRIPTION

## What changes are proposed in this pull request?

Fix the following macOS linker failure when building `libvelox.dylib` with
`BUILD_TESTS=OFF`:

```text
Undefined symbols for architecture arm64:
  facebook::velox::tpch::dbgen::load_dists(...)
  facebook::velox::tpch::dbgen::mk_order(...)
  facebook::velox::tpch::dbgen::mk_part(...)
  facebook::velox::tpch::dbgen::mk_cust(...)
  facebook::velox::tpch::dbgen::row_start(...)
  facebook::velox::tpch::dbgen::row_stop_h(...)
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1
On macOS, Gluten force-loads the Velox mono archive into libvelox.dylib.
This also pulls in DBGenIterator.cpp.o, whose TPCH dbgen symbols are provided
by libdbgen.a. Previously, libdbgen.a was linked only when
BUILD_TESTS=ON.
This change also links Velox dbgen on macOS, while preserving the existing
behavior on other platforms.
```

## How was this patch tested?

Local macOS build test.

## Was this patch authored or co-authored using generative AI tooling?

ChatGPT 5.6 Sol.
