### PR TITLE
[GLUTEN-11550][VL] Fix GlutenSetCommandSuite in Spark 4.x

### DIFF
--- a/gluten-ut/spark40/src/test/resources/hive-site.xml
+++ b/gluten-ut/spark40/src/test/resources/hive-site.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+  <property>
+    <name>hive.in.test</name>
+    <value>true</value>
+    <description>Internal marker for test.</description>
+  </property>
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>/tmp/hive_one</value>
+    <description>default is /tmp/hadoop-${user.name} and will be overridden</description>
+  </property>
+  <property>
+    <name>hadoop.this.is.a.test.key</name>
+    <value>2018-11-17 13:33:33.333</value>
+  </property>
+</configuration>

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -895,7 +895,7 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenRuntimeConfigSuite]
   enableSuite[GlutenSSBQuerySuite]
   enableSuite[GlutenSessionStateSuite]
-  // TODO: 4.x enableSuite[GlutenSetCommandSuite]  // 1 failure
+  enableSuite[GlutenSetCommandSuite]
   enableSuite[GlutenSparkSessionBuilderSuite]
   enableSuite[GlutenSparkSessionJobTaggingAndCancellationSuite]
     .exclude("Tags set from session are prefixed with session UUID")

--- a/gluten-ut/spark41/src/test/resources/hive-site.xml
+++ b/gluten-ut/spark41/src/test/resources/hive-site.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+  <property>
+    <name>hive.in.test</name>
+    <value>true</value>
+    <description>Internal marker for test.</description>
+  </property>
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>/tmp/hive_one</value>
+    <description>default is /tmp/hadoop-${user.name} and will be overridden</description>
+  </property>
+  <property>
+    <name>hadoop.this.is.a.test.key</name>
+    <value>2018-11-17 13:33:33.333</value>
+  </property>
+</configuration>

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -869,13 +869,13 @@ class VeloxTestSettings extends BackendTestSettings {
     // Overridden
     .exclude("Query Spark logs with exception using SQL")
   enableSuite[GlutenPercentileQuerySuite]
-  // TODO: 4.x enableSuite[GlutenRandomDataGeneratorSuite]  // 232 failures
+  enableSuite[GlutenRandomDataGeneratorSuite]
   enableSuite[GlutenRowJsonSuite]
   enableSuite[GlutenRowSuite]
   enableSuite[GlutenRuntimeConfigSuite]
   enableSuite[GlutenSSBQuerySuite]
   enableSuite[GlutenSessionStateSuite]
-  // TODO: 4.x enableSuite[GlutenSetCommandSuite]  // 1 failure
+  enableSuite[GlutenSetCommandSuite]
   enableSuite[GlutenSparkSessionBuilderSuite]
   enableSuite[GlutenSparkSessionJobTaggingAndCancellationSuite]
     .exclude("Tags set from session are prefixed with session UUID")


### PR DESCRIPTION
Added hive-site.xml to the Spark 4.x test resources because GlutenSetCommandSuite relies on the Hadoop configuration defined in Spark’s test environment.
The previously reported 232 failures in GlutenRandomDataGeneratorSuite on Spark 4.1 were local-environment issues: spark.test was not set, causing TimeType to be disabled.

Related issue: #11550