### PR TITLE
[GLUTEN-10215][VL] Delta write: Native top-level NOT NULL checks

### DIFF
--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.extension.columnar.transition.Transitions
 
 import org.apache.spark.sql.{AnalysisException, Dataset}
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction}
-import org.apache.spark.sql.delta.constraints.{Constraint, Constraints, DeltaInvariantCheckerExec}
+import org.apache.spark.sql.delta.constraints.{Constraint, Constraints, DeltaInvariantCheckerExec, GlutenDeltaInvariantChecker}
 import org.apache.spark.sql.delta.files.{GlutenDeltaFileFormatWriter, TransactionalWrite}
 import org.apache.spark.sql.delta.hooks.AutoCompact
 import org.apache.spark.sql.delta.perf.{DeltaOptimizedWriterExec, GlutenDeltaOptimizedWriterExec}
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.schema.InnerInvariantViolationException
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
-import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, WriteJobStatsTracker}
+import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, V1WritesUtils, WriteJobStatsTracker}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.util.ScalaExtensions.OptionExt
 import org.apache.spark.util.SerializableConfiguration
@@ -91,7 +91,7 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
 
       val empty2NullPlan =
         convertEmptyToNullIfNeeded(queryExecution.executedPlan, partitioningColumns, constraints)
-      val maybeCheckInvariants = if (constraints.isEmpty) {
+      val rowInvariantPlan = if (constraints.isEmpty) {
         // Compared to vanilla Delta, we simply avoid adding the invariant checker
         // when the constraint list is empty, to prevent the unnecessary transitions
         // from being added around the invariant checker.
@@ -99,15 +99,22 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
       } else {
         DeltaInvariantCheckerExec(empty2NullPlan, constraints)
       }
+      val nativeInvariantChecker = if (V1WritesUtils.getWriteFilesOpt(empty2NullPlan).isEmpty) {
+        GlutenDeltaInvariantChecker.create(empty2NullPlan.output, constraints)
+      } else {
+        None
+      }
+      val nativeInvariantPlan = nativeInvariantChecker.map(_ => empty2NullPlan).getOrElse(
+        rowInvariantPlan)
       def toVeloxPlan(plan: SparkPlan): SparkPlan = plan match {
         case aqe: AdaptiveSparkPlanExec =>
           assert(!aqe.isFinalPlan)
           aqe.copy(supportsColumnar = true)
-        case _ => Transitions.toBatchPlan(maybeCheckInvariants, VeloxBatchType)
+        case _ => Transitions.toBatchPlan(plan, VeloxBatchType)
       }
       // No need to plan optimized write if the write command is OPTIMIZE, which aims to produce
       // evenly-balanced data files already.
-      val physicalPlan =
+      val (physicalPlan, nativeInvariantCheckerForWrite) =
         if (
           !isOptimize &&
           shouldOptimizeWrite(writeOptions, spark.sessionState.conf)
@@ -115,29 +122,33 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
           // We uniformly convert the query plan to a columnar plan. If
           // the further write operation turns out to be non-offload-able, the
           // columnar plan will be converted back to a row-based plan.
-          val veloxPlan = toVeloxPlan(maybeCheckInvariants)
+          val veloxPlan = toVeloxPlan(nativeInvariantPlan)
           try {
             val glutenWriterExec =
               GlutenDeltaOptimizedWriterExec(veloxPlan, metadata.partitionColumns, deltaLog)
             val validationResult = glutenWriterExec.doValidate()
             if (validationResult.ok()) {
-              glutenWriterExec
+              (glutenWriterExec, nativeInvariantChecker)
             } else {
               logInfo(
                 s"GlutenDeltaOptimizedWriterExec: Internal shuffle validated negative," +
                   s" reason: ${validationResult.reason()}. Falling back to row-based shuffle.")
-              DeltaOptimizedWriterExec(maybeCheckInvariants, metadata.partitionColumns, deltaLog)
+              (
+                DeltaOptimizedWriterExec(rowInvariantPlan, metadata.partitionColumns, deltaLog),
+                None)
             }
           } catch {
             case e: AnalysisException =>
               logWarning(
                 s"GlutenDeltaOptimizedWriterExec: Failed to create internal shuffle," +
                   s" reason: ${e.getMessage()}. Falling back to row-based shuffle.")
-              DeltaOptimizedWriterExec(maybeCheckInvariants, metadata.partitionColumns, deltaLog)
+              (
+                DeltaOptimizedWriterExec(rowInvariantPlan, metadata.partitionColumns, deltaLog),
+                None)
           }
         } else {
-          val veloxPlan = toVeloxPlan(maybeCheckInvariants)
-          veloxPlan
+          val veloxPlan = toVeloxPlan(nativeInvariantPlan)
+          (veloxPlan, nativeInvariantChecker)
         }
 
       val statsTrackers: ListBuffer[WriteJobStatsTracker] = ListBuffer()
@@ -185,7 +196,8 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
             optionalStatsTracker.toSeq
               ++ statsTrackers
               ++ identityTrackerOpt.toSeq,
-          options = options
+          options = options,
+          nativeInvariantChecker = nativeInvariantCheckerForWrite
         )
       } catch {
         case InnerInvariantViolationException(violationException) =>

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/constraints/GlutenDeltaInvariantChecker.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/constraints/GlutenDeltaInvariantChecker.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta.constraints
+
+import org.apache.gluten.columnarbatch.VeloxColumnarBatches
+import org.apache.gluten.execution.{PlaceholderRow, TerminalRow}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.delta.constraints.Constraints.NotNull
+import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, SchemaUtils}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * Native write-time invariant checker for constraints that can be validated without converting
+ * Velox batches back to Spark rows.
+ *
+ * Violations are detected natively from batch null metadata (no per-row expression evaluation, no
+ * extra operator in the write plan) but thrown on the JVM side, preserving Delta's typed
+ * [[DeltaInvariantViolationException]] error contract. Offloading Delta's CheckDeltaInvariant
+ * expression to Velox instead would lose that contract: exceptions raised inside Velox surface only
+ * as GlutenException with a message string. CHECK constraints and nested NOT NULL constraints fall
+ * back to Delta's row-based DeltaInvariantCheckerExec.
+ */
+private[delta] case class GlutenDeltaInvariantChecker private (
+    notNullConstraints: Seq[(Int, NotNull)])
+  extends Serializable {
+
+  @transient private lazy val columnOrdinals: Array[Int] =
+    notNullConstraints.map(_._1).toArray
+
+  def wrap(rows: Iterator[InternalRow]): Iterator[InternalRow] = {
+    rows.map {
+      row =>
+        check(row)
+        row
+    }
+  }
+
+  private def check(row: InternalRow): Unit = row match {
+    case _: PlaceholderRow =>
+    case terminal: TerminalRow => check(terminal.batch())
+    case other => checkRow(other)
+  }
+
+  private def check(batch: ColumnarBatch): Unit = {
+    val failedConstraintIndex = VeloxColumnarBatches.firstNullColumnIndex(batch, columnOrdinals)
+    if (failedConstraintIndex >= 0) {
+      throw DeltaInvariantViolationException(notNullConstraints(failedConstraintIndex)._2)
+    }
+  }
+
+  private def checkRow(row: InternalRow): Unit = {
+    var i = 0
+    while (i < notNullConstraints.size) {
+      val (ordinal, constraint) = notNullConstraints(i)
+      if (row.isNullAt(ordinal)) {
+        throw DeltaInvariantViolationException(constraint)
+      }
+      i += 1
+    }
+  }
+}
+
+private[delta] object GlutenDeltaInvariantChecker {
+  def create(
+      output: Seq[Attribute],
+      constraints: Seq[Constraint]): Option[GlutenDeltaInvariantChecker] = {
+    if (constraints.isEmpty) {
+      return None
+    }
+
+    val topLevelNotNullConstraints = constraints.collect {
+      case constraint: NotNull if constraint.column.length == 1 => constraint
+    }
+    if (topLevelNotNullConstraints.size != constraints.size) {
+      return None
+    }
+
+    val checks = topLevelNotNullConstraints.map {
+      constraint =>
+        val columnName = constraint.column.head
+        val ordinal = output.indexWhere {
+          attribute => SchemaUtils.DELTA_COL_RESOLVER(attribute.name, columnName)
+        }
+        if (ordinal < 0) {
+          return None
+        }
+        ordinal -> constraint
+    }
+    Some(GlutenDeltaInvariantChecker(checks))
+  }
+}

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.expressions.BindReferences.bindReferences
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.delta.DeltaOptions
+import org.apache.spark.sql.delta.constraints.GlutenDeltaInvariantChecker
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.stats.GlutenDeltaJobStatsTracker
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -71,6 +72,12 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
   /** A variable used in tests to check the final executed plan. */
   private var executedPlan: Option[SparkPlan] = None
 
+  private[delta] def getExecutedPlanForTesting: Option[SparkPlan] = executedPlan
+
+  private[delta] def clearExecutedPlanForTesting(): Unit = {
+    executedPlan = None
+  }
+
   // scalastyle:off argcount
   /**
    * Basic work flow of this command is:
@@ -96,7 +103,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       bucketSpec: Option[BucketSpec],
       statsTrackers: Seq[WriteJobStatsTracker],
       options: Map[String, String],
-      numStaticPartitionCols: Int = 0): Set[String] = {
+      numStaticPartitionCols: Int = 0,
+      nativeInvariantChecker: Option[GlutenDeltaInvariantChecker] = None): Set[String] = {
     require(partitionColumns.size >= numStaticPartitionCols)
 
     val job = Job.getInstance(hadoopConf)
@@ -225,7 +233,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
         partitionColumns,
         sortColumns,
         orderingMatched,
-        isNativeWritable
+        isNativeWritable,
+        nativeInvariantChecker
       )
     }
   }
@@ -242,7 +251,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       partitionColumns: Seq[Attribute],
       sortColumns: Seq[Attribute],
       orderingMatched: Boolean,
-      writeOffloadable: Boolean): Set[String] = {
+      writeOffloadable: Boolean,
+      nativeInvariantChecker: Option[GlutenDeltaInvariantChecker]): Set[String] = {
     val projectList = V1WritesUtils.convertEmptyToNull(plan.output, partitionColumns)
     val empty2NullPlan =
       if (projectList.nonEmpty) ProjectExecTransformer(projectList, plan) else plan
@@ -318,7 +328,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
             committer,
             iterator = iter,
             concurrentOutputWriterSpec = concurrentOutputWriterSpec,
-            partitionColumnToDataType
+            partitionColumnToDataType,
+            nativeInvariantChecker
           )
         },
         rddWithNonEmptyPartitions.partitions.indices,
@@ -433,7 +444,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       committer: FileCommitProtocol,
       iterator: Iterator[InternalRow],
       concurrentOutputWriterSpec: Option[ConcurrentOutputWriterSpec],
-      partitionColumnToDataType: Map[String, DataType]): WriteTaskResult = {
+      partitionColumnToDataType: Map[String, DataType],
+      nativeInvariantChecker: Option[GlutenDeltaInvariantChecker]): WriteTaskResult = {
 
     val jobId = SparkHadoopWriterUtils.createJobID(jobTrackerID, sparkStageId)
     val taskId = new TaskID(jobId, TaskType.MAP, sparkPartitionId)
@@ -487,7 +499,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
     try {
       Utils.tryWithSafeFinallyAndFailureCallbacks(block = {
         // Execute the task to write rows out and commit the task.
-        dataWriter.writeWithIterator(iterator)
+        val rowsToWrite = nativeInvariantChecker.map(_.wrap(iterator)).getOrElse(iterator)
+        dataWriter.writeWithIterator(rowsToWrite)
         dataWriter.commit()
       })(
         catchBlock = {

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteInvariantSuite.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteInvariantSuite.scala
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import org.apache.gluten.config.GlutenConfig
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.delta.files.GlutenDeltaFileFormatWriter
+import org.apache.spark.sql.delta.schema.InvariantViolationException
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.command.ExecutedCommandExec
+import org.apache.spark.sql.execution.datasources.v2.{GlutenDeltaLeafRunnableCommand, GlutenDeltaLeafV2CommandExec}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.util.QueryExecutionListener
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+import scala.jdk.CollectionConverters._
+
+class DeltaNativeWriteInvariantSuite extends DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  private lazy val isMac = sys.props
+    .get("os.name")
+    .exists(_.toLowerCase(java.util.Locale.ROOT).contains("mac"))
+
+  private def withNativeWriteOffloadConf[T](f: => T): T = {
+    val confs = Seq(
+      SQLConf.ANSI_ENABLED.key -> "false",
+      SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC",
+      GlutenConfig.GLUTEN_ANSI_FALLBACK_ENABLED.key -> "false",
+      DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false"
+    ) ++
+      (if (isMac) {
+         Seq(GlutenConfig.NATIVE_VALIDATION_ENABLED.key -> "false")
+       } else {
+         Seq.empty
+       })
+
+    var result: Option[T] = None
+    withSQLConf(confs: _*) {
+      result = Some(f)
+    }
+    result.get
+  }
+
+  private def hasGlutenDeltaWriteCommand(plan: SparkPlan): Boolean = {
+    val nativeClassMatch = plan
+      .collectFirst {
+        case ExecutedCommandExec(_: GlutenDeltaLeafRunnableCommand) => true
+        case _: GlutenDeltaLeafV2CommandExec => true
+      }
+      .getOrElse(false)
+
+    val nativeNodeMatch = plan
+      .collectFirst {
+        case p if p.nodeName.startsWith("Execute GlutenDelta ") => true
+        case p if p.nodeName.startsWith("GlutenDelta ") => true
+      }
+      .getOrElse(false)
+
+    val nativeTreeMatch = plan.treeString.contains("GlutenDelta ")
+
+    nativeClassMatch || nativeNodeMatch || nativeTreeMatch
+  }
+
+  private def collectExecutedPlans(action: => Unit): Seq[SparkPlan] = {
+    val plans = new CopyOnWriteArrayList[SparkPlan]()
+    val listener = new QueryExecutionListener {
+      override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+        plans.add(qe.executedPlan)
+      }
+
+      override def onFailure(funcName: String, qe: QueryExecution, exception: Exception): Unit = {}
+    }
+
+    spark.listenerManager.register(listener)
+    try {
+      action
+    } finally {
+      spark.listenerManager.unregister(listener)
+    }
+    plans.asScala.toSeq
+  }
+
+  private def assertContainsNativeWriteCommand(plans: Seq[SparkPlan], context: String): Unit = {
+    assert(
+      plans.exists(hasGlutenDeltaWriteCommand),
+      s"Expected native delta write command for $context, but got plans:\n" +
+        plans.map(_.treeString).mkString("\n---\n")
+    )
+  }
+
+  test("native delta write checks top-level NOT NULL without DeltaInvariantCheckerExec") {
+    withNativeWriteOffloadConf {
+      withTable("delta_native_write_not_null") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            sql(
+              s"CREATE TABLE delta_native_write_not_null " +
+                s"(id BIGINT NOT NULL, value STRING) USING delta LOCATION '$path'")
+
+            GlutenDeltaFileFormatWriter.clearExecutedPlanForTesting()
+            val plans = collectExecutedPlans {
+              Seq((1L, "a"), (2L, "b"))
+                .toDF("id", "value")
+                .write
+                .format("delta")
+                .mode("append")
+                .save(path)
+            }
+
+            assertContainsNativeWriteCommand(plans, "top-level NOT NULL append")
+            val writerPlan = GlutenDeltaFileFormatWriter.getExecutedPlanForTesting
+              .getOrElse(fail("Expected GlutenDeltaFileFormatWriter to record the executed plan"))
+            val writerPlanString = writerPlan.treeString
+            assert(
+              !writerPlanString.contains("DeltaInvariantChecker"),
+              s"Expected native invariant checker to avoid DeltaInvariantCheckerExec, but got:\n" +
+                writerPlanString
+            )
+            assert(
+              !writerPlanString.contains("ColumnarToRow"),
+              s"Expected native invariant checker to avoid C2R transitions, but got:\n" +
+                writerPlanString
+            )
+
+            val result = spark.read.format("delta").load(path)
+            assert(result.collect().toSet == Set(Row(1L, "a"), Row(2L, "b")))
+        }
+      }
+    }
+  }
+
+  test("native delta write keeps DeltaInvariantCheckerExec for CHECK constraints") {
+    withNativeWriteOffloadConf {
+      withTable("delta_native_write_check_constraint") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            sql(
+              s"CREATE TABLE delta_native_write_check_constraint " +
+                s"(id BIGINT, value STRING) USING delta LOCATION '$path' " +
+                s"TBLPROPERTIES ('delta.constraints.id_positive' = 'id > 0')")
+
+            GlutenDeltaFileFormatWriter.clearExecutedPlanForTesting()
+            Seq((1L, "a"), (2L, "b"))
+              .toDF("id", "value")
+              .write
+              .format("delta")
+              .mode("append")
+              .save(path)
+
+            val writerPlan = GlutenDeltaFileFormatWriter.getExecutedPlanForTesting
+              .getOrElse(fail("Expected GlutenDeltaFileFormatWriter to record the executed plan"))
+            assert(
+              writerPlan.treeString.contains("DeltaInvariantChecker"),
+              s"Expected DeltaInvariantCheckerExec for unsupported CHECK constraint, but got:\n" +
+                writerPlan.treeString
+            )
+        }
+      }
+    }
+  }
+
+  test("native delta write reports top-level NOT NULL violations") {
+    withNativeWriteOffloadConf {
+      withTable("delta_native_write_not_null_violation") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            sql(
+              s"CREATE TABLE delta_native_write_not_null_violation " +
+                s"(id BIGINT NOT NULL, value STRING) USING delta LOCATION '$path'")
+
+            val schema = StructType(
+              Seq(
+                StructField("id", LongType, nullable = true),
+                StructField("value", StringType, nullable = true)))
+            val invalidData = spark.createDataFrame(
+              spark.sparkContext.parallelize(Seq(Row(null, "bad"))),
+              schema)
+
+            GlutenDeltaFileFormatWriter.clearExecutedPlanForTesting()
+            val exception = intercept[InvariantViolationException] {
+              invalidData.write.format("delta").mode("append").save(path)
+            }
+            assert(exception.getMessage.toLowerCase(java.util.Locale.ROOT).contains("not null"))
+            assert(exception.getMessage.contains("id"))
+
+            val writerPlan = GlutenDeltaFileFormatWriter.getExecutedPlanForTesting
+              .getOrElse(fail("Expected GlutenDeltaFileFormatWriter to record the executed plan"))
+            assert(
+              !writerPlan.treeString.contains("DeltaInvariantChecker"),
+              s"Expected native invariant checker to avoid DeltaInvariantCheckerExec, but got:\n" +
+                writerPlan.treeString
+            )
+        }
+      }
+    }
+  }
+}

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenOptimisticTransaction.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.extension.columnar.transition.Transitions
 
 import org.apache.spark.sql.{AnalysisException, Dataset}
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction}
-import org.apache.spark.sql.delta.constraints.{Constraint, Constraints, DeltaInvariantCheckerExec}
+import org.apache.spark.sql.delta.constraints.{Constraint, Constraints, DeltaInvariantCheckerExec, GlutenDeltaInvariantChecker}
 import org.apache.spark.sql.delta.files.{GlutenDeltaFileFormatWriter, TransactionalWrite}
 import org.apache.spark.sql.delta.hooks.AutoCompact
 import org.apache.spark.sql.delta.perf.{DeltaOptimizedWriterExec, GlutenDeltaOptimizedWriterExec}
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.schema.InnerInvariantViolationException
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.execution.{SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
-import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, WriteJobStatsTracker}
+import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, V1WritesUtils, WriteJobStatsTracker}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.util.ScalaExtensions.OptionExt
 import org.apache.spark.util.SerializableConfiguration
@@ -104,7 +104,7 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
 
       val empty2NullPlan =
         convertEmptyToNullIfNeeded(queryExecution.executedPlan, partitioningColumns, constraints)
-      val maybeCheckInvariants = if (constraints.isEmpty) {
+      val rowInvariantPlan = if (constraints.isEmpty) {
         // Compared to vanilla Delta, we simply avoid adding the invariant checker
         // when the constraint list is empty, to prevent the unnecessary transitions
         // from being added around the invariant checker.
@@ -112,15 +112,22 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
       } else {
         DeltaInvariantCheckerExec(spark, empty2NullPlan, constraints)
       }
+      val nativeInvariantChecker = if (V1WritesUtils.getWriteFilesOpt(empty2NullPlan).isEmpty) {
+        GlutenDeltaInvariantChecker.create(empty2NullPlan.output, constraints)
+      } else {
+        None
+      }
+      val nativeInvariantPlan = nativeInvariantChecker.map(_ => empty2NullPlan).getOrElse(
+        rowInvariantPlan)
       def toVeloxPlan(plan: SparkPlan): SparkPlan = plan match {
         case aqe: AdaptiveSparkPlanExec =>
           assert(!aqe.isFinalPlan)
           aqe.copy(supportsColumnar = true)
-        case _ => Transitions.toBatchPlan(maybeCheckInvariants, VeloxBatchType)
+        case _ => Transitions.toBatchPlan(plan, VeloxBatchType)
       }
       // No need to plan optimized write if the write command is OPTIMIZE, which aims to produce
       // evenly-balanced data files already.
-      val physicalPlan =
+      val (physicalPlan, nativeInvariantCheckerForWrite) =
         if (
           !isOptimize &&
           shouldOptimizeWrite(writeOptions, spark.sessionState.conf)
@@ -128,29 +135,33 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
           // We uniformly convert the query plan to a columnar plan. If
           // the further write operation turns out to be non-offload-able, the
           // columnar plan will be converted back to a row-based plan.
-          val veloxPlan = toVeloxPlan(maybeCheckInvariants)
+          val veloxPlan = toVeloxPlan(nativeInvariantPlan)
           try {
             val glutenWriterExec =
               GlutenDeltaOptimizedWriterExec(veloxPlan, metadata.partitionColumns, deltaLog)
             val validationResult = glutenWriterExec.doValidate()
             if (validationResult.ok()) {
-              glutenWriterExec
+              (glutenWriterExec, nativeInvariantChecker)
             } else {
               logInfo(
                 s"GlutenDeltaOptimizedWriterExec: Internal shuffle validated negative," +
                   s" reason: ${validationResult.reason()}. Falling back to row-based shuffle.")
-              DeltaOptimizedWriterExec(maybeCheckInvariants, metadata.partitionColumns, deltaLog)
+              (
+                DeltaOptimizedWriterExec(rowInvariantPlan, metadata.partitionColumns, deltaLog),
+                None)
             }
           } catch {
             case e: AnalysisException =>
               logWarning(
                 s"GlutenDeltaOptimizedWriterExec: Failed to create internal shuffle," +
                   s" reason: ${e.getMessage()}. Falling back to row-based shuffle.")
-              DeltaOptimizedWriterExec(maybeCheckInvariants, metadata.partitionColumns, deltaLog)
+              (
+                DeltaOptimizedWriterExec(rowInvariantPlan, metadata.partitionColumns, deltaLog),
+                None)
           }
         } else {
-          val veloxPlan = toVeloxPlan(maybeCheckInvariants)
-          veloxPlan
+          val veloxPlan = toVeloxPlan(nativeInvariantPlan)
+          (veloxPlan, nativeInvariantChecker)
         }
 
       val statsTrackers: ListBuffer[WriteJobStatsTracker] = ListBuffer()
@@ -198,7 +209,8 @@ class GlutenOptimisticTransaction(delegate: OptimisticTransaction)
             optionalStatsTracker.toSeq
               ++ statsTrackers
               ++ identityTrackerOpt.toSeq,
-          options = options
+          options = options,
+          nativeInvariantChecker = nativeInvariantCheckerForWrite
         )
       } catch {
         case InnerInvariantViolationException(violationException) =>

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/constraints/GlutenDeltaInvariantChecker.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/constraints/GlutenDeltaInvariantChecker.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta.constraints
+
+import org.apache.gluten.columnarbatch.VeloxColumnarBatches
+import org.apache.gluten.execution.{PlaceholderRow, TerminalRow}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.delta.constraints.Constraints.NotNull
+import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, SchemaUtils}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+/**
+ * Native write-time invariant checker for constraints that can be validated without converting
+ * Velox batches back to Spark rows.
+ *
+ * Violations are detected natively from batch null metadata (no per-row expression evaluation, no
+ * extra operator in the write plan) but thrown on the JVM side, preserving Delta's typed
+ * [[DeltaInvariantViolationException]] error contract. Offloading Delta's CheckDeltaInvariant
+ * expression to Velox instead would lose that contract: exceptions raised inside Velox surface only
+ * as GlutenException with a message string. CHECK constraints and nested NOT NULL constraints fall
+ * back to Delta's row-based DeltaInvariantCheckerExec.
+ */
+private[delta] case class GlutenDeltaInvariantChecker private (
+    notNullConstraints: Seq[(Int, NotNull)])
+  extends Serializable {
+
+  @transient private lazy val columnOrdinals: Array[Int] =
+    notNullConstraints.map(_._1).toArray
+
+  def wrap(rows: Iterator[InternalRow]): Iterator[InternalRow] = {
+    rows.map {
+      row =>
+        check(row)
+        row
+    }
+  }
+
+  private def check(row: InternalRow): Unit = row match {
+    case _: PlaceholderRow =>
+    case terminal: TerminalRow => check(terminal.batch())
+    case other => checkRow(other)
+  }
+
+  private def check(batch: ColumnarBatch): Unit = {
+    val failedConstraintIndex = VeloxColumnarBatches.firstNullColumnIndex(batch, columnOrdinals)
+    if (failedConstraintIndex >= 0) {
+      throw DeltaInvariantViolationException(notNullConstraints(failedConstraintIndex)._2)
+    }
+  }
+
+  private def checkRow(row: InternalRow): Unit = {
+    var i = 0
+    while (i < notNullConstraints.size) {
+      val (ordinal, constraint) = notNullConstraints(i)
+      if (row.isNullAt(ordinal)) {
+        throw DeltaInvariantViolationException(constraint)
+      }
+      i += 1
+    }
+  }
+}
+
+private[delta] object GlutenDeltaInvariantChecker {
+  def create(
+      output: Seq[Attribute],
+      constraints: Seq[Constraint]): Option[GlutenDeltaInvariantChecker] = {
+    if (constraints.isEmpty) {
+      return None
+    }
+
+    val topLevelNotNullConstraints = constraints.collect {
+      case constraint: NotNull if constraint.column.length == 1 => constraint
+    }
+    if (topLevelNotNullConstraints.size != constraints.size) {
+      return None
+    }
+
+    val checks = topLevelNotNullConstraints.map {
+      constraint =>
+        val columnName = constraint.column.head
+        val ordinal = output.indexWhere {
+          attribute => SchemaUtils.DELTA_COL_RESOLVER(attribute.name, columnName)
+        }
+        if (ordinal < 0) {
+          return None
+        }
+        ordinal -> constraint
+    }
+    Some(GlutenDeltaInvariantChecker(checks))
+  }
+}

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.delta.DeltaOptions
+import org.apache.spark.sql.delta.constraints.GlutenDeltaInvariantChecker
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.stats.GlutenDeltaJobStatsTracker
 import org.apache.spark.sql.errors.QueryExecutionErrors
@@ -76,6 +77,12 @@ object GlutenDeltaFileFormatWriter extends Logging {
    */
   private var executedPlan: Option[SparkPlan] = None
 
+  private[delta] def getExecutedPlanForTesting: Option[SparkPlan] = executedPlan
+
+  private[delta] def clearExecutedPlanForTesting(): Unit = {
+    executedPlan = None
+  }
+
   // scalastyle:off argcount
   /**
    * Basic work flow of this command is:
@@ -92,17 +99,18 @@ object GlutenDeltaFileFormatWriter extends Logging {
    * @return The set of all partition paths that were updated during this write job.
    */
   def write(
-             sparkSession: SparkSession,
-             plan: SparkPlan,
-             fileFormat: FileFormat,
-             committer: FileCommitProtocol,
-             outputSpec: OutputSpec,
-             hadoopConf: Configuration,
-             partitionColumns: Seq[Attribute],
-             bucketSpec: Option[BucketSpec],
-             statsTrackers: Seq[WriteJobStatsTracker],
-             options: Map[String, String],
-             numStaticPartitionCols: Int = 0): Set[String] = {
+      sparkSession: SparkSession,
+      plan: SparkPlan,
+      fileFormat: FileFormat,
+      committer: FileCommitProtocol,
+      outputSpec: OutputSpec,
+      hadoopConf: Configuration,
+      partitionColumns: Seq[Attribute],
+      bucketSpec: Option[BucketSpec],
+      statsTrackers: Seq[WriteJobStatsTracker],
+      options: Map[String, String],
+      numStaticPartitionCols: Int = 0,
+      nativeInvariantChecker: Option[GlutenDeltaInvariantChecker] = None): Set[String] = {
     require(partitionColumns.size >= numStaticPartitionCols)
 
     val job = Job.getInstance(hadoopConf)
@@ -231,24 +239,26 @@ object GlutenDeltaFileFormatWriter extends Logging {
         partitionColumns,
         sortColumns,
         orderingMatched,
-        isNativeWritable
+        isNativeWritable,
+        nativeInvariantChecker
       )
     }
   }
   // scalastyle:on argcount
 
   private def executeWrite(
-                            sparkSession: SparkSession,
-                            plan: SparkPlan,
-                            job: Job,
-                            description: WriteJobDescription,
-                            committer: FileCommitProtocol,
-                            outputSpec: OutputSpec,
-                            requiredOrdering: Seq[Expression],
-                            partitionColumns: Seq[Attribute],
-                            sortColumns: Seq[Attribute],
-                            orderingMatched: Boolean,
-                            writeOffloadable: Boolean): Set[String] = {
+      sparkSession: SparkSession,
+      plan: SparkPlan,
+      job: Job,
+      description: WriteJobDescription,
+      committer: FileCommitProtocol,
+      outputSpec: OutputSpec,
+      requiredOrdering: Seq[Expression],
+      partitionColumns: Seq[Attribute],
+      sortColumns: Seq[Attribute],
+      orderingMatched: Boolean,
+      writeOffloadable: Boolean,
+      nativeInvariantChecker: Option[GlutenDeltaInvariantChecker]): Set[String] = {
     val projectList = V1WritesUtils.convertEmptyToNull(plan.output, partitionColumns)
     val empty2NullPlan = if (projectList.nonEmpty) ProjectExecTransformer(projectList, plan) else plan
 
@@ -319,7 +329,8 @@ object GlutenDeltaFileFormatWriter extends Logging {
             committer,
             iterator = iter,
             concurrentOutputWriterSpec = concurrentOutputWriterSpec,
-            partitionColumnToDataType
+            partitionColumnToDataType,
+            nativeInvariantChecker
           )
         },
         rddWithNonEmptyPartitions.partitions.indices,
@@ -426,15 +437,16 @@ object GlutenDeltaFileFormatWriter extends Logging {
 
   /** Writes data out in a single Spark task. */
   private def executeTask(
-                           description: WriteJobDescription,
-                           jobTrackerID: String,
-                           sparkStageId: Int,
-                           sparkPartitionId: Int,
-                           sparkAttemptNumber: Int,
-                           committer: FileCommitProtocol,
-                           iterator: Iterator[InternalRow],
-                           concurrentOutputWriterSpec: Option[ConcurrentOutputWriterSpec],
-                           partitionColumnToDataType: Map[String, DataType]): WriteTaskResult = {
+      description: WriteJobDescription,
+      jobTrackerID: String,
+      sparkStageId: Int,
+      sparkPartitionId: Int,
+      sparkAttemptNumber: Int,
+      committer: FileCommitProtocol,
+      iterator: Iterator[InternalRow],
+      concurrentOutputWriterSpec: Option[ConcurrentOutputWriterSpec],
+      partitionColumnToDataType: Map[String, DataType],
+      nativeInvariantChecker: Option[GlutenDeltaInvariantChecker]): WriteTaskResult = {
 
     val jobId = SparkHadoopWriterUtils.createJobID(jobTrackerID, sparkStageId)
     val taskId = new TaskID(jobId, TaskType.MAP, sparkPartitionId)
@@ -485,7 +497,8 @@ object GlutenDeltaFileFormatWriter extends Logging {
     try {
       Utils.tryWithSafeFinallyAndFailureCallbacks(block = {
         // Execute the task to write rows out and commit the task.
-        dataWriter.writeWithIterator(iterator)
+        val rowsToWrite = nativeInvariantChecker.map(_.wrap(iterator)).getOrElse(iterator)
+        dataWriter.writeWithIterator(rowsToWrite)
         dataWriter.commit()
       })(catchBlock = {
         // If there is an error, abort the task

--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteSuite.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/DeltaNativeWriteSuite.scala
@@ -23,6 +23,8 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
+import org.apache.spark.sql.delta.files.GlutenDeltaFileFormatWriter
+import org.apache.spark.sql.delta.schema.InvariantViolationException
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.execution.QueryExecution
@@ -30,6 +32,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.ExecutedCommandExec
 import org.apache.spark.sql.execution.datasources.v2.{GlutenDeltaLeafRunnableCommand, GlutenDeltaLeafV2CommandExec, GlutenDeltaRunnableCommand}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
 import org.apache.spark.sql.util.QueryExecutionListener
 
 import java.util.concurrent.{CopyOnWriteArrayList, TimeUnit}
@@ -511,6 +514,116 @@ class DeltaNativeWriteSuite extends DeltaSQLCommandTest {
             "DataFrameWriter.save(overwrite) with native write disabled")
           val result = spark.read.format("delta").load(path)
           assert(result.collect().toSet == Set(Row(1, "a"), Row(2, "b")))
+      }
+    }
+  }
+
+  test("native delta write checks top-level NOT NULL without DeltaInvariantCheckerExec") {
+    withNativeWriteOffloadConf {
+      withTable("delta_native_write_not_null") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            sql(
+              s"CREATE TABLE delta_native_write_not_null " +
+                s"(id BIGINT NOT NULL, value STRING) USING delta LOCATION '$path'")
+
+            GlutenDeltaFileFormatWriter.clearExecutedPlanForTesting()
+            val plans = collectExecutedPlans {
+              Seq((1L, "a"), (2L, "b"))
+                .toDF("id", "value")
+                .write
+                .format("delta")
+                .mode("append")
+                .save(path)
+            }
+
+            assertContainsNativeWriteCommand(plans, "top-level NOT NULL append")
+            val writerPlan = GlutenDeltaFileFormatWriter.getExecutedPlanForTesting
+              .getOrElse(fail("Expected GlutenDeltaFileFormatWriter to record the executed plan"))
+            val writerPlanString = writerPlan.treeString
+            assert(
+              !writerPlanString.contains("DeltaInvariantChecker"),
+              s"Expected native invariant checker to avoid DeltaInvariantCheckerExec, but got:\n" +
+                writerPlanString
+            )
+            assert(
+              !writerPlanString.contains("ColumnarToRow"),
+              s"Expected native invariant checker to avoid C2R transitions, but got:\n" +
+                writerPlanString
+            )
+
+            val result = spark.read.format("delta").load(path)
+            assert(result.collect().toSet == Set(Row(1L, "a"), Row(2L, "b")))
+        }
+      }
+    }
+  }
+
+  test("native delta write keeps DeltaInvariantCheckerExec for CHECK constraints") {
+    withNativeWriteOffloadConf {
+      withTable("delta_native_write_check_constraint") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            sql(
+              s"CREATE TABLE delta_native_write_check_constraint " +
+                s"(id BIGINT, value STRING) USING delta LOCATION '$path' " +
+                s"TBLPROPERTIES ('delta.constraints.id_positive' = 'id > 0')")
+
+            GlutenDeltaFileFormatWriter.clearExecutedPlanForTesting()
+            Seq((1L, "a"), (2L, "b"))
+              .toDF("id", "value")
+              .write
+              .format("delta")
+              .mode("append")
+              .save(path)
+
+            val writerPlan = GlutenDeltaFileFormatWriter.getExecutedPlanForTesting
+              .getOrElse(fail("Expected GlutenDeltaFileFormatWriter to record the executed plan"))
+            assert(
+              writerPlan.treeString.contains("DeltaInvariantChecker"),
+              s"Expected DeltaInvariantCheckerExec for unsupported CHECK constraint, but got:\n" +
+                writerPlan.treeString
+            )
+        }
+      }
+    }
+  }
+
+  test("native delta write reports top-level NOT NULL violations") {
+    withNativeWriteOffloadConf {
+      withTable("delta_native_write_not_null_violation") {
+        withTempDir {
+          dir =>
+            val path = dir.getCanonicalPath
+            sql(
+              s"CREATE TABLE delta_native_write_not_null_violation " +
+                s"(id BIGINT NOT NULL, value STRING) USING delta LOCATION '$path'")
+
+            val schema = StructType(
+              Seq(
+                StructField("id", LongType, nullable = true),
+                StructField("value", StringType, nullable = true)))
+            val invalidData = spark.createDataFrame(
+              spark.sparkContext.parallelize(Seq(Row(null, "bad"))),
+              schema)
+
+            GlutenDeltaFileFormatWriter.clearExecutedPlanForTesting()
+            val exception = intercept[InvariantViolationException] {
+              invalidData.write.format("delta").mode("append").save(path)
+            }
+            assert(exception.getMessage.toLowerCase(java.util.Locale.ROOT).contains("not null"))
+            assert(exception.getMessage.contains("id"))
+
+            val writerPlan = GlutenDeltaFileFormatWriter.getExecutedPlanForTesting
+              .getOrElse(fail("Expected GlutenDeltaFileFormatWriter to record the executed plan"))
+            assert(
+              !writerPlan.treeString.contains("DeltaInvariantChecker"),
+              s"Expected native invariant checker to avoid DeltaInvariantCheckerExec, but got:\n" +
+                writerPlan.treeString
+            )
+        }
       }
     }
   }

--- a/backends-velox/src/main/java/org/apache/gluten/columnarbatch/VeloxColumnarBatchJniWrapper.java
+++ b/backends-velox/src/main/java/org/apache/gluten/columnarbatch/VeloxColumnarBatchJniWrapper.java
@@ -36,6 +36,8 @@ public class VeloxColumnarBatchJniWrapper implements RuntimeAware {
 
   public native long slice(long veloxBatchHandle, int offset, int limit);
 
+  public native int firstNullColumnIndex(long veloxBatchHandle, int[] columnOrdinals);
+
   public native long repeatedThenCompose(
       long repeatedBatch, long nonRepeatedBatch, int[] rowId2RowNums);
 

--- a/backends-velox/src/main/java/org/apache/gluten/columnarbatch/VeloxColumnarBatches.java
+++ b/backends-velox/src/main/java/org/apache/gluten/columnarbatch/VeloxColumnarBatches.java
@@ -142,6 +142,19 @@ public final class VeloxColumnarBatches {
     }
   }
 
+  public static int firstNullColumnIndex(ColumnarBatch batch, int[] columnOrdinals) {
+    if (columnOrdinals.length == 0 || batch.numRows() == 0) {
+      return -1;
+    }
+    ColumnarBatches.checkOffloaded(batch);
+    Runtime runtime =
+        Runtimes.contextInstance(
+            BackendsApiManager.getBackendName(), "VeloxColumnarBatches#firstNullColumnIndex");
+    long nativeHandle = ColumnarBatches.getNativeHandle(BackendsApiManager.getBackendName(), batch);
+    return VeloxColumnarBatchJniWrapper.create(runtime)
+        .firstNullColumnIndex(nativeHandle, columnOrdinals);
+  }
+
   /**
    * repeat batch1 using the array `rowId2RowNums` passed in and then compose with batch2.
    * rowId2RowNums records the number of each row after repeated.

--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -717,6 +717,72 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_columnarbatch_VeloxColumnarBatchJ
   JNI_METHOD_END(kInvalidObjectHandle)
 }
 
+JNIEXPORT jint JNICALL Java_org_apache_gluten_columnarbatch_VeloxColumnarBatchJniWrapper_firstNullColumnIndex( // NOLINT
+    JNIEnv* env,
+    jobject wrapper,
+    jlong veloxBatchHandle,
+    jintArray columnOrdinals) {
+  JNI_METHOD_START
+  auto ctx = getRuntime(env, wrapper);
+  auto runtime = dynamic_cast<VeloxRuntime*>(ctx);
+  auto batch = ObjectStore::retrieve<ColumnarBatch>(veloxBatchHandle);
+  auto safeColumnOrdinals = getIntArrayElementsSafe(env, columnOrdinals);
+
+  const auto numColumnsToCheck = safeColumnOrdinals.length();
+  if (numColumnsToCheck == 0 || batch->numRows() == 0) {
+    return -1;
+  }
+
+  auto veloxBatch = VeloxColumnarBatch::from(runtime->memoryManager()->getLeafMemoryPool().get(), batch);
+  auto rowVector = veloxBatch->getRowVector();
+  const auto rowCount = rowVector->size();
+  const auto columnCount = static_cast<int32_t>(rowVector->childrenSize());
+
+  for (int i = 0; i < numColumnsToCheck; ++i) {
+    const auto ordinal = safeColumnOrdinals.elems()[i];
+    GLUTEN_CHECK(ordinal >= 0 && ordinal < columnCount, "Column ordinal overflow when checking Delta invariant");
+  }
+
+  if (rowVector->mayHaveNulls()) {
+    const auto nullCount = rowVector->getNullCount();
+    if (nullCount.has_value()) {
+      if (*nullCount > 0) {
+        return 0;
+      }
+    } else {
+      for (auto row = 0; row < rowCount; ++row) {
+        if (rowVector->isNullAt(row)) {
+          return 0;
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < numColumnsToCheck; ++i) {
+    const auto ordinal = safeColumnOrdinals.elems()[i];
+    const auto child = rowVector->childAt(ordinal);
+    VELOX_CHECK_NOT_NULL(child, "Column vector is null when checking Delta invariant.");
+    if (!child->mayHaveNulls()) {
+      continue;
+    }
+    const auto nullCount = child->getNullCount();
+    if (nullCount.has_value()) {
+      if (*nullCount > 0) {
+        return i;
+      }
+      continue;
+    }
+    for (auto row = 0; row < rowCount; ++row) {
+      if (child->isNullAt(row)) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+  JNI_METHOD_END(-1)
+}
+
 JNIEXPORT void JNICALL Java_org_apache_gluten_monitor_VeloxMemoryProfiler_start( // NOLINT
     JNIEnv* env,
     jclass) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Revives #12030, which was auto-closed as stale, rebased onto current main. cc @felipepessoto

This patch keeps simple Delta write invariants native in the Velox backend.

The change:

- Adds `GlutenDeltaInvariantChecker` for Delta 3.3 and Delta 4.0 sources.
- Validates top-level `NOT NULL` constraints directly on Velox columnar batches before write.
- Avoids `DeltaInvariantCheckerExec` and `ColumnarToRow` for supported NOT NULL-only writes.
- Keeps unsupported constraints conservative: `CHECK` constraints and nested NOT NULL constraints still use Delta's row checker.
- Adds a Velox JNI helper to detect nulls in selected columns, using cached `nullCount` when available.
- Adds Spark 3.5 and Spark 4.0 tests for native NOT NULL checks, fallback behavior, and violation reporting.

Changes compared to #12030:

- Rebased onto current main.
- Dropped the `VeloxTestSettings` (spark41) flaky-test excludes, which were unrelated to this change; main has since excluded the affected test independently.
- Added a design note on `GlutenDeltaInvariantChecker` documenting why the check is batch-metadata-based rather than an offloaded expression (see below).

### Design note: why not offload `CheckDeltaInvariant` to Velox?

@zhztheplayer asked this on #12030 — I looked at offloading `CheckDeltaInvariant` as an expression before settling on this design. Three reasons I went with the batch-metadata check for the NOT NULL-only case:

1. **Error contract.** Delta's contract is a typed `DeltaInvariantViolationException` with error classes (`DELTA_NOT_NULL_CONSTRAINT_VIOLATED`, etc.), and `writeFiles` unwraps `InnerInvariantViolationException` to re-surface exactly that type. Anything thrown inside Velox crosses the JNI boundary via `JNI_METHOD_END`, which flattens every native exception into `GlutenException(e.what())` — the exception type and error class are lost, only the message survives. Our existing offloaded `raise_error`/`assert_true` show this: `GlutenColumnExpressionSuite` can only assert `RuntimeException` + message-contains, not the vanilla Spark exception types. With this approach the violation is *detected* natively but *thrown* on the JVM side, so we throw the genuine `DeltaInvariantViolationException(constraint)` with full fidelity.

2. **Cost.** An offloaded `CheckDeltaInvariant` still evaluates per row and adds an operator to the write pipeline. The batch check reads Velox vector `nullCount` metadata (falling back to a null-buffer scan only when unset), so the common no-violation case is near-free and there is no plan change at all — which also means nothing new to validate or fall back on.

3. **Surface.** Expression offload needs a new Substrait function, a Velox-side throwing function registration, an `ExpressionTransformer` for a Delta-internal non-SQL expression, and a `DeltaInvariantCheckerExec` transformer with validation/fallback wired into the manually-built write plan. That is a lot of machinery for a case where a metadata read answers the question.

Where expression offload wins is generality: it would cover `CHECK` constraints and nested NOT NULL, which this PR deliberately leaves on the row-based `DeltaInvariantCheckerExec` fallback. I see that as a follow-up that becomes attractive once Gluten has a structured way to map native errors back to typed Spark/Delta exceptions. The fallback structure here doesn't block it — `GlutenDeltaInvariantChecker.create` already returns `None` for anything beyond top-level NOT NULL, so an offloaded path could slot in for those cases later.

## Why are the changes needed?

Delta writes with table invariants currently go through `DeltaInvariantCheckerExec`, which is row-based. Even simple top-level `NOT NULL` constraints can introduce a C2R transition in an otherwise native Delta write path.

This patch handles the safe common case natively while preserving Delta's existing fallback behavior for unsupported constraints.

## Does this PR introduce any user-facing change?

No public API change. Delta constraint behavior is preserved; supported NOT NULL-only writes can stay native.

## How was this patch tested?

On this rebased branch:

- Spark 3.5 (`-Pspark-3.5,delta,spark-ut`) test-compile of `backends-velox`: passed
- Spark 4.0 (`-Pspark-4.0,scala-2.13,java-17,delta,spark-ut`) test-compile of `backends-velox`: passed
- Spark 3.5 and Spark 4.0 spotless: passed
- clang-format-15 on `cpp/velox/jni/VeloxJniWrapper.cc`: clean

On #12030 (same change before the rebase; only conflicts with drifted test imports were resolved):

- Spark 3.5 `DeltaNativeWriteInvariantSuite`: passed
- Spark 4.0 `DeltaNativeWriteSuite`: passed
- C++ Velox build passed, JNI symbol verified in `libvelox.dylib`

Covered cases:

- native Delta write checks top-level NOT NULL without `DeltaInvariantCheckerExec`
- native NOT NULL path avoids `ColumnarToRow`
- CHECK constraints keep `DeltaInvariantCheckerExec`
- NOT NULL violations report `InvariantViolationException`

Note on CI coverage: the Spark 3.5 suite runs in the `velox_backend_enhanced` Spark 3.5 job. The Spark 4.0 delta suites (including the pre-existing `DeltaNativeWriteSuite`) are compile-checked by CI but not currently executed by any Spark 4.0 test job — that is a pre-existing gap for the whole `src-delta40` test tree, so the Spark 4.0 tests were verified locally.

From #12030, a targeted local benchmark for append workloads comparing the native top-level NOT NULL path with an equivalent unsupported CHECK fallback path (2,000,000 rows, 14 columns, 3 append iterations):

| path | avg ms |
| --- | ---: |
| native top-level NOT NULL checker | 1713 |
| row CHECK fallback path | 1664 |

Excluding the first warm-up append:

| path | avg ms |
| --- | ---: |
| native top-level NOT NULL checker | 1605 |
| row CHECK fallback path | 1647 |

The benchmark is effectively neutral because Delta write setup, Parquet output, and commit/log work dominate this microbenchmark. This PR is mainly native write correctness/posture work: it removes a row invariant operator and C2R transition from a common constrained Delta write path.

Related issue: #10215

Tracked by #12025

Supersedes #12030
