### PR TITLE
[GLUTEN-12652][CORE] Support merging two-phase aggregates with FILTER clause

### DIFF
--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MergeTwoPhasesHashBaseAggregate.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/MergeTwoPhasesHashBaseAggregate.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.config.GlutenConfig
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Final, Partial}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Final, Partial}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.aggregate.{BaseAggregateExec, HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
@@ -45,10 +45,19 @@ case class MergeTwoPhasesHashBaseAggregate(session: SparkSession)
   val mergeTwoPhasesAggEnabled: Boolean = GlutenConfig.get.mergeTwoPhasesAggEnabled
 
   private def isPartialAgg(partialAgg: BaseAggregateExec, finalAgg: BaseAggregateExec): Boolean = {
-    // TODO: now it can not support to merge agg which there are the filters in the aggregate exprs.
+    // Aggregates with a FILTER clause can be merged as long as the FILTER predicate is carried
+    // over to the Complete mode aggregate. Note the physical final aggregate has its FILTER
+    // stripped (Spark's AggUtils.mayRemoveAggFilters only keeps FILTER in Partial/Complete modes),
+    // so the FILTER must be restored from the partial aggregate when merging. Spark's aggregate
+    // planning produces the partial and final aggregate expression lists together and keeps them
+    // positionally aligned (the final phase reads the partial buffer by position), so a
+    // partial/final pair can be matched by position. We cannot match by `resultId`: for a single
+    // distinct aggregate, `AggUtils.planAggregateWithOneDistinct` builds the partial and final
+    // distinct expressions with fresh `AggregateExpression` instances, so their `resultId`s differ.
     if (
-      partialAgg.aggregateExpressions.forall(x => x.mode == Partial && x.filter.isEmpty) &&
-      finalAgg.aggregateExpressions.forall(x => x.mode == Final && x.filter.isEmpty)
+      partialAgg.aggregateExpressions.forall(x => x.mode == Partial) &&
+      finalAgg.aggregateExpressions.forall(x => x.mode == Final) &&
+      partialAgg.aggregateExpressions.size == finalAgg.aggregateExpressions.size
     ) {
       (finalAgg.logicalLink, partialAgg.logicalLink) match {
         case (Some(agg1), Some(agg2)) => agg1.sameResult(agg2)
@@ -56,6 +65,23 @@ case class MergeTwoPhasesHashBaseAggregate(session: SparkSession)
       }
     } else {
       false
+    }
+  }
+
+  /**
+   * Builds Complete mode aggregate expressions from the final aggregate. The physical final
+   * aggregate no longer carries the FILTER predicate (see `isPartialAgg`), so the FILTER is
+   * restored from the partial aggregate. A partial/final pair is matched by position: Spark's
+   * aggregate planning emits the two expression lists together and keeps them positionally aligned
+   * (the final phase reads the partial buffer by position), and `isPartialAgg` has already checked
+   * that the two lists have the same size.
+   */
+  private def toCompleteAggregateExpressions(
+      partialAgg: BaseAggregateExec,
+      finalAggExpressions: Seq[AggregateExpression]): Seq[AggregateExpression] = {
+    finalAggExpressions.zip(partialAgg.aggregateExpressions).map {
+      case (finalExpr, partialExpr) =>
+        finalExpr.copy(mode = Complete, filter = partialExpr.filter)
     }
   }
 
@@ -75,7 +101,8 @@ case class MergeTwoPhasesHashBaseAggregate(session: SparkSession)
               resultExpressions,
               child: HashAggregateExec) if !isStreaming && isPartialAgg(child, hashAgg) =>
           // convert to complete mode aggregate expressions
-          val completeAggregateExpressions = aggregateExpressions.map(_.copy(mode = Complete))
+          val completeAggregateExpressions =
+            toCompleteAggregateExpressions(child, aggregateExpressions)
           hashAgg.copy(
             groupingExpressions = child.groupingExpressions,
             aggregateExpressions = completeAggregateExpressions,
@@ -94,7 +121,8 @@ case class MergeTwoPhasesHashBaseAggregate(session: SparkSession)
               child: ObjectHashAggregateExec)
             if !isStreaming && isPartialAgg(child, objectHashAgg) =>
           // convert to complete mode aggregate expressions
-          val completeAggregateExpressions = aggregateExpressions.map(_.copy(mode = Complete))
+          val completeAggregateExpressions =
+            toCompleteAggregateExpressions(child, aggregateExpressions)
           objectHashAgg.copy(
             requiredChildDistributionExpressions = None,
             groupingExpressions = child.groupingExpressions,
@@ -114,7 +142,8 @@ case class MergeTwoPhasesHashBaseAggregate(session: SparkSession)
               child: SortAggregateExec)
             if replaceSortAggWithHashAgg && !isStreaming && isPartialAgg(child, sortAgg) =>
           // convert to complete mode aggregate expressions
-          val completeAggregateExpressions = aggregateExpressions.map(_.copy(mode = Complete))
+          val completeAggregateExpressions =
+            toCompleteAggregateExpressions(child, aggregateExpressions)
           sortAgg.copy(
             requiredChildDistributionExpressions = None,
             groupingExpressions = child.groupingExpressions,

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/execution/MergeTwoPhasesHashBaseAggregateSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/execution/MergeTwoPhasesHashBaseAggregateSuite.scala
@@ -90,14 +90,28 @@ abstract class BaseMergeTwoPhasesHashBaseAggregateSuite extends WholeStageTransf
         1
       )
 
-      // with filter hash aggregate
-      checkHashAggregateCount(
-        spark.sql("""
-                    |SELECT key, count(key) FILTER (WHERE key LIKE '%1%') AS pc2
-                    |FROM v1
-                    |GROUP BY key
-                    |""".stripMargin),
-        2
+      // with filter hash aggregate: it is merged into one complete-mode aggregate, and the
+      // FILTER predicate must be preserved so the result still matches vanilla Spark.
+      compareResultsAgainstVanillaSpark(
+        """
+          |SELECT key, count(key) FILTER (WHERE key LIKE '%1%') AS pc2
+          |FROM v1
+          |GROUP BY key
+          |""".stripMargin,
+        compareResult = true,
+        df => checkHashAggregateCount(df, 1)
+      )
+
+      // mix of filtered and non-filtered aggregates: verifies the FILTER is restored on the
+      // right aggregate expression (positional alignment) after merging to complete mode.
+      compareResultsAgainstVanillaSpark(
+        """
+          |SELECT key, count(key) AS c, count(key) FILTER (WHERE key LIKE '%1%') AS pc2
+          |FROM v1
+          |GROUP BY key
+          |""".stripMargin,
+        compareResult = true,
+        df => checkHashAggregateCount(df, 1)
       )
     }
 
@@ -130,14 +144,16 @@ abstract class BaseMergeTwoPhasesHashBaseAggregateSuite extends WholeStageTransf
         1
       )
 
-      // with filter object aggregate
-      checkObjectAggregateCount(
-        spark.sql("""
-                    |SELECT key, collect_list(key) FILTER (WHERE key LIKE '%1%') AS pc2
-                    |FROM v1
-                    |GROUP BY key
-                    |""".stripMargin),
-        2
+      // with filter object aggregate: it is merged into one complete-mode aggregate, and the
+      // FILTER predicate must be preserved so the result still matches vanilla Spark.
+      compareResultsAgainstVanillaSpark(
+        """
+          |SELECT key, collect_list(key) FILTER (WHERE key LIKE '%1%') AS pc2
+          |FROM v1
+          |GROUP BY key
+          |""".stripMargin,
+        compareResult = true,
+        df => checkObjectAggregateCount(df, 1)
       )
     }
 
@@ -171,14 +187,16 @@ abstract class BaseMergeTwoPhasesHashBaseAggregateSuite extends WholeStageTransf
           1
         )
 
-        // with filter sort aggregate
-        checkSortAggregateCount(
-          spark.sql("""
-                      |SELECT key, sum(if(key<0,0,key)) FILTER (WHERE key LIKE '%1%') AS pc2
-                      |FROM v1
-                      |GROUP BY key
-                      |""".stripMargin),
-          2
+        // with filter sort aggregate: it is merged into one complete-mode aggregate, and the
+        // FILTER predicate must be preserved so the result still matches vanilla Spark.
+        compareResultsAgainstVanillaSpark(
+          """
+            |SELECT key, sum(if(key<0,0,key)) FILTER (WHERE key LIKE '%1%') AS pc2
+            |FROM v1
+            |GROUP BY key
+            |""".stripMargin,
+          compareResult = true,
+          df => checkSortAggregateCount(df, 1)
         )
       }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Previously MergeTwoPhasesHashBaseAggregate skipped merging any two-phase aggregate whose expressions carry a FILTER clause. This PR removes that restriction.

The physical Final aggregate has its FILTER stripped by Spark's AggUtils.mayRemoveAggFilters (FILTER is only kept in Partial/Complete modes). So when merging into Complete mode, the FILTER is now restored from the partial aggregate — whose expressions align 1:1 with the final ones — via a new `toCompleteAggregateExpressions` helper (guarded by a length check). This covers the hash, object-hash, and sort aggregate merge paths.

Fix https://github.com/apache/gluten/issues/12652.
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

Extended MergeTwoPhasesHashBaseAggregateSuite to assert both merge (single aggregate node) and result correctness against vanilla Spark for filtered hash/object/sort aggregates, plus a mixed filtered + non-filtered case that verifies the FILTER is restored on the correct expression by positional alignment.

## Was this patch authored or co-authored using generative AI tooling?
Yes, Generated-by: Claude claude-opus-4-8
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
