### PR TITLE
[MINOR][CORE] Remove dead code across gluten-core

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/config/ConfigBuilder.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/config/ConfigBuilder.scala
@@ -19,7 +19,6 @@ package org.apache.gluten.config
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
 
 import java.util.concurrent.TimeUnit
-import java.util.regex.Pattern
 
 object BackendType extends Enumeration {
   type BackendType = Value
@@ -140,8 +139,6 @@ private object ConfigHelpers {
         throw new IllegalArgumentException(s"$key should be boolean, but was $s")
     }
   }
-
-  private val TIME_STRING_PATTERN = Pattern.compile("(-?[0-9]+)([a-z]+)?")
 
   def timeFromString(str: String, unit: TimeUnit): Long = JavaUtils.timeStringAs(str, unit)
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/FloydWarshallGraph.scala
@@ -89,12 +89,10 @@ object FloydWarshallGraph {
   private object Builder {
     private class Impl[V <: AnyRef, E <: AnyRef]() extends Builder[V, E] {
       private val pathTable: mutable.Map[V, mutable.Map[V, Path[E]]] = mutable.Map()
-      private var graph: Option[FloydWarshallGraph[V, E]] = None
 
       override def addVertex(v: V): Builder[V, E] = {
         assert(!pathTable.contains(v), s"Vertex $v already exists in graph")
         pathTable.getOrElseUpdate(v, mutable.Map()).getOrElseUpdate(v, Path(Nil))
-        graph = None
         this
       }
 
@@ -104,7 +102,6 @@ object FloydWarshallGraph {
         assert(pathTable.contains(to), s"Vertex $to not exists in graph")
         assert(!hasPath(from, to), s"Path from $from to $to already exists in graph")
         pathTable(from) += to -> Path(Seq(edge))
-        graph = None
         this
       }
 

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/package.scala
@@ -33,11 +33,11 @@ package object transition {
   //
   // Extend this list in shim layer once Spark has more.
   def canPropagateConvention(plan: SparkPlan): Boolean = plan match {
-    case p: DebugExec => true
-    case p: UnionExec => true
-    case p: AQEShuffleReadExec => true
-    case p: InputAdapter => true
-    case p: WholeStageCodegenExec => true
+    case _: DebugExec => true
+    case _: UnionExec => true
+    case _: AQEShuffleReadExec => true
+    case _: InputAdapter => true
+    case _: WholeStageCodegenExec => true
     case _ => false
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Cleanup pass over `gluten-core` that removes three dead code paths surfaced by the `Dead code / dead cases` cross-cutting theme in the earlier L1/L2/L3 review docs. No behavior change on reachable paths.

1. **`FloydWarshallGraph.Builder.Impl`**: drop the never-read `private var graph` field and its two `graph = None` writes in `addVertex` / `addEdge`. Remnant of an abandoned build-cache mechanism; the live cache is `Transition.factory#graphCache`.

2. **`ConfigHelpers.TIME_STRING_PATTERN`**: drop the compiled `Pattern` plus its `java.util.regex.Pattern` import. `timeFromString` delegates to `JavaUtils.timeStringAs`; the regex has no reference.

3. **`canPropagateConvention`**: rename five unused pattern vars `p` to `_` in the `case _: X => true` arms.

Two changes from the initial version were dropped after review:
- `GlutenInjector.applier` keeps `val conf = new GlutenCoreConfig(...)`: instantiating it forces `GlutenCoreConfig` registration, so it is not safe to remove.
- `Transition.Factory#findTransition` keeps the `case _` branch as a guard against future additions to the sealed `RowType` / `BatchType` hierarchy.

### How was this patch tested?

- Existing tests; this is a no-op cleanup on reachable paths.
- Compilation runs under `-Wconf:any:e` (fatal warnings): `./build/mvn -Pbackends-velox -Pspark-3.5 -pl gluten-core -am install -DskipTests`.
- `./dev/format-scala-code.sh`: no additional diff.
- Repo-wide `grep` verified zero references to `TIME_STRING_PATTERN` and to the removed `FloydWarshallGraph.Builder.Impl.graph` field.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-4-7
