### PR TITLE
[GLUTEN-12616][CORE] Guard SparkResourceUtil.getTaskSlots against non-positive task cpus

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
@@ -77,18 +77,17 @@ object SparkResourceUtil extends Logging {
 
   def getTaskSlots(conf: SparkConf): Int = {
     val executorCores = SparkResourceUtil.getExecutorCores(conf)
+    // spark.task.cpus is read raw here, which bypasses Spark's own checkValue(_ > 0) (and on
+    // Spark < 4.2 that positivity check does not exist at all). getTaskSlots runs during driver
+    // plugin init, before Spark validates the value, so fail fast on a non-positive setting rather
+    // than dividing by it: a zero would throw an opaque "/ by zero" ArithmeticException and a
+    // negative would silently produce negative task slots and off-heap budgets.
     val taskCores = conf.getInt("spark.task.cpus", 1)
-    if (taskCores <= 0) {
-      // spark.task.cpus <= 0 is invalid; Spark rejects it in its own validation, which runs after
-      // the driver plugin init where callers divide by the slot count. Return a single slot so we
-      // don't pre-empt that check with an opaque "/ by zero" ArithmeticException.
-      1
-    } else {
-      // Floor at one slot. spark.task.cpus > executor cores is an invalid combo that Spark also
-      // rejects later, but callers divide by the slot count during init, so a 0 quotient would
-      // throw before Spark can report the real misconfiguration.
-      Math.max(executorCores / taskCores, 1)
-    }
+    require(taskCores > 0, s"spark.task.cpus should be positive, but was $taskCores")
+    // Floor at one slot. spark.task.cpus > executor cores is an invalid combination that Spark
+    // rejects later with a dedicated message, but callers divide by the slot count during init, so
+    // a 0 quotient would throw before Spark can report the real misconfiguration.
+    Math.max(executorCores / taskCores, 1)
   }
 
   def isLocalMaster(conf: SparkConf): Boolean = {

--- a/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/util/SparkResourceUtil.scala
@@ -78,7 +78,17 @@ object SparkResourceUtil extends Logging {
   def getTaskSlots(conf: SparkConf): Int = {
     val executorCores = SparkResourceUtil.getExecutorCores(conf)
     val taskCores = conf.getInt("spark.task.cpus", 1)
-    executorCores / taskCores
+    if (taskCores <= 0) {
+      // spark.task.cpus <= 0 is invalid; Spark rejects it in its own validation, which runs after
+      // the driver plugin init where callers divide by the slot count. Return a single slot so we
+      // don't pre-empt that check with an opaque "/ by zero" ArithmeticException.
+      1
+    } else {
+      // Floor at one slot. spark.task.cpus > executor cores is an invalid combo that Spark also
+      // rejects later, but callers divide by the slot count during init, so a 0 quotient would
+      // throw before Spark can report the real misconfiguration.
+      Math.max(executorCores / taskCores, 1)
+    }
   }
 
   def isLocalMaster(conf: SparkConf): Boolean = {

--- a/gluten-core/src/test/scala/org/apache/spark/util/SparkResourceUtilSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/util/SparkResourceUtilSuite.scala
@@ -49,8 +49,8 @@ class SparkResourceUtilSuite extends AnyFunSuite {
     assert(SparkResourceUtil.getTaskSlots(conf) == 4)
   }
 
-  test("getTaskSlots returns one core per slot by default") {
-    val conf = new SparkConf(false).set("spark.master", "local[1]")
-    assert(SparkResourceUtil.getTaskSlots(conf) == 1)
+  test("getTaskSlots returns one slot per core when task cpus defaults to one") {
+    val conf = new SparkConf(false).set("spark.master", "local[8]")
+    assert(SparkResourceUtil.getTaskSlots(conf) == 8)
   }
 }

--- a/gluten-core/src/test/scala/org/apache/spark/util/SparkResourceUtilSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/util/SparkResourceUtilSuite.scala
@@ -33,13 +33,25 @@ class SparkResourceUtilSuite extends AnyFunSuite {
     assert(SparkResourceUtil.getTaskSlots(conf) == 1)
   }
 
-  test("getTaskSlots does not divide by zero when task cpus is zero") {
-    // spark.task.cpus is read via raw conf.getInt, which bypasses Spark's checkValue(_ > 0), so a
-    // zero value must not reach the division.
+  test("getTaskSlots fails fast when task cpus is zero") {
+    // spark.task.cpus is read via raw conf.getInt, which bypasses Spark's checkValue(_ > 0) (a
+    // check that only exists on Spark >= 4.2), so a zero value must not reach the division. Fail
+    // fast with a clear message instead of an opaque "/ by zero" ArithmeticException.
     val conf = new SparkConf(false)
       .set("spark.master", "local[8]")
       .set("spark.task.cpus", "0")
-    assert(SparkResourceUtil.getTaskSlots(conf) == 1)
+    val e = intercept[IllegalArgumentException](SparkResourceUtil.getTaskSlots(conf))
+    assert(e.getMessage.contains("spark.task.cpus should be positive"))
+  }
+
+  test("getTaskSlots fails fast when task cpus is negative") {
+    // A negative spark.task.cpus would otherwise divide to a negative slot count, silently yielding
+    // negative per-task off-heap budgets. Fail fast rather than propagate the bad value.
+    val conf = new SparkConf(false)
+      .set("spark.master", "local[8]")
+      .set("spark.task.cpus", "-2")
+    val e = intercept[IllegalArgumentException](SparkResourceUtil.getTaskSlots(conf))
+    assert(e.getMessage.contains("spark.task.cpus should be positive"))
   }
 
   test("getTaskSlots divides executor cores by task cpus") {

--- a/gluten-core/src/test/scala/org/apache/spark/util/SparkResourceUtilSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/spark/util/SparkResourceUtilSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.util
+
+import org.apache.spark.SparkConf
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class SparkResourceUtilSuite extends AnyFunSuite {
+
+  test("getTaskSlots floors at one when task cpus exceed executor cores") {
+    // spark.task.cpus > executor cores is an invalid config that Spark rejects later, but Gluten
+    // reads task slots during plugin init and divides by the result. Returning 0 here makes that
+    // division throw ArithmeticException before Spark's validateTaskCpusLargeEnough can report the
+    // real misconfiguration.
+    val conf = new SparkConf(false)
+      .set("spark.master", "local[1]")
+      .set("spark.task.cpus", "2")
+    assert(SparkResourceUtil.getTaskSlots(conf) == 1)
+  }
+
+  test("getTaskSlots does not divide by zero when task cpus is zero") {
+    // spark.task.cpus is read via raw conf.getInt, which bypasses Spark's checkValue(_ > 0), so a
+    // zero value must not reach the division.
+    val conf = new SparkConf(false)
+      .set("spark.master", "local[8]")
+      .set("spark.task.cpus", "0")
+    assert(SparkResourceUtil.getTaskSlots(conf) == 1)
+  }
+
+  test("getTaskSlots divides executor cores by task cpus") {
+    val conf = new SparkConf(false)
+      .set("spark.master", "local[8]")
+      .set("spark.task.cpus", "2")
+    assert(SparkResourceUtil.getTaskSlots(conf) == 4)
+  }
+
+  test("getTaskSlots returns one core per slot by default") {
+    val conf = new SparkConf(false).set("spark.master", "local[1]")
+    assert(SparkResourceUtil.getTaskSlots(conf) == 1)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

`SparkResourceUtil.getTaskSlots` computed `executorCores / taskCores` with no guard, and callers divide by its result: `GlutenDriverPlugin.setPredefinedConfigs` does `offHeapSize / taskSlots`, and `MemoryTargets`, `ColumnarShuffleWriter`, and the Celeborn and Uniffle writers use it as a denominator too.

`spark.task.cpus=0` made `getTaskSlots` itself throw `ArithmeticException: / by zero`. A negative value was worse: it produced a negative slot count, so per-task off-heap budgets came out negative and the driver started anyway. `spark.task.cpus > spark.executor.cores` made the integer division yield 0, so a caller's `offHeapSize / taskSlots` threw.

Gluten reads this value before Spark can reject it. `getTaskSlots` runs during `PluginContainer` init in `SparkContext`, before `createTaskScheduler`, and it reads the value with raw `conf.getInt`, which skips the `ConfigEntry`. Spark's `CPUS_PER_TASK.checkValue(_ > 0)` also only exists from Spark 4.2 (SPARK-55757); on 3.3 through 4.1 nothing validates it at all. There is no later Spark check to defer to, so `getTaskSlots` now fails fast with `require(taskCores > 0, ...)`. Coercing the value to 1 would hide the misconfiguration and size every off-heap budget for a single slot.

The `task.cpus > executor.cores` case is handled differently. That is a cross-config relationship Spark validates with its own dedicated message (`validateTaskCpusLargeEnough`), so `getTaskSlots` floors the quotient at 1 to keep init from dividing by zero first, and leaves the reporting to Spark.

### How was this patch tested?

Added `SparkResourceUtilSuite` with five tests: `task.cpus=0` and `task.cpus=-2` each fail with `IllegalArgumentException` naming the config, `task.cpus` greater than executor cores floors to one slot, `8 / 2` gives 4, and the default is one slot per core (asserted on `local[8]` so the default path is distinguishable). The three non-happy-path tests fail on the unfixed code and pass after the fix.

Closes #12616
