### PR TITLE
[GLUTEN-12611][VL] Fix Ubuntu Arrow setup target

### DIFF
--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -65,7 +65,7 @@ if [ "$VELOX_HOME" == "" ]; then
 fi
 
 function process_setup_ubuntu {
-  sed -i "s|run_and_time install_arrow||g" scripts/setup-centos9.sh
+  sed -i "s|run_and_time install_arrow||g" scripts/setup-ubuntu.sh
   echo "Using setup script from Velox"
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix `process_setup_ubuntu()` to remove Velox's Arrow installation step from
`scripts/setup-ubuntu.sh` instead of `scripts/setup-centos9.sh`.

The previous target left Ubuntu's setup script unchanged, so Velox could
unexpectedly build its own Arrow and fail while resolving `Boost::process` for
`arrow_testing_objlib`.

Fixes #12611.

## How was this patch tested?

- `bash -n ep/build-velox/src/get-velox.sh`
- `git diff --check`
- Compared the Ubuntu setup handling with the merged branch-1.7 fix in #12600

The full Velox dependency build was not run locally.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5.6 and GPT-5.4-mini)
