### PR TITLE
[MINOR][CORE] Remove stale libhdfs install rule

### DIFF
--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -230,19 +230,11 @@ if(BUILD_TESTS)
   add_subdirectory(tests)
 endif()
 
-if(DEFINED ENV{HADOOP_HOME})
-  set(LIBHDFS3_DESTINATION $ENV{HADOOP_HOME}/lib/native)
-else()
-  set(LIBHDFS3_DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()
-
 target_link_libraries(gluten PUBLIC Arrow::arrow
                                     Arrow::arrow_bundled_dependencies)
 target_link_libraries(gluten PRIVATE google::glog)
 
 install(TARGETS gluten DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/resources/libhdfs.so
-        DESTINATION ${LIBHDFS3_DESTINATION})
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   add_custom_command(


### PR DESCRIPTION
### What changes are proposed in this pull request?

Remove the stale CMake install rule for the deleted `cpp/core/resources/libhdfs.so` binary, together with the now-unused `LIBHDFS3_DESTINATION` variable.

This does not change HDFS runtime support. `libhdfs.so` remains an external runtime dependency loaded dynamically from the Hadoop installation.

### How was this patch tested?

Test manully.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex 0.144.4 (GPT-5)