### PR TITLE
[GLUTEN-12597][CORE] Make AdvancedExtension.optimization repeated

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v1/CHFormatWriterInjects.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/spark/sql/execution/datasources/v1/CHFormatWriterInjects.scala
@@ -62,7 +62,7 @@ trait CHFormatWriterInjects extends GlutenFormatWriterInjectsBase {
           .setAdvancedExtension(
             AdvancedExtension
               .newBuilder()
-              .setOptimization(Any.pack(createNativeWrite(outputPath, context)))
+              .addOptimization(Any.pack(createNativeWrite(outputPath, context)))
               .build())
           .build())
       .build()

--- a/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.cpp
@@ -129,7 +129,7 @@ void AggregateRelParser::setup(DB::QueryPlanPtr query_plan, const substrait::Rel
     has_complete_stage = phase_set.contains(substrait::AggregationPhase::AGGREGATION_PHASE_INITIAL_TO_RESULT);
     bool next_step_is_agg = false;
     google::protobuf::StringValue raw_extra_params;
-    raw_extra_params.ParseFromString(aggregate_rel->advanced_extension().optimization().value());
+    raw_extra_params.ParseFromString(firstOptimizationOrDefault(aggregate_rel->advanced_extension()).value());
     auto extra_params = AggregateOptimizationInfo::parse(raw_extra_params.value());
     if (aggregate_rel->measures().empty())
     {

--- a/cpp-ch/local-engine/Parser/RelParsers/CrossRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/CrossRelParser.cpp
@@ -27,6 +27,7 @@
 #include <Parser/AdvancedParametersParseUtil.h>
 #include <Parser/ExpressionParser.h>
 #include <Parser/SerializedPlanParser.h>
+#include <Parser/SubstraitParserUtils.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
@@ -168,7 +169,7 @@ void CrossRelParser::renamePlanColumns(DB::QueryPlan & left, DB::QueryPlan & rig
 DB::QueryPlanPtr CrossRelParser::parseJoin(const substrait::CrossRel & join, DB::QueryPlanPtr left, DB::QueryPlanPtr right)
 {
     google::protobuf::StringValue optimization_info;
-    optimization_info.ParseFromString(join.advanced_extension().optimization().value());
+    optimization_info.ParseFromString(firstOptimizationOrDefault(join.advanced_extension()).value());
     auto join_opt_info = JoinOptimizationInfo::parse(optimization_info.value());
     const auto & storage_join_key = join_opt_info.storage_join_key;
     auto storage_join = !storage_join_key.empty() ? BroadcastJoinBuilder::getJoin(storage_join_key) : nullptr;

--- a/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/GroupLimitRelParser.cpp
@@ -80,7 +80,7 @@ GroupLimitRelParser::parse(DB::QueryPlanPtr current_plan_, const substrait::Rel 
 {
     const auto win_rel_def = rel.windowgrouplimit();
     google::protobuf::StringValue optimize_info_str;
-    optimize_info_str.ParseFromString(win_rel_def.advanced_extension().optimization().value());
+    optimize_info_str.ParseFromString(firstOptimizationOrDefault(win_rel_def.advanced_extension()).value());
     auto optimization_info = WindowGroupOptimizationInfo::parse(optimize_info_str.value());
     if (optimization_info.is_aggregate_group_limit)
     {
@@ -134,7 +134,7 @@ WindowGroupLimitRelParser::parse(DB::QueryPlanPtr current_plan_, const substrait
 {
     const auto win_rel_def = rel.windowgrouplimit();
     google::protobuf::StringValue optimize_info_str;
-    optimize_info_str.ParseFromString(win_rel_def.advanced_extension().optimization().value());
+    optimize_info_str.ParseFromString(firstOptimizationOrDefault(win_rel_def.advanced_extension()).value());
     auto optimization_info = WindowGroupOptimizationInfo::parse(optimize_info_str.value());
     window_function_name = optimization_info.window_function;
 
@@ -198,7 +198,7 @@ DB::QueryPlanPtr AggregateGroupLimitRelParser::parse(
     win_rel_def = &rel.windowgrouplimit();
 
     google::protobuf::StringValue optimize_info_str;
-    optimize_info_str.ParseFromString(win_rel_def->advanced_extension().optimization().value());
+    optimize_info_str.ParseFromString(firstOptimizationOrDefault(win_rel_def->advanced_extension()).value());
     auto optimization_info = WindowGroupOptimizationInfo::parse(optimize_info_str.value());
     limit = static_cast<size_t>(win_rel_def->limit());
     aggregate_function_name = getAggregateFunctionName(optimization_info.window_function);
@@ -499,7 +499,7 @@ static DB::WindowFunctionDescription buildWindowFunctionDescription(const std::s
 void AggregateGroupLimitRelParser::addWindowLimitStep(DB::QueryPlan & plan)
 {
     google::protobuf::StringValue optimize_info_str;
-    optimize_info_str.ParseFromString(win_rel_def->advanced_extension().optimization().value());
+    optimize_info_str.ParseFromString(firstOptimizationOrDefault(win_rel_def->advanced_extension()).value());
     auto optimization_info = WindowGroupOptimizationInfo::parse(optimize_info_str.value());
     auto window_function_name = optimization_info.window_function;
 

--- a/cpp-ch/local-engine/Parser/RelParsers/JoinRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/JoinRelParser.cpp
@@ -204,7 +204,7 @@ DB::QueryPlanPtr JoinRelParser::parseJoin(const substrait::JoinRel & join, DB::Q
 {
     auto join_config = JoinConfig::loadFromContext(getContext());
     google::protobuf::StringValue optimization_info;
-    optimization_info.ParseFromString(join.advanced_extension().optimization().value());
+    optimization_info.ParseFromString(firstOptimizationOrDefault(join.advanced_extension()).value());
     auto join_opt_info = JoinOptimizationInfo::parse(optimization_info.value());
     LOG_DEBUG(getLogger("JoinRelParser"), "optimization info:{}", optimization_info.value());
     auto storage_join = join_opt_info.is_broadcast ? BroadcastJoinBuilder::getJoin(join_opt_info.storage_join_key) : nullptr;

--- a/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.cpp
@@ -131,7 +131,7 @@ bool ReadRelParser::isReadRelFromMergeTree(const substrait::ReadRel & rel)
         return false;
 
     google::protobuf::StringValue optimization;
-    optimization.ParseFromString(rel.advanced_extension().optimization().value());
+    optimization.ParseFromString(firstOptimizationOrDefault(rel.advanced_extension()).value());
     ReadBufferFromString in(optimization.value());
     if (!checkString("isMergeTree=", in))
         return false;
@@ -148,7 +148,7 @@ bool ReadRelParser::isReadRelFromRange(const substrait::ReadRel & rel)
         return false;
 
     google::protobuf::StringValue optimization;
-    optimization.ParseFromString(rel.advanced_extension().optimization().value());
+    optimization.ParseFromString(firstOptimizationOrDefault(rel.advanced_extension()).value());
     ReadBufferFromString in(optimization.value());
     if (!checkString("isRange=", in))
         return false;

--- a/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/WriteRelParser.cpp
@@ -21,6 +21,7 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
+#include <Parser/SubstraitParserUtils.h>
 #include <Parser/TypeParser.h>
 #include <Processors/Transforms/ExpressionTransform.h>
 #include <Processors/Transforms/MaterializingTransform.h>
@@ -196,7 +197,7 @@ void addSinkTransform(const DB::ContextPtr & context, const substrait::WriteRel 
     const substrait::NamedObjectWrite & named_table = write_rel.named_table();
 
     local_engine::Write write;
-    if (!named_table.advanced_extension().optimization().UnpackTo(&write))
+    if (!firstOptimizationOrDefault(named_table.advanced_extension()).UnpackTo(&write))
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Failed to unpack write optimization with local_engine::Write.");
     assert(write.has_common());
     const substrait::NamedStruct & table_schema = write_rel.table_schema();

--- a/cpp-ch/local-engine/Parser/SubstraitParserUtils.h
+++ b/cpp-ch/local-engine/Parser/SubstraitParserUtils.h
@@ -78,6 +78,17 @@ inline std::string toString(const google::protobuf::Any & any)
     return sv.value();
 }
 
+/// Substrait 0.98 changed AdvancedExtension.optimization from a singular to a repeated field.
+/// The old singular accessor returned a default-constructed Any when the field was unset (empty
+/// value(), empty type_url), so callers could unconditionally read optimization().value()/UnpackTo().
+/// optimization(0) on an empty repeated field is out-of-bounds and crashes, so route reads of the
+/// first optimization through this helper to preserve the null-safe behavior.
+inline const google::protobuf::Any & firstOptimizationOrDefault(const substrait::extensions::AdvancedExtension & advanced_extension)
+{
+    return advanced_extension.optimization_size() > 0 ? advanced_extension.optimization(0)
+                                                      : google::protobuf::Any::default_instance();
+}
+
 namespace SubstraitParserUtils
 {
     std::optional<size_t> getStructFieldIndex(const substrait::Expression & e);

--- a/cpp-ch/local-engine/local_engine_jni.cpp
+++ b/cpp-ch/local-engine/local_engine_jni.cpp
@@ -961,7 +961,7 @@ JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniW
     assert(write_rel.has_named_table());
     const substrait::NamedObjectWrite & named_table = write_rel.named_table();
     local_engine::Write write_opt;
-    named_table.advanced_extension().optimization().UnpackTo(&write_opt);
+    local_engine::firstOptimizationOrDefault(named_table.advanced_extension()).UnpackTo(&write_opt);
     DB::Block preferred_schema = local_engine::TypeParser::buildBlockFromNamedStructWithoutDFS(write_rel.table_schema());
 
     const auto file_uri = jstring2string(env, file_uri_);
@@ -990,7 +990,7 @@ JNIEXPORT jlong Java_org_apache_spark_sql_execution_datasources_CHDatasourceJniW
     assert(write_rel.has_named_table());
     const substrait::NamedObjectWrite & named_table = write_rel.named_table();
     local_engine::Write write;
-    if (!named_table.advanced_extension().optimization().UnpackTo(&write))
+    if (!local_engine::firstOptimizationOrDefault(named_table.advanced_extension()).UnpackTo(&write))
         throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Failed to unpack write optimization with local_engine::Write.");
     assert(write.has_common());
     assert(write.has_mergetree());

--- a/cpp/velox/substrait/SubstraitParser.cc
+++ b/cpp/velox/substrait/SubstraitParser.cc
@@ -279,9 +279,9 @@ std::string SubstraitParser::mapToVeloxFunction(const std::string& substraitFunc
 bool SubstraitParser::configSetInOptimization(
     const ::substrait::extensions::AdvancedExtension& extension,
     const std::string& config) {
-  if (extension.has_optimization()) {
+  if (extension.optimization_size() > 0) {
     google::protobuf::StringValue msg;
-    extension.optimization().UnpackTo(&msg);
+    extension.optimization(0).UnpackTo(&msg);
     std::size_t pos = msg.value().find(config);
     if ((pos != std::string::npos) && (msg.value().substr(pos + config.size(), 1) == "1")) {
       return true;
@@ -294,9 +294,9 @@ bool SubstraitParser::checkWindowFunction(
     const ::substrait::extensions::AdvancedExtension& extension,
     const std::string& targetFunction) {
   const std::string config = "window_function=";
-  if (extension.has_optimization()) {
+  if (extension.optimization_size() > 0) {
     google::protobuf::StringValue msg;
-    extension.optimization().UnpackTo(&msg);
+    extension.optimization(0).UnpackTo(&msg);
     std::size_t pos = msg.value().find(config);
     if ((pos != std::string::npos) && (msg.value().size() >= targetFunction.size()) &&
         (msg.value().substr(pos + config.size(), targetFunction.size()) == targetFunction)) {

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -870,8 +870,8 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
 
   GLUTEN_CHECK(writeRel.named_table().has_advanced_extension(), "Advanced extension not found in WriteRel");
   const auto& ext = writeRel.named_table().advanced_extension();
-  GLUTEN_CHECK(ext.has_optimization(), "Extension optimization not found in WriteRel");
-  const auto& opt = ext.optimization();
+  GLUTEN_CHECK(ext.optimization_size() > 0, "Extension optimization not found in WriteRel");
+  const auto& opt = ext.optimization(0);
   gluten::ConfigMap confMap;
   opt.UnpackTo(&confMap);
   std::unordered_map<std::string, std::string> writeConfs;

--- a/cpp/velox/substrait/VeloxToSubstraitPlan.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitPlan.cc
@@ -282,7 +282,7 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
         substrait::extensions::AdvancedExtension ae{};
         google::protobuf::StringValue msg;
         msg.set_value("allowFlush=1");
-        ae.mutable_optimization()->PackFrom(msg);
+        ae.add_optimization()->PackFrom(msg);
         aggregateRel->mutable_advanced_extension()->MergeFrom(ae);
         break;
       }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/extensions/AdvancedExtensionNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/extensions/AdvancedExtensionNode.java
@@ -51,7 +51,7 @@ public class AdvancedExtensionNode implements Serializable {
   public AdvancedExtension toProtobuf() {
     AdvancedExtension.Builder extensionBuilder = AdvancedExtension.newBuilder();
     if (optimization != null) {
-      extensionBuilder.setOptimization(optimization);
+      extensionBuilder.addOptimization(optimization);
     }
     if (enhancement != null) {
       extensionBuilder.setEnhancement(enhancement);

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/extensions/extensions.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/extensions/extensions.proto
@@ -82,7 +82,7 @@ message SimpleExtensionDeclaration {
 message AdvancedExtension {
   // An optimization is helpful information that don't influence semantics. May
   // be ignored by a consumer.
-  google.protobuf.Any optimization = 1;
+  repeated google.protobuf.Any optimization = 1;
 
   // An enhancement alter semantics. Cannot be ignored by a consumer.
   google.protobuf.Any enhancement = 2;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Third increment of the Substrait 0.98 proto rebase (#12597), following #12598 (dead-proto/`Expression.Enum` removal) and #12604 (URI→URN referencing, now merged). This PR is rebased directly on `main`, so its diff is exactly this increment.

Adopts the 0.98 shape of `AdvancedExtension.optimization`, which changed from a singular `google.protobuf.Any` to `repeated google.protobuf.Any` (substrait-io/substrait#1084). An optimization is helpful information that does not influence semantics, so a list is the natural model and there is no semantic change for Gluten.

- **`extensions.proto`**: `optimization` becomes `repeated`.
- **JVM producer** (`AdvancedExtensionNode`): `setOptimization(...)` → `addOptimization(...)`. Gluten sets at most one optimization message today, so this appends a single element.
- **ClickHouse producer** (`CHFormatWriterInjects`): `setOptimization(...)` → `addOptimization(...)`.
- **Native consumers** (Velox `SubstraitParser` / `SubstraitToVeloxPlan` / `VeloxToSubstraitPlan`; ClickHouse `local_engine_jni` and the `RelParsers` for Aggregate/Cross/GroupLimit/Join/Read/Write): read/write sites migrate from the singular accessor to the indexed form — `has_optimization()` → `optimization_size() > 0`, `.optimization()` → `.optimization(0)`, and producer `PackFrom` moves to `add_optimization()`.

Reading `optimization(0)` at the consumer sites is safe: Gluten's producer and both native consumers are regenerated from this single vendored proto and ship together (no wire-compatibility window), and the producer only ever emits a single optimization element. If a future increment emits multiple, these sites are the ones to revisit.

## How was this patch tested?

No behavioral change — this migrates the field's cardinality, and Gluten uses a single element. Verified locally: the vendored proto compiles (`protoc`); the `gluten-substrait` JVM build succeeds against the regenerated classes; and the Velox native library builds (`libgluten` / `libvelox`, recompiling `SubstraitParser` / `SubstraitToVeloxPlan` / `VeloxToSubstraitPlan`). The ClickHouse changes (Scala `CHFormatWriterInjects` and the native `RelParsers` / `local_engine_jni`) are mechanical singular→indexed accessor migrations, verified by inspection and covered by CI, which builds the CH backend. Existing conversion tests exercise these paths.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)

🤖 Generated with AI
