### PR TITLE
[VL][CI] Fix Spark 4.1 CI crash: isolate libgluten's bundled libstdc++

### DIFF
--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -163,6 +163,27 @@ add_dependencies(gluten jni_proto)
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
   target_link_options(
     gluten PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map)
+  # libgluten statically links libstdc++/libgcc (see dev/vcpkg/toolchain.cmake's
+  # -static-libstdc++ -static-libgcc). The version script above has no "local:
+  # *" catch-all (it must keep Arrow/substrait/etc. exported for libvelox to
+  # resolve against), so by default the bundled gcc-13 C++ runtime symbols also
+  # stay in libgluten's dynamic symbol table -- and the std::locale::id objects
+  # that index the facet table are emitted as STB_GNU_UNIQUE. When another
+  # libstdc++ is already loaded in the process (the system gcc-11 libstdc++.so.6
+  # pulled in by the JVM inside the centos-9 image), the loader collapses those
+  # unique ids into one process-wide definition; libgluten then indexes its
+  # gcc-13 facet table with the system id value, reads a bogus num_put/codecvt
+  # facet pointer, and crashes with SIGSEGV during Velox backend initialization
+  # (do_unshift, si_addr=0x30). -Bsymbolic does not help because STB_GNU_UNIQUE
+  # overrides it. --exclude-libs demotes the symbols coming from the named C++
+  # runtime archives to STB_LOCAL, dropping them from the dynamic symbol table
+  # entirely (this also clears their STB_GNU_UNIQUE binding) so they can neither
+  # interpose nor be interposed -- the same isolation libvelox already gets from
+  # its "local: *" map. Symbols from the other static deps (Arrow, substrait,
+  # ...) come from different archives and stay exported.
+  target_link_options(
+    gluten PRIVATE -Wl,--exclude-libs,libstdc++.a -Wl,--exclude-libs,libgcc.a
+    -Wl,--exclude-libs,libgcc_eh.a)
 endif()
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `spark-test-spark41` / `spark-test-spark41-slow` jobs in `Velox Backend (x86)` have been failing **consistently** (exit 134 / SIGABRT) since the mid-July GitHub-hosted runner image rollout (tracked in #12534). The forked Surefire JVM crashes with SIGSEGV during Velox backend initialization, before the first native test (`ColumnarBatchTest`) even runs:

```
# C  [libgluten.so+0xdb73a4]  std::__codecvt_utf16_base<char16_t>::do_unshift(...)+0x4
# siginfo: si_code: SEGV_MAPERR, si_addr: 0x0000000000000030
Java frames:
 org.apache.gluten.init.NativeBackendInitializer.initialize(...)
 org.apache.gluten.backendsapi.velox.VeloxListenerApi.onExecutorStart(...)
 org.apache.gluten.test.VeloxBackendTestBase.setup()
```

### Root cause (verified with `readelf` / `addr2line` on the CI artifact)

`libgluten.so` and `libvelox.so` both statically link the gcc-13 libstdc++ (`dev/vcpkg/toolchain.cmake`: `-static-libstdc++ -static-libgcc`).

- **libvelox** has a `local: *` catch-all in its `symbols.map`, so its bundled libstdc++ symbols are demoted to `STB_LOCAL` and never take part in global symbol resolution.
- **libgluten** *cannot* use `local: *` — it must keep Arrow/substrait exported for libvelox to link against — so its ~5000 bundled libstdc++ symbols stay in the dynamic symbol table. Critically, the `std::locale::id` objects that index the facet table are emitted as **`STB_GNU_UNIQUE`**.

Inside the `centos-9` image, the JVM pulls in the **system gcc-11 `libstdc++.so.6.0.29`**. The dynamic loader collapses libgluten's `STB_GNU_UNIQUE` locale ids into a single process-wide definition, so libgluten indexes its own gcc-13 facet table with the wrong id, reads a bogus `num_put`/`codecvt` facet pointer, and dereferences `null+0x30`.

The older `centos-8` system libstdc++ (gcc-8) is not new enough to interpose, which is exactly why **only the centos-9 spark41 jobs crashed** while `spark33`…`spark40` (centos-8), built from the *very same* native artifact, stayed green. This is not a code regression from any merged PR.

### Fix

Pass `-Wl,--exclude-libs` for the bundled C++ runtime archives (`libstdc++.a`, `libgcc.a`, `libgcc_eh.a`) when linking `libgluten`. This demotes those symbols to `STB_LOCAL` — which also clears the `STB_GNU_UNIQUE` binding — giving libgluten the same self-contained libstdc++ isolation libvelox already has, **without** hiding the Arrow/substrait symbols libvelox resolves against.

`-Bsymbolic` alone does **not** work here, because `STB_GNU_UNIQUE` overrides it (verified in a separate CI run).

**The CI workflow is unchanged — the Spark 4.1 jobs keep running on `centos-9-jdk17`.** The fix is purely in the native link step, so it addresses the image itself rather than side-stepping it.

## How was this patch tested?

Validated on a debug branch that trims the workflow to only the affected jobs and rebuilds the native libs with this change, keeping the container on **centos-9-jdk17**:

- `spark-test-spark41` — the SIGSEGV is gone; `ColumnarBatchTest`, `arrow batched python udf over parquet scan`, and the full backends-velox / gluten-ut suites run
- `spark-test-spark41-slow` — **success**

Run: https://github.com/jackylee-ch/gluten/actions/runs/29676262109

Closes #12534