### PR TITLE
[GLUTEN-11622][VL] Support Cast from VARCHAR to TIMESTAMP_NTZ

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -621,6 +621,11 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
           checkGlutenPlan[ProjectExecTransformer]
         }
 
+        // cast(timestamp_ntz as string)
+        runQueryAndCompare("select cast(ts as string) from view") {
+          checkGlutenPlan[ProjectExecTransformer]
+        }
+
         withSQLConf("spark.sql.session.timeZone" -> "Asia/Hong_Kong") {
           val dstPath = dir.getAbsolutePath + "/dst_gap"
           spark
@@ -660,6 +665,21 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
           runQueryAndCompare("select cast(ts as timestamp_ntz) from ts_view") {
             checkGlutenPlan[ProjectExecTransformer]
           }
+        }
+
+        val strPath = dir.getAbsolutePath + "/str_view"
+        spark
+          .createDataset(inputs)
+          .toDF("str")
+          .coalesce(1)
+          .write
+          .mode("overwrite")
+          .parquet(strPath)
+        spark.read.parquet(strPath).createOrReplaceTempView("str_view")
+
+        // cast(varchar as timestamp_ntz)
+        runQueryAndCompare("select cast(str as timestamp_ntz) from str_view") {
+          checkGlutenPlan[ProjectExecTransformer]
         }
     }
   }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -303,7 +303,9 @@ bool SubstraitToVeloxPlanValidator::isAllowedCast(const TypePtr& fromType, const
     return false;
   }
   if (toType->equivalent(*TIMESTAMP_UTC())) {
-    // Only supports from Timestamp to TimestampNTZ.
+    if (fromType->isVarchar()) {
+      return true;
+    }
     return false;
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/validator/Validators.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.execution.exchange.{BroadcastExchangeExec, ShuffleEx
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.hive.HiveTableScanExecTransformer
-import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType, TimestampType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 
 object Validators {
   implicit class ValidatorBuilderImplicits(builder: Validator.Builder) {
@@ -283,8 +283,7 @@ object Validators {
                   case Minute(child, _) => containsNTZ(child.dataType)
                   case Second(child, _) => containsNTZ(child.dataType)
                   case TimestampAdd(_, _, child, _) => containsNTZ(child.dataType)
-                  case c: Cast if c.dataType == TimestampType => isNTZ(c.child.dataType)
-                  case c: Cast if isNTZ(c.dataType) => c.child.dataType == TimestampType
+                  case c: Cast if isNTZ(c.dataType) || isNTZ(c.child.dataType) => true
                   case _ => false
                 }
             }


### PR DESCRIPTION
Enable CAST(varchar AS timestamp_ntz) and CAST(timestamp_ntz AS string)
to run natively in the Velox backend instead of falling back to Spark.

Velox PR: facebookincubator/velox#17498, facebookincubator/velox#17514

Related issue: #11622
