### PR TITLE
[GLUTEN-12668][CORE] Add injectPre hook so rules survive whole-stage AQE fallback

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/heuristic/HeuristicApplier.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.execution.SparkPlan
  */
 class HeuristicApplier(
     session: SparkSession,
+    preBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]],
     transformBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]],
     fallbackPolicyBuilders: Seq[ColumnarRuleCall => SparkPlan => Rule[SparkPlan]],
     postBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]],
@@ -47,10 +48,15 @@ class HeuristicApplier(
 
   private def makeRule(call: ColumnarRuleCall): Rule[SparkPlan] = {
     originalPlan =>
-      val suggestedPlan = transformPlan("transform", transformRules(call), originalPlan)
+      // `rewrittenPlan` (not `originalPlan`) is what `fallbackPolicies` uses as its reference
+      // plan, so a whole-stage fallback reverts to the already-`pre`-rewritten plan instead of
+      // the raw vanilla one. Rules registered here are therefore immune to being reverted away
+      // by whole-stage fallback.
+      val rewrittenPlan = transformPlan("pre", preRules(call), originalPlan)
+      val suggestedPlan = transformPlan("transform", transformRules(call), rewrittenPlan)
       val finalPlan = transformPlan(
         "fallback",
-        fallbackPolicies(call).map(_(originalPlan)),
+        fallbackPolicies(call).map(_(rewrittenPlan)),
         suggestedPlan) match {
         case FallbackNode(fallbackPlan) =>
           // we should use vanilla c2r rather than native c2r,
@@ -72,6 +78,15 @@ class HeuristicApplier(
         rules.map(wrapper)
     }
     new ColumnarRuleExecutor(phase, wrappedRules).execute(plan)
+  }
+
+  /**
+   * Rules applying to the plan before any offload decision is made. Unlike `transformRules`,
+   * `preRules` are consistently baked into the plan that `fallbackPolicies` reverts to on
+   * whole-stage fallback, so their effects cannot be reverted away.
+   */
+  private def preRules(call: ColumnarRuleCall): Seq[Rule[SparkPlan]] = {
+    preBuilders.map(b => b.apply(call))
   }
 
   /**

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/injector/GlutenInjector.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/injector/GlutenInjector.scala
@@ -46,6 +46,7 @@ class GlutenInjector private[injector] (control: InjectorControl) {
 
 object GlutenInjector {
   class LegacyInjector {
+    private val preBuilders = mutable.Buffer.empty[ColumnarRuleCall => Rule[SparkPlan]]
     private val preTransformBuilders = mutable.Buffer.empty[ColumnarRuleCall => Rule[SparkPlan]]
     private val transformBuilders = mutable.Buffer.empty[ColumnarRuleCall => Rule[SparkPlan]]
     private val postTransformBuilders = mutable.Buffer.empty[ColumnarRuleCall => Rule[SparkPlan]]
@@ -54,6 +55,10 @@ object GlutenInjector {
     private val postBuilders = mutable.Buffer.empty[ColumnarRuleCall => Rule[SparkPlan]]
     private val finalBuilders = mutable.Buffer.empty[ColumnarRuleCall => Rule[SparkPlan]]
     private val ruleWrappers = mutable.Buffer.empty[Rule[SparkPlan] => Rule[SparkPlan]]
+
+    def injectPre(builder: ColumnarRuleCall => Rule[SparkPlan]): Unit = {
+      preBuilders += builder
+    }
 
     def injectPreTransform(builder: ColumnarRuleCall => Rule[SparkPlan]): Unit = {
       preTransformBuilders += builder
@@ -86,6 +91,7 @@ object GlutenInjector {
     private[injector] def createApplier(session: SparkSession): ColumnarRuleApplier = {
       new HeuristicApplier(
         session,
+        preBuilders.toSeq,
         (preTransformBuilders ++ Seq(
           c => createHeuristicTransform(c)) ++ postTransformBuilders).toSeq,
         fallbackPolicyBuilders.toSeq,

--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -185,6 +185,7 @@ private object FallbackStrategiesSuite {
       transformBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]]): HeuristicApplier = {
     new HeuristicApplier(
       spark,
+      Nil,
       transformBuilders,
       List(c => p => ExpandFallbackPolicy(c.caller.isAqe(), p)),
       List(

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -185,6 +185,7 @@ private object FallbackStrategiesSuite {
       transformBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]]): HeuristicApplier = {
     new HeuristicApplier(
       spark,
+      Nil,
       transformBuilders,
       List(c => p => ExpandFallbackPolicy(c.caller.isAqe(), p)),
       List(

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/execution/FallbackStrategiesSuite.scala
@@ -186,6 +186,7 @@ private object FallbackStrategiesSuite {
       transformBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]]): HeuristicApplier = {
     new HeuristicApplier(
       spark,
+      Nil,
       transformBuilders,
       List(c => p => ExpandFallbackPolicy(c.caller.isAqe(), p)),
       List(

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
@@ -187,6 +187,7 @@ private object GlutenFallbackStrategiesSuite {
       transformBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]]): HeuristicApplier = {
     new HeuristicApplier(
       spark,
+      Nil,
       transformBuilders,
       List(c => p => ExpandFallbackPolicy(c.caller.isAqe(), p)),
       List(

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/gluten/GlutenFallbackStrategiesSuite.scala
@@ -187,6 +187,7 @@ private object GlutenFallbackStrategiesSuite {
       transformBuilders: Seq[ColumnarRuleCall => Rule[SparkPlan]]): HeuristicApplier = {
     new HeuristicApplier(
       spark,
+      Nil,
       transformBuilders,
       List(c => p => ExpandFallbackPolicy(c.caller.isAqe(), p)),
       List(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #12668.

Discussed in review of #12151 (GLUTEN-12013 bloom filter fix): https://github.com/apache/gluten/pull/12151#issuecomment-5103480155

### Background

Today, `ExpandFallbackPolicy`'s whole-stage-fallback revert target (`originalPlan` in `HeuristicApplier.makeRule`) is captured before *any* physical rule runs -- including `injectPreTransform` rules. This means a rule registered at `injectPreTransform` gets its rewrite stripped away whenever `ExpandFallbackPolicy` promotes an individual-stage fallback to a whole-stage one, requiring a second re-application registered at `injectFinal` as a workaround (see `RuntimeBloomFilterRewriteRule` in #12151).

### Proposal

Add a new `injectPre` hook to `GlutenInjector.LegacyInjector`, with its own `"pre"` phase in `HeuristicApplier.makeRule`, running before `"transform"`. `fallbackPolicies` closes over the post-`"pre"` plan instead of the raw `originalPlan`, so a whole-stage revert can no longer strip away anything registered at `injectPre` -- removing the need for the `injectFinal` re-application workaround.

This is purely additive: a new empty-by-default builder list threaded through `HeuristicApplier`'s constructor. No existing backend (Velox, ClickHouse) needs to change unless it opts in. The five `FallbackStrategiesSuite`/`GlutenFallbackStrategiesSuite` test files across `gluten-ut/spark{33,34,35,40,41}` construct `HeuristicApplier` directly (bypassing the injector layer) and needed a trivial update (an extra `Nil` argument) for the new constructor parameter.

Once merged, #12151 will be rebased to use `injectPre` for `RuntimeBloomFilterRewriteRule`, collapsing its current two registrations (`injectPreTransform` + `injectFinal`) down to one.

## How was this patch tested?

- Full 7-suite TPC-DS/TPC-H plan-stability set (322/322): confirms the new no-op-by-default `"pre"` phase changes no existing plan or behavior.
- `backends-clickhouse` builds, links, and packages successfully unmodified against the changed `gluten-core` (`CHRuleApi.scala` never calls `injectPre`).
- Prototyped switching `RuntimeBloomFilterRewriteRule` (#12151) to a single `injectPre` registration: full Velox bloom-filter suite passes, including both whole-stage-reversion scenarios and native-offload preservation, with the TPC-DS/TPC-H plan-stability suite unchanged.