### PR TITLE
[VL] Install Flex under /usr in CentOS 7 vcpkg images

### DIFF
--- a/dev/vcpkg/setup-build-depends.sh
+++ b/dev/vcpkg/setup-build-depends.sh
@@ -113,7 +113,7 @@ install_centos_7() {
         wget -q --max-redirect 3 -O - "${FLEX_URL}" | tar -xz -C /tmp/flex --strip-components=1
         cd /tmp/flex
         ./autogen.sh
-        ./configure
+        ./configure --prefix=/usr
         make install
         cd
         rm -rf /tmp/flex


### PR DESCRIPTION
## What changes are proposed in this pull request?

This is a prerequisite for #12625.

Install the source-built Flex 2.6.4 under `/usr` in the CentOS 7 vcpkg build environment. PR #12625 isolates vcpkg builds from `/usr/local`, while the current image places `flex` and `FlexLexer.h` under that ignored prefix.

CentOS 7's packaged Flex 2.5.37 is not compatible with the current Velox `YyFlexLexerShim`, so this keeps Flex 2.6.4 and only changes its installation prefix. Once the image is rebuilt, #12625 can remove its temporary Flex path workaround.

## How was this patch tested?

- Ran `bash -n dev/vcpkg/setup-build-depends.sh`.
- In #12625 CI, confirmed that CentOS 7 Flex 2.5.37 is found under `/usr` but fails to compile the current Velox `YyFlexLexerShim`.
- Confirmed that Flex 2.6.4 with matching executable and headers completes both x86 and Enhanced native builds.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI 1.0.75
