### PR TITLE
[MINOR] Sync LICENSE with actual on-disk paths

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -209,7 +209,7 @@
 
    Apache Spark(https://github.com/apache/spark)
    ./backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/CHColumnarWrite.scala
-   ./backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/SparkWriteFilesCommitProtocol.scala
+   ./backends-velox/src/main/scala/org/apache/spark/sql/execution/SparkWriteFilesCommitProtocol.scala
    ./cpp-ch/local-engine/Parser/aggregate_function_parser/BloomFilterAggParser.cpp
    ./gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
    ./shims/spark33/src/main/scala/org/apache/spark/sql/execution/FileSourceScanExecShim.scala
@@ -219,20 +219,20 @@
    ./tools/gluten-it/common/src/main/scala/org/apache/spark/sql/TestUtils.scala
 
    Delta Lake(https://github.com/delta-io/delta)
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/Snapshot.scala
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
-   ./backends-clickhouse/src-delta-23/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
-   ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
-   ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/PreprocessTableWithDVs.scala
-   ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/Snapshot.scala
-   ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
-   ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
-   ./backends-clickhouse/src-delta-33/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+   ./backends-clickhouse/src-delta23/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+   ./backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+   ./backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/PreprocessTableWithDVs.scala
+   ./backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+   ./backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+   ./backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+   ./backends-clickhouse/src-delta33/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
 
     The Velox Project(https://github.com/facebookincubator/velox)
    ./cpp/velox/udf/examples/MyUDAF.cc


### PR DESCRIPTION
### What changes were proposed in this pull request?

Two hygiene issues in `LICENSE` unrelated to Spark version cleanup:

- `./backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/SparkWriteFilesCommitProtocol.scala` was moved to `backends-velox` in an earlier refactor. Update the attribution path accordingly.
- All 14 `./backends-clickhouse/src-delta-23/...` and `./backends-clickhouse/src-delta-33/...` entries in the Delta Lake attribution section use hyphenated directory names (`src-delta-23`, `src-delta-33`), but the actual on-disk directories are `src-delta23` and `src-delta33` — no hyphen after "delta". Correct the paths so every entry resolves to a real file.

### How was this patch tested?

- After the change, every `./...` path in `LICENSE` resolves to an existing file, verified via:
  ```bash
  grep -oE './[^ ]+\.(scala|cpp|yml|java)' LICENSE | while read p; do
    [ -f "${p#./}" ] || echo "MISSING: $p"
  done
  ```
  Output is empty.
- `LICENSE-binary` was also checked and needs no changes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-4-7
