### PR TITLE
[GLUTEN-12599][VL] Fall back to actions/cache when Apache Stash misses

### DIFF
--- a/.github/workflows/velox_backend_arm.yml
+++ b/.github/workflows/velox_backend_arm.yml
@@ -61,6 +61,7 @@ jobs:
           case "$(uname -m)" in
             x86_64) ARCH=amd64 ;;
             aarch64) ARCH=arm64 ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
           esac
           curl -fsSL "https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_${ARCH}.tar.gz" \
             | tar -xz -C /usr/local --strip-components=1 "gh_2.63.2_linux_${ARCH}/bin/gh"
@@ -68,10 +69,19 @@ jobs:
           chmod +x /usr/local/bin/jq
           gh --version && jq --version
       - name: Get Ccache from Apache Stash
+        id: ccache-stash
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-centos8-release-default-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+      - name: Get Ccache from actions/cache (fallback on Stash miss)
+        if: steps.ccache-stash.outputs.stash-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-centos8-release-default-${{runner.arch}}-${{github.sha}}
+          restore-keys: |
+            ccache-centos8-release-default-${{runner.arch}}
       - name: Build Gluten native libraries
         run: |
           df -a
@@ -143,6 +153,7 @@ jobs:
           case "$(uname -m)" in
             x86_64) ARCH=amd64 ;;
             aarch64) ARCH=arm64 ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
           esac
           curl -fsSL "https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_${ARCH}.tar.gz" \
             | tar -xz -C /usr/local --strip-components=1 "gh_2.63.2_linux_${ARCH}/bin/gh"
@@ -150,10 +161,19 @@ jobs:
           chmod +x /usr/local/bin/jq
           gh --version && jq --version
       - name: Get Ccache from Apache Stash
+        id: ccache-stash
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+      - name: Get Ccache from actions/cache (fallback on Stash miss)
+        if: steps.ccache-stash.outputs.stash-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-centos9-release-shared-${{runner.arch}}-${{github.sha}}
+          restore-keys: |
+            ccache-centos9-release-shared-${{runner.arch}}
       - name: Build Gluten native libraries
         run: |
           df -a

--- a/.github/workflows/velox_backend_arm.yml
+++ b/.github/workflows/velox_backend_arm.yml
@@ -73,7 +73,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos8-release-default-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+          key: ccache-centos8-release-default-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4
@@ -165,7 +165,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4

--- a/.github/workflows/velox_backend_arm.yml
+++ b/.github/workflows/velox_backend_arm.yml
@@ -73,7 +73,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos8-release-default-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
+          key: ccache-centos8-release-default-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4
@@ -165,7 +165,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
+          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4

--- a/.github/workflows/velox_backend_enhanced.yml
+++ b/.github/workflows/velox_backend_enhanced.yml
@@ -57,10 +57,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get Ccache from Apache Stash
+        id: ccache-stash
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-enhanced-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}
+      - name: Get Ccache from actions/cache (fallback on Stash miss)
+        if: steps.ccache-stash.outputs.stash-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-enhanced-centos7-release-default-${{github.sha}}
+          restore-keys: |
+            ccache-enhanced-centos7-release-default
       - name: Build Gluten native libraries
         run: |
           docker pull apache/gluten:vcpkg-centos-7-gcc13

--- a/.github/workflows/velox_backend_enhanced.yml
+++ b/.github/workflows/velox_backend_enhanced.yml
@@ -61,7 +61,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-enhanced-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
+          key: ccache-enhanced-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4

--- a/.github/workflows/velox_backend_enhanced.yml
+++ b/.github/workflows/velox_backend_enhanced.yml
@@ -61,7 +61,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-enhanced-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}
+          key: ccache-enhanced-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -60,10 +60,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get Ccache from Apache Stash
+        id: ccache-stash
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}
+      - name: Get Ccache from actions/cache (fallback on Stash miss)
+        if: steps.ccache-stash.outputs.stash-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-centos7-release-default-${{github.sha}}
+          restore-keys: |
+            ccache-centos7-release-default
       - name: Build Gluten native libraries
         run: |
           docker run -v $GITHUB_WORKSPACE:/work -w /work apache/gluten:vcpkg-centos-7-gcc13 bash -c "
@@ -985,6 +994,7 @@ jobs:
           case "$(uname -m)" in
             x86_64) ARCH=amd64 ;;
             aarch64) ARCH=arm64 ;;
+            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
           esac
           curl -fsSL "https://github.com/cli/cli/releases/download/v2.63.2/gh_2.63.2_linux_${ARCH}.tar.gz" \
             | tar -xz -C /usr/local --strip-components=1 "gh_2.63.2_linux_${ARCH}/bin/gh"
@@ -992,10 +1002,19 @@ jobs:
           chmod +x /usr/local/bin/jq
           gh --version && jq --version
       - name: Get Ccache from Apache Stash
+        id: ccache-stash
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+      - name: Get Ccache from actions/cache (fallback on Stash miss)
+        if: steps.ccache-stash.outputs.stash-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-centos9-release-shared-${{runner.arch}}-${{github.sha}}
+          restore-keys: |
+            ccache-centos9-release-shared-${{runner.arch}}
       - name: Build Gluten native libraries
         run: |
           df -a
@@ -1060,10 +1079,19 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: Get Ccache from Apache Stash
+        id: ccache-stash
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
           key: ccache-centos9-cudf-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+      - name: Get Ccache from actions/cache (fallback on Stash miss)
+        if: steps.ccache-stash.outputs.stash-hit != 'true'
+        uses: actions/cache/restore@v4
+        with:
+          path: '${{ env.CCACHE_DIR }}'
+          key: ccache-centos9-cudf-release-shared-${{runner.arch}}-${{github.sha}}
+          restore-keys: |
+            ccache-centos9-cudf-release-shared-${{runner.arch}}
       - name: Build Gluten native libraries
         run: |
           docker run -v $GITHUB_WORKSPACE:/work -w /work apache/gluten:centos-9-jdk8-cudf bash -c "

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -64,7 +64,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}
+          key: ccache-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4
@@ -1006,7 +1006,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4
@@ -1083,7 +1083,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos9-cudf-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
+          key: ccache-centos9-cudf-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -64,7 +64,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
+          key: ccache-centos7-release-default-${{ hashFiles('ep/build-velox/src/**') }}
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4
@@ -1006,7 +1006,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
+          key: ccache-centos9-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4
@@ -1083,7 +1083,7 @@ jobs:
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
-          key: ccache-centos9-cudf-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}-forced-miss-validation
+          key: ccache-centos9-cudf-release-shared-${{runner.arch}}-${{ hashFiles('ep/build-velox/src/**') }}
       - name: Get Ccache from actions/cache (fallback on Stash miss)
         if: steps.ccache-stash.outputs.stash-hit != 'true'
         uses: actions/cache/restore@v4


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up to #12610 (merged as 86df8560c). Apache Stash only supports exact-key restore and has no `restore-keys` mechanism. When `hashFiles('ep/build-velox/src/**')` changes for a PR branch, the exact Stash key misses and the native build starts cold. This PR adds a fallback to the legacy `actions/cache/restore` with the original `restore-keys` prefix, which can still pull the latest warm cache seeded on `main`.

### Design

```
Stash exact key hit → native build (fast)
Stash miss → actions/cache/restore with restore-keys → native build (still warm)
```

Each consumer restore now works in two steps:

1. `stash/restore` first (exact `ccache-<variant>-${{ hashFiles('ep/build-velox/src/**') }}` key);
2. if `stash-hit` is not `'true'`, fall back to `actions/cache/restore` with the pre-migration `restore-keys`, which pulls the latest cache seeded on main.

The existing `actions/cache/save` steps are kept, so both the Stash and actions/cache paths stay populated.

### Scope

- **Modified** (3 files, 57 additions): `velox_backend_arm.yml`, `velox_backend_enhanced.yml`, `velox_backend_x86.yml`
- **Not modified**: `velox_backend_cache.yml` (producer), `velox_nightly.yml`, `build_bundle_package.yml`, `flink.yml`, `velox_backend_ansi.yml`

The cache producer, nightly and bundle workflows, and self-contained caches (flink, ansi) are untouched — they keep the legacy `actions/cache` method as-is.

## How was this patch tested?

### Static validation
- YAML parsing passes for all three modified workflow files.
- All 6 fallback restore keys and their `restore-keys` prefixes have been verified against the producer's `actions/cache/save` entries in `velox_backend_cache.yml`.
- No trailing whitespace, no unrelated formatting changes, no modifications outside the three scope files.

### Forced-miss CI validation: PASS

A temporary commit appended `-forced-miss-validation` to the six Stash restore keys to force Stash to miss. All three Velox Backend workflows completed successfully:

| Workflow | Stash result | Fallback executed | Cache hit rate | Build time |
|----------|-------------|-------------------|:--------------:|:----------:|
| **x86** (centos7 x86_64) | `stash-hit=false` | ✅ actions/cache restored (prefix: `ccache-centos7-release-default`) | 95.36 % | ~2.5 min |
| **ARM** (centos8 aarch64) | `stash-hit=false` | ✅ actions/cache restored (prefix: `ccache-centos8-release-default-ARM64`, 443 MB, ~3.2 s) | 94.49 % | ~2 min |
| **Enhanced** (centos7 x86_64) | `stash-hit=false` | ✅ actions/cache restored (prefix: `ccache-enhanced-centos7-release-default`) | 92.52 % | ~27 min |

Key evidence from each workflow:
- The `Get Ccache from Apache Stash` step logged `stash-hit=false` — the key suffix `-forced-miss-validation` was present.
- The `Get Ccache from actions/cache (fallback on Stash miss)` step executed and restored a warm cache via the `restore-keys` prefix.
- All native builds reported `"Successfully built Velox from Source."` with ccache hit rates above 92%.
- The forced-miss commit has been reverted; the final branch contains only the clean hybrid diff.

### Normal path (Stash hit)

The normal Stash-first path was validated and merged in #12610. On an earlier revision of that PR, `build-native-lib-centos-8 (ARM64)` showed:
- `stash-hit=true`
- ccache Hits: 101618 / 107649 (94.40%)
- Native build ~1h → 2m35s

### Relationship to other PRs

- #12599 (umbrella issue)
- #12602 (producer Stash seeding)
- #12610 (consumer Stash restore)
- PR #12619 currently contains an overlapping x86 centos7 fallback hunk used during its CI investigation. This PR centralizes the complete six-consumer fallback behavior; the overlapping hunk should be removed from #12619.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude