### PR TITLE
[CORE] Hide gflags namespace symbols in native core

### DIFF
--- a/cpp/core/symbols.map
+++ b/cpp/core/symbols.map
@@ -9,6 +9,7 @@
     extern "C++" {
       # Hide symbols of glog, gflags (protobuf is made global at above).
       *google::*;
+      *gflags::*;
       fL*::FLAGS_*;
       gflags_mutex_namespace::*;
       glog_internal_namespace_::*;


### PR DESCRIPTION
  ## What changes are proposed in this pull request?

The native core already links gflags, but its implementation is usually built in the `google` namespace, which is already hidden by the version script. The `gflags` namespace is normally only an alias and does not introduce additional symbols.

However, when gflags is built with `gflags` as its primary namespace, those symbols may be exported. This PR hides `gflags::*` as well, making the symbol isolation work for both configurations.

  ## How was this patch tested?

  - Used `readelf`/`nm` to verify that gflags namespace symbols are not exported from the resulting shared library.

  ## Was this patch authored or co-authored using generative AI tooling?

  Yes.

  Generated-by: Codex GPT-5