### PR TITLE
[GLUTEN-12594][VL] Fix incorrect task attempt ID used for Uniffle block IDs

### DIFF
--- a/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/gluten/uniffle/UniffleShuffleManager.java
+++ b/backends-velox/src-uniffle/main/java/org/apache/spark/shuffle/gluten/uniffle/UniffleShuffleManager.java
@@ -54,6 +54,8 @@ public class UniffleShuffleManager extends RssShuffleManager implements Supports
           (ColumnarShuffleDependency<K, V, V>) rssHandle.getDependency();
       setPusherAppId(rssHandle);
       String taskId = context.taskAttemptId() + "_" + context.attemptNumber();
+      long rssTaskAttemptId =
+          getTaskAttemptIdForBlockId(context.partitionId(), context.attemptNumber());
       ShuffleWriteMetrics writeMetrics;
       if (metrics != null) {
         writeMetrics = new WriteMetrics(metrics);
@@ -72,7 +74,7 @@ public class UniffleShuffleManager extends RssShuffleManager implements Supports
           rssHandle.getAppId(),
           rssHandle.getShuffleId(),
           taskId,
-          context.taskAttemptId(),
+          rssTaskAttemptId,
           writeMetrics,
           this,
           conf,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix the task attempt ID used to generate Uniffle block IDs in the Velox columnar shuffle path.

Previously, `UniffleShuffleManager#getWriter` passed Spark's globally increasing
`TaskContext.taskAttemptId()` to `VeloxUniffleColumnarShuffleWriter`. This value may exceed the
number of bits reserved for task attempt IDs in Uniffle's `BlockIdLayout`.

This patch derives the task attempt ID using Uniffle's standard implementation:

```java
getTaskAttemptIdForBlockId(context.partitionId(), context.attemptNumber())
```

The derived stage-scoped ID is passed to the columnar shuffle writer, matching the behavior of
Uniffle's standard `RssShuffleManager`. The string-form task ID remains unchanged.

Fixes #12594

## How was this patch tested?

existing uniffle integration tests.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)