### PR TITLE
[GLUTEN-12462][CORE] Expose shuffle reader metrics iterator delegate

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ShuffledColumnarBatchRDD.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ShuffledColumnarBatchRDD.scala
@@ -32,6 +32,19 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 final private case class ShuffledColumnarBatchRDDPartition(index: Int, spec: ShufflePartitionSpec)
   extends Partition
 
+/** Wrap metrics with named class, so callers can access the delegate iterator when needed. */
+class ShuffleReaderWithMetricsIterator(
+    val delegate: Iterator[Product2[Int, ColumnarBatch]],
+    sqlMetricsReporter: SQLColumnarShuffleReadMetricsReporter)
+  extends Iterator[ColumnarBatch] {
+  override def hasNext: Boolean = delegate.hasNext
+  override def next(): ColumnarBatch = {
+    val batch = delegate.next()._2
+    sqlMetricsReporter.incBatchesRecordsRead(batch.numRows())
+    batch
+  }
+}
+
 /** [[ShuffledColumnarBatchRDD]] is the columnar version of [[org.apache.spark.rdd.ShuffledRDD]]. */
 class ShuffledColumnarBatchRDD(
     var dependency: ShuffleDependency[Int, ColumnarBatch, ColumnarBatch],
@@ -149,11 +162,9 @@ class ShuffledColumnarBatchRDD(
           sqlMetricsReporter,
           executionMode)
     }
-    reader.read().asInstanceOf[Iterator[Product2[Int, ColumnarBatch]]].map {
-      case (_, batch: ColumnarBatch) =>
-        sqlMetricsReporter.incBatchesRecordsRead(batch.numRows())
-        batch
-    }
+    new ShuffleReaderWithMetricsIterator(
+      reader.read().asInstanceOf[Iterator[Product2[Int, ColumnarBatch]]],
+      sqlMetricsReporter)
   }
 
   override def clearDependencies(): Unit = {


### PR DESCRIPTION
### Background

One of a small series of common-code changes to introduce a new backend — **Bolt** (ByteDance’s unified lakehouse analytics acceleration engine) — into the Gluten community. The series minimizes the delta to Gluten common code so Bolt can plug in cleanly, while leaving Velox and ClickHouse backends unaffected. It is part of plan in https://github.com/apache/gluten/issues/12456, close https://github.com/apache/gluten/issues/12462

### This PR

Refactor the anonymous `map` inside `ShuffledColumnarBatchRDD.compute` into a named class `ShuffleReaderWithMetricsIterator` that exposes the underlying shuffle-read iterator via a public `delegate` field. Per-batch semantics are preserved: for every batch we still call `SQLColumnarShuffleReadMetricsReporter.incBatchesRecordsRead(numRows)` and return the batch.

The Bolt backend needs to unwrap the underlying `Iterator[Product2[Int, ColumnarBatch]]` for additional post-processing after the shuffle read. Giving the wrapper a stable name and a `delegate` accessor lets that be done without duplicating the entire `compute()` path. 

**Note: the same patch I created before(https://github.com/apache/gluten/pull/12432) had been deleted by https://github.com/apache/gluten/pull/12511 cc @marin-ma. So I create it again...**

 

