### PR TITLE
[GLUTEN-12094][VL] Strip default array_sort comparator for Velox offloading

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -214,7 +214,13 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
       argument: ExpressionTransformer,
       function: ExpressionTransformer,
       expr: ArraySort): ExpressionTransformer = {
-    GenericExpressionTransformer(substraitExprName, Seq(argument, function), expr)
+    val children = expr.function match {
+      case LambdaFunction(functionBody, Seq(left, right), _)
+          if functionBody.semanticEquals(ArraySort.comparator(left, right)) =>
+        Seq(argument)
+      case _ => Seq(argument, function)
+    }
+    GenericExpressionTransformer(substraitExprName, children, expr)
   }
 
   /** Transform array exists to Substrait */

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1234,6 +1234,36 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
       }
     }
   }
+  test("array_sort with default comparator") {
+    withTable("array_sort_default") {
+      sql("create table array_sort_default (id int, a array<int>) using parquet")
+      sql(
+        "insert into array_sort_default values " +
+          "(1, array(3, null, 1, 2)), " +
+          "(2, cast(array() as array<int>)), " +
+          "(3, cast(null as array<int>)), " +
+          "(4, array(-1, 0, 1))")
+      runQueryAndCompare(
+        "select id, array_sort(a) from array_sort_default order by id") {
+        checkGlutenPlan[ProjectExecTransformer]
+      }
+      runQueryAndCompare(
+        "select id, array_sort(a, (x, y) -> " +
+          "if(x < y, 1, if(x > y, -1, 0))) from array_sort_default where id = 4") {
+        checkGlutenPlan[ProjectExecTransformer]
+      }
+    }
+    withTable("array_sort_default_double") {
+      sql("create table array_sort_default_double (a array<double>) using parquet")
+      sql(
+        "insert into array_sort_default_double values " +
+          "(array(cast('NaN' as double), cast(0.0 as double), " +
+          "cast(-1.0 as double), cast(null as double)))")
+      runQueryAndCompare("select array_sort(a) from array_sort_default_double") {
+        checkGlutenPlan[ProjectExecTransformer]
+      }
+    }
+  }
 
   test("Support bool type filter in scan") {
     withTable("t") {


### PR DESCRIPTION
### What changes

Spark represents `array_sort(array)` using a generated null-aware default comparator. Gluten currently passes this comparator to Velox as a lambda, but Velox cannot rewrite it and falls back to Spark execution.

This change detects Spark's default comparator using the bound lambda arguments and omits the lambda only for an exact semantic match (`semanticEquals`), allowing Velox to use its native one-argument `array_sort`.

Custom comparators remain unchanged and continue using the two-argument path.

This revives and revalidates the approach from #12095, which was auto-closed as stale.

Fixes #12094

### Tests

- Spark 4.0.2 targeted native test passed (`MiscOperatorSuite - "array_sort with default comparator"`; full suite blocked by unrelated Velox HashTable SIGFPE)
- Spark 4.1.1 targeted native test passed (`MiscOperatorSuite - "array_sort with default comparator"`, 1/1 PASS, BUILD SUCCESS)
- Spark 3.5 clean compile and test-compile passed (`./build/mvn -ntp clean test-compile -Pspark-3.5 -Pscala-2.12 -Pjava-17 -Pbackends-velox -Pspark-ut`)
- Test coverage: integer arrays, null elements, empty array, null array, double arrays with NaN, descending custom-comparator negative control
- Spark oracle comparison and `ProjectExecTransformer` plan assertion verified

### AI Tooling Disclosure

Was this patch authored or co-authored using generative AI tooling?
Generated-by: Gemini 3.6 Flash