### PR TITLE
[GLUTEN-12655][CORE] Reset the component graph after ComponentSuite

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
@@ -47,12 +47,20 @@ trait Component {
     if (!isRegistered.compareAndSet(false, true)) {
       return
     }
-    graph.add(this)
+    try {
+      graph.add(this)
+    } catch {
+      // Nothing entered the graph, so Graph#clear will not see this component and cannot reset
+      // its flag. Roll the flag back here to keep it in sync with the graph.
+      case t: Throwable =>
+        isRegistered.set(false)
+        throw t
+    }
     dependencies().foreach(req => graph.declareDependency(this, req))
   }
 
   // Visible for testing. Paired with Graph#clear so a cleared component can register again.
-  private[component] def resetRegisteredForTesting(): Unit = {
+  final private[component] def resetRegisteredForTesting(): Unit = {
     isRegistered.set(false)
   }
 
@@ -129,14 +137,8 @@ object Component extends Logging {
     graph.sorted()
   }
 
-  /**
-   * Removes all registered components from the graph, and resets their registration flags so they
-   * can be registered again.
-   *
-   * Visible for testing. The graph is JVM-global, so a suite that registers components into it
-   * leaks them into every later suite that calls #sorted. Such a suite must call
-   * [[org.apache.gluten.component.clearAllForTesting]] when it finishes.
-   */
+  // Visible for testing. Internal to component.clearAllForTesting; does not touch the discovery
+  // latch.
   private[component] def clearForTesting(): Unit = {
     graph.clear()
   }

--- a/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
@@ -51,6 +51,11 @@ trait Component {
     dependencies().foreach(req => graph.declareDependency(this, req))
   }
 
+  // Visible for testing. Paired with Graph#clear so a cleared component can register again.
+  private[component] def resetRegisteredForTesting(): Unit = {
+    isRegistered.set(false)
+  }
+
   /**
    * Determines whether a component should be registered based on runtime conditions. For instance,
    * if a component depends on a Spark extension's JAR, this method should be overridden to check
@@ -124,6 +129,18 @@ object Component extends Logging {
     graph.sorted()
   }
 
+  /**
+   * Removes all registered components from the graph, and resets their registration flags so they
+   * can be registered again.
+   *
+   * Visible for testing. The graph is JVM-global, so a suite that registers components into it
+   * leaks them into every later suite that calls #sorted. Such a suite must call
+   * [[org.apache.gluten.component.clearAllForTesting]] when it finishes.
+   */
+  private[component] def clearForTesting(): Unit = {
+    graph.clear()
+  }
+
   private class Registry {
     private val lookupByUid: mutable.Map[Int, Component] = mutable.Map()
     private val lookupByClass: mutable.Map[Class[_ <: Component], Component] = mutable.Map()
@@ -137,6 +154,12 @@ object Component extends Logging {
         s"Component class $clazz already registered: ${comp.name()}")
       lookupByUid(uid) = comp
       lookupByClass(clazz) = comp
+    }
+
+    def clear(): Unit = synchronized {
+      lookupByUid.values.foreach(_.resetRegisteredForTesting())
+      lookupByUid.clear()
+      lookupByClass.clear()
     }
 
     def isUidRegistered(uid: Int): Boolean = synchronized {
@@ -188,6 +211,12 @@ object Component extends Logging {
         uidAndDependencyPairs += comp.uid -> dependencyCompClass
         sortedComponents = None
       }
+
+    def clear(): Unit = synchronized {
+      registry.clear()
+      uidAndDependencyPairs.clear()
+      sortedComponents = None
+    }
 
     private def newLookup(): Map[Int, Node] = {
       val uidToNodeLookup: mutable.Map[Int, Node] = mutable.Map()

--- a/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/Component.scala
@@ -28,6 +28,7 @@ import org.apache.spark.internal.Logging
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 /**
  * The base API to inject user-defined logic to Gluten. To register a component, the implementation
@@ -52,7 +53,7 @@ trait Component {
     } catch {
       // Nothing entered the graph, so Graph#clear will not see this component and cannot reset
       // its flag. Roll the flag back here to keep it in sync with the graph.
-      case t: Throwable =>
+      case NonFatal(t) =>
         isRegistered.set(false)
         throw t
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
@@ -45,4 +45,17 @@ package object component extends Logging {
     )
     logInfo(s"Components registered within order: ${components.map(_.name()).mkString(", ")}")
   }
+
+  /**
+   * Empties the component graph and lets the next call to [[Component.sorted]] rediscover the
+   * components on the classpath.
+   *
+   * Visible for testing. The graph and the discovery latch are both JVM-global, so a suite that
+   * registers components of its own leaks them into every later suite in the same JVM. Such a suite
+   * must call this when it finishes.
+   */
+  private[gluten] def clearAllForTesting(): Unit = {
+    Component.clearForTesting()
+    allComponentsLoaded.set(false)
+  }
 }

--- a/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/component/package.scala
@@ -47,15 +47,25 @@ package object component extends Logging {
   }
 
   /**
-   * Empties the component graph and lets the next call to [[Component.sorted]] rediscover the
-   * components on the classpath.
+   * Empties the component graph and re-arms the discovery latch, so the next call to
+   * [[Component.sorted]] runs classpath discovery again.
    *
-   * Visible for testing. The graph and the discovery latch are both JVM-global, so a suite that
-   * registers components of its own leaks them into every later suite in the same JVM. Such a suite
-   * must call this when it finishes.
+   * Only the graph and the latch are reset. Values derived from an earlier [[Component.sorted]] are
+   * not: `BackendsApiManager.backend`, `GlutenCostModel.costModelRegistry` and the `graphCache`
+   * inside `Transition.factory` keep what they computed from the pre-clear component set. Neither
+   * are the per-vertex `TransitionGraph.Vertex.initialized` flags, so a re-registered component
+   * does not add its transition edges a second time. Rediscovery also constructs fresh component
+   * instances, so such a value can end up holding an instance that is no longer the one in the
+   * graph.
+   *
+   * Visible for testing. The graph and the latch are both JVM-global, so a suite that registers
+   * components of its own leaks them into every later suite in the same JVM. Such a suite must call
+   * this when it finishes.
    */
   private[gluten] def clearAllForTesting(): Unit = {
     Component.clearForTesting()
+    // Re-arms discovery. Unobservable in gluten-core, whose test classpath carries no
+    // 'META-INF/gluten-components' file; the backend modules are the ones that need it.
     allComponentsLoaded.set(false)
   }
 }

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentGraphResetSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentGraphResetSuite.scala
@@ -18,14 +18,26 @@ package org.apache.gluten.component
 
 import org.apache.gluten.extension.injector.Injector
 
+import org.scalatest.{Args, BeforeAndAfterAll, Reporter}
+import org.scalatest.events.{Event, SuiteAborted, TestFailed}
 import org.scalatest.funsuite.AnyFunSuite
 
-class ComponentGraphResetSuite extends AnyFunSuite {
+import scala.collection.mutable
+
+class ComponentGraphResetSuite extends AnyFunSuite with BeforeAndAfterAll {
   import ComponentGraphResetSuite._
+
+  override protected def afterAll(): Unit = {
+    // Every test here registers components of its own into the JVM-global graph. Clearing from
+    // afterAll rather than from the test body makes sure a failed assertion cannot leak them.
+    clearAllForTesting()
+    super.afterAll()
+  }
 
   test("a cycle registered by an earlier suite does not outlive the reset") {
     // Reproduces what ComponentSuite leaves behind: components wired into a cycle. Without the
     // reset these stay in the JVM-global graph and every later Component#sorted call throws.
+    clearAllForTesting()
     new CycleA().ensureRegistered()
     new CycleB().ensureRegistered()
     assertThrows[UnsupportedOperationException](Component.sortedUnsafe())
@@ -33,12 +45,60 @@ class ComponentGraphResetSuite extends AnyFunSuite {
     clearAllForTesting()
 
     // The graph is empty again, so sorting no longer reports the cycle.
-    val sorted = Component.sortedUnsafe()
-    assert(!sorted.exists(c => c.name() == "reset-A" || c.name() == "reset-B"))
+    assert(Component.sortedUnsafe().isEmpty)
+  }
+
+  test("a component cleared from the graph can be registered again") {
+    // Covers the registration-flag reset the clear performs: without it this very instance could
+    // never re-enter the graph, because ensureRegistered short-circuits on its own flag.
+    clearAllForTesting()
+    val standalone = new Standalone()
+    standalone.ensureRegistered()
+    assert(Component.sortedUnsafe().exists(_.name() == StandaloneName))
+
+    clearAllForTesting()
+    assert(Component.sortedUnsafe().isEmpty)
+
+    standalone.ensureRegistered()
+    assert(Component.sortedUnsafe().exists(_.name() == StandaloneName))
+  }
+
+  test("ComponentSuite leaves the component graph empty") {
+    // Covers ComponentSuite's own cleanup without depending on suite execution order: run that
+    // suite in-process, then assert it took its dummy components back out of the graph.
+    clearAllForTesting()
+    val reporter = new FailureCollectingReporter()
+    val status = new ComponentSuite().run(None, Args(reporter))
+    assert(status.succeeds(), s"ComponentSuite itself failed: ${reporter.failures.mkString("; ")}")
+    assert(Component.sortedUnsafe().isEmpty)
   }
 }
 
 object ComponentGraphResetSuite {
+  private val StandaloneName: String = "reset-standalone"
+
+  /**
+   * Keeps the nested suite's events out of the test log, while retaining enough of them to say what
+   * went wrong if the nested suite itself fails.
+   */
+  private class FailureCollectingReporter extends Reporter {
+    private val buffer = mutable.Buffer[String]()
+
+    def failures: Seq[String] = buffer.toSeq
+
+    override def apply(event: Event): Unit = event match {
+      case e: TestFailed => buffer += s"${e.testName}: ${e.message}"
+      case e: SuiteAborted => buffer += s"${e.suiteName} aborted: ${e.message}"
+      case _ =>
+    }
+  }
+
+  private class Standalone extends Component {
+    override def name(): String = StandaloneName
+    override def dependencies(): Seq[Class[_ <: Component]] = Nil
+    override def injectRules(injector: Injector): Unit = {}
+  }
+
   private class CycleA extends Component {
     override def name(): String = "reset-A"
     override def dependencies(): Seq[Class[_ <: Component]] = Seq(classOf[CycleB])

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentGraphResetSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentGraphResetSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.component
+
+import org.apache.gluten.extension.injector.Injector
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ComponentGraphResetSuite extends AnyFunSuite {
+  import ComponentGraphResetSuite._
+
+  test("a cycle registered by an earlier suite does not outlive the reset") {
+    // Reproduces what ComponentSuite leaves behind: components wired into a cycle. Without the
+    // reset these stay in the JVM-global graph and every later Component#sorted call throws.
+    new CycleA().ensureRegistered()
+    new CycleB().ensureRegistered()
+    assertThrows[UnsupportedOperationException](Component.sortedUnsafe())
+
+    clearAllForTesting()
+
+    // The graph is empty again, so sorting no longer reports the cycle.
+    val sorted = Component.sortedUnsafe()
+    assert(!sorted.exists(c => c.name() == "reset-A" || c.name() == "reset-B"))
+  }
+}
+
+object ComponentGraphResetSuite {
+  private class CycleA extends Component {
+    override def name(): String = "reset-A"
+    override def dependencies(): Seq[Class[_ <: Component]] = Seq(classOf[CycleB])
+    override def injectRules(injector: Injector): Unit = {}
+  }
+
+  private class CycleB extends Component {
+    override def name(): String = "reset-B"
+    override def dependencies(): Seq[Class[_ <: Component]] = Seq(classOf[CycleA])
+    override def injectRules(injector: Injector): Unit = {}
+  }
+}

--- a/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/component/ComponentSuite.scala
@@ -27,6 +27,14 @@ import scala.collection.mutable
 class ComponentSuite extends AnyFunSuite with BeforeAndAfterAll {
   import ComponentSuite._
 
+  override protected def afterAll(): Unit = {
+    // The component graph is JVM-global, and these tests register dummy components into it,
+    // including a deliberate dependency cycle. Leaving them behind makes any later suite that
+    // calls Component#sorted fail.
+    clearAllForTesting()
+    super.afterAll()
+  }
+
   test("Load order") {
     val a = new DummyBackend("A") {}
     val b = new DummyBackend("B") {}


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ComponentSuite` registers dummy components into the JVM-global component graph, including a deliberate dependency cycle, and never removes them. Any later suite in the same JVM that calls `Component.sorted()` then fails with `Cycle detected in the component graph: B, D, C`, naming components unrelated to the failing test. Nothing in `gluten-core` calls `sorted()` after `ComponentSuite` today, but ten call sites in main sources reach it, so a suite that boots a `SparkContext` with the Gluten plugin fails as soon as it is ordered after `ComponentSuite`.

`Component`'s graph and the `allComponentsLoaded` discovery latch are `object`-level state with no reset, so a suite that registers components cannot clean up after itself. This adds a testing-only reset that empties the graph, clears each component's registration flag so it can register again, and re-arms the latch. `ComponentSuite#afterAll` calls it.

`ensureRegistered` now rolls its flag back when `graph.add` throws. A component that never entered the graph is invisible to `Registry#clear`, so without the rollback its flag stays set and it can never register again. The rollback covers only `graph.add`, not `dependencies()`: a component that is already in the graph would then fail its next registration with a misleading "UID already registered". `resetRegisteredForTesting` is `final`, since nine of the eleven in-repo `Component` implementations sit in this package and could otherwise override it to a no-op and silently defeat the clear.

Four values survive the reset, and the `clearAllForTesting` scaladoc now says so: `BackendsApiManager.backend`, `GlutenCostModel.costModelRegistry`, the `graphCache` inside `Transition.factory`, and the per-vertex `TransitionGraph.Vertex.initialized` flags all keep what they computed from the pre-clear component set. Rediscovery also constructs fresh instances, so one of those values can end up holding an instance that is no longer the one in the graph. The latch line carries a comment explaining it serves the backend modules, whose classpath carries component files, so it does not read as dead code here.

### How was this patch tested?

Added `ComponentGraphResetSuite` with three tests, each covering one part of the reset:

- register a cycle, reset, assert the graph is empty;
- register a component, reset, register the same instance again, assert it is back in the graph. This fails without the registration-flag reset;
- run `ComponentSuite` in-process via `new ComponentSuite().run(None, Args(reporter))` and assert the graph is empty afterwards. That covers the fix's own call site without depending on suite execution order, and fails when `ComponentSuite#afterAll` is removed.

Cleanup lives in `afterAll` so a failed assertion cannot leak the cycle the suite registers. I verified each test fails against the corresponding mutant, and that `mvn -pl gluten-core,gluten-substrait test` passes (37 + 51), both in the natural suite order and with `ComponentSuite` forced to run first.

Closes #12655
