### PR TITLE
[VL] Support regexp_instr function

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/utils/CHExpressionUtil.scala
@@ -212,6 +212,7 @@ object CHExpressionUtil {
     VARCHAR_TYPE_WRITE_SIDE_CHECK -> DefaultValidator(),
     CHAR_TYPE_WRITE_SIDE_CHECK -> DefaultValidator(),
     READ_SIDE_PADDING -> DefaultValidator(),
-    DIV -> DefaultValidator()
+    DIV -> DefaultValidator(),
+    REGEXP_INSTR -> DefaultValidator()
   )
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -714,6 +714,29 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  testWithMinSparkVersion("regexp_instr", "3.4") {
+    // Two-argument form.
+    runQueryAndCompare("SELECT regexp_instr(c_comment, '\\w+') FROM customer limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    // No match returns 0.
+    runQueryAndCompare("SELECT regexp_instr(c_comment, '#[0-9]+#') FROM customer limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    // Three-argument form: Spark ignores the group index and Velox has no such
+    // argument, so the idx child must be dropped while staying result-consistent.
+    runQueryAndCompare("SELECT regexp_instr(c_comment, '(\\w)(\\w)', 1) FROM customer limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    // Three-argument form where the requested group starts at a different
+    // position than the whole match: the whole match "a1" starts at 1 while
+    // group 2 "1" starts at 2. Spark ignores idx and returns 1, so this guards
+    // against any future divergence if Spark starts honoring the group index.
+    runQueryAndCompare("SELECT regexp_instr('a1b2', '([a-z])([0-9])', 2)") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+  }
+
   testWithMinSparkVersion("mask", "3.4") {
     runQueryAndCompare("SELECT mask(c_comment) FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -54,7 +54,7 @@ const char* extractFileName(const char* file) {
       reason))
 
 const std::unordered_set<std::string> kRegexFunctions =
-    {"regexp_extract", "regexp_extract_all", "regexp_replace", "rlike", "split"};
+    {"regexp_extract", "regexp_extract_all", "regexp_replace", "regexp_instr", "rlike", "split"};
 
 const std::unordered_set<std::string> kBlackList = {"split_part", "sequence", "approx_percentile", "map_from_arrays"};
 } // namespace

--- a/docs/velox-backend-scalar-function-support.md
+++ b/docs/velox-backend-scalar-function-support.md
@@ -391,7 +391,7 @@
 | regexp_count       | RegExpCount                 |          |                                                         |
 | regexp_extract     | RegExpExtract               | PS       | Lookaround unsupported                                  |
 | regexp_extract_all | RegExpExtractAll            | PS       | Lookaround unsupported                                  |
-| regexp_instr       | RegExpInStr                 |          |                                                         |
+| regexp_instr       | RegExpInStr                 | PS       | Lookaround unsupported, group index ignored             |
 | regexp_replace     | RegExpReplace               | PS       | Lookaround unsupported                                  |
 | regexp_substr      | RegExpSubStr                |          |                                                         |
 | repeat             | StringRepeat                | S        |                                                         |

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -570,6 +570,19 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           ),
           r
         )
+      case instr: TernaryExpression if instr.getClass.getSimpleName.equals("RegExpInStr") =>
+        // Spark's RegExpInStr carries a third `idx` child but ignores it during
+        // evaluation (it always returns the start position of the whole match).
+        // Velox's regexp_instr only takes (subject, regexp), so drop the idx child.
+        // Matched by class name because RegExpInStr does not exist in Spark 3.3.
+        GenericExpressionTransformer(
+          substraitExprName,
+          Seq(
+            replaceWithExpressionTransformer0(instr.first, attributeSeq, expressionsMap),
+            replaceWithExpressionTransformer0(instr.second, attributeSeq, expressionsMap)
+          ),
+          instr
+        )
       case size: Size =>
         // Covers Spark ArraySize which is replaced by Size(child, false).
         val child =

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -76,6 +76,7 @@ object ExpressionNames {
   final val REGEXP_REPLACE = "regexp_replace"
   final val REGEXP_EXTRACT = "regexp_extract"
   final val REGEXP_EXTRACT_ALL = "regexp_extract_all"
+  final val REGEXP_INSTR = "regexp_instr"
   final val EQUAL = "equal"
   final val EQUAL_NULL_SAFE = "equal_null_safe"
   final val EQUAL_NULL = "equal_null"

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -70,7 +70,8 @@ class Spark34Shims extends SparkShims {
       Sig[CheckOverflowInTableInsert](ExpressionNames.CHECK_OVERFLOW_IN_TABLE_INSERT),
       Sig[ArrayAppend](ExpressionNames.ARRAY_APPEND),
       Sig[UrlEncode](ExpressionNames.URL_ENCODE),
-      Sig[UrlDecode](ExpressionNames.URL_DECODE)
+      Sig[UrlDecode](ExpressionNames.URL_DECODE),
+      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR)
     )
   }
 

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -73,7 +73,8 @@ class Spark35Shims extends SparkShims {
       Sig[ArrayAppend](ExpressionNames.ARRAY_APPEND),
       Sig[UrlEncode](ExpressionNames.URL_ENCODE),
       Sig[UrlDecode](ExpressionNames.URL_DECODE),
-      Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING)
+      Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING),
+      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR)
     )
   }
 

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -78,7 +78,8 @@ class Spark40Shims extends SparkShims {
       Sig[KnownNotContainsNull](ExpressionNames.KNOWN_NOT_CONTAINS_NULL),
       Sig[UrlDecode](ExpressionNames.URL_DECODE),
       Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING),
-      Sig[RandStr](ExpressionNames.RANDSTR)
+      Sig[RandStr](ExpressionNames.RANDSTR),
+      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR)
     )
   }
 

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -77,7 +77,8 @@ class Spark41Shims extends SparkShims {
       Sig[KnownNotContainsNull](ExpressionNames.KNOWN_NOT_CONTAINS_NULL),
       Sig[UrlDecode](ExpressionNames.URL_DECODE),
       Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING),
-      Sig[RandStr](ExpressionNames.RANDSTR)
+      Sig[RandStr](ExpressionNames.RANDSTR),
+      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR)
     )
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Fix https://github.com/apache/gluten/issues/12696.

Wire up the Spark `regexp_instr` function for the Velox backend. Velox already registers `regexp_instr(string, pattern)` with Spark-compatible semantics, so this is Gluten-side plumbing only:

  - Map RegExpInStr in the spark34/35/40/41 shims (the expression doesn't exist in Spark 3.3); the converter matches it by class name so gluten-substrait still builds on 3.3.
  - Drop the idx child: Spark's RegExpInStr ignores it (always returns the whole-match start), while Velox's regexp_instr is 2-arg.
  - Add regexp_instr to the native validator's kRegexFunctions so non-constant / RE2-incompatible patterns fall back to Spark.
  - Blacklist it for the ClickHouse backend (native support not verified there).
  - Update the function-support doc.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
Added regexp_instr cases in ScalarFunctionsValidateSuite (compares Gluten vs vanilla Spark): 
1. 2-arg form
2. no-match (returns 0)
3. 3-arg form, and a 3-arg case where the group's start differs from the whole match to guard against future idx divergence.

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, AI-assisted, Generated-by: Claude claude-opus-4-8.
