### PR TITLE
[GLUTEN-12566][CORE] Propagate keyGroupedPartitioning in BatchScanExecTransformer

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
@@ -197,8 +197,8 @@ abstract class BatchScanExecTransformerBase(
   override def equals(other: Any): Boolean = other match {
     case other: BatchScanExecTransformerBase =>
       this.keyGroupedPartitioning == other.keyGroupedPartitioning &&
-        this.pushDownFilters == other.pushDownFilters &&
-        super.equals(other)
+      this.pushDownFilters == other.pushDownFilters &&
+      super.equals(other)
     case _ =>
       false
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
@@ -68,6 +68,8 @@ case class BatchScanExecTransformer(
       runtimeFilters = QueryPlan.normalizePredicates(
         runtimeFilters.filterNot(_ == DynamicPruningExpression(Literal.TrueLiteral)),
         output),
+      keyGroupedPartitioning = keyGroupedPartitioning.map(
+        _.map(QueryPlan.normalizeExpressions(_, output))),
       pushDownFilters = pushDownFilters.map(QueryPlan.normalizePredicates(_, output))
     )
   }
@@ -194,12 +196,15 @@ abstract class BatchScanExecTransformerBase(
 
   override def equals(other: Any): Boolean = other match {
     case other: BatchScanExecTransformerBase =>
-      this.pushDownFilters == other.pushDownFilters && super.equals(other)
+      this.pushDownFilters == other.pushDownFilters &&
+      this.keyGroupedPartitioning == other.keyGroupedPartitioning &&
+      super.equals(other)
     case _ =>
       false
   }
 
-  override def hashCode(): Int = Objects.hashCode(batch, runtimeFilters, pushDownFilters)
+  override def hashCode(): Int =
+    Objects.hashCode(batch, runtimeFilters, keyGroupedPartitioning, pushDownFilters)
 
   /** Return a copy of this scan with a new output schema. */
   def withOutput(newOutput: Seq[AttributeReference]): BatchScanExecTransformerBase

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/BatchScanExecTransformer.scala
@@ -196,9 +196,9 @@ abstract class BatchScanExecTransformerBase(
 
   override def equals(other: Any): Boolean = other match {
     case other: BatchScanExecTransformerBase =>
-      this.pushDownFilters == other.pushDownFilters &&
       this.keyGroupedPartitioning == other.keyGroupedPartitioning &&
-      super.equals(other)
+        this.pushDownFilters == other.pushDownFilters &&
+        super.equals(other)
     case _ =>
       false
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
@@ -44,6 +44,8 @@ object ScanTransformerFactory {
       batchScanExec.output,
       batchScanExec.scan,
       batchScanExec.runtimeFilters,
+      keyGroupedPartitioning =
+        SparkShimLoader.getSparkShims.getKeyGroupedPartitioning(batchScanExec),
       table = SparkShimLoader.getSparkShims.getBatchScanExecTable(batchScanExec)
     )
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix three related bugs around `keyGroupedPartitioning` in `BatchScanExecTransformer`:

### 1. `ScanTransformerFactory` does not propagate `keyGroupedPartitioning` (main fix)

`ScanTransformerFactory.createBatchScanTransformer()` creates a `BatchScanExecTransformer` without passing `keyGroupedPartitioning` from the source `BatchScanExec`. This means Gluten's scan always reports `UnknownPartitioning` instead of `KeyGroupedPartitioning`, defeating SPJ (Storage Partitioned Joins) and inserting redundant shuffles.

`IcebergScanTransformer` and `PaimonScanTransformer` already pass `keyGroupedPartitioning` correctly — this fixes the same gap for regular file scans (Parquet, ORC, etc.).

### 2. `doCanonicalize()` does not normalize `keyGroupedPartitioning`

When two semantically identical scans have different expression IDs in their `keyGroupedPartitioning` expressions, the canonicalized plans are not equal, preventing AQE exchange reuse.

### 3. `hashCode()` does not include `keyGroupedPartitioning` — equals/hashCode contract violation

`equals()` compares `keyGroupedPartitioning` (via `spjParams`) but `hashCode()` omits it.

## How was this patch tested?

Existing tests. The fix aligns `ScanTransformerFactory` with `IcebergScanTransformer`/`PaimonScanTransformer` (same `getKeyGroupedPartitioning` shim call), and aligns `hashCode()`/`doCanonicalize()` with the existing `equals()` behavior.

Closes #12566.

---

### Was this patch authored or co-authored using generative AI tooling?

No