### PR TITLE
[GLUTEN-12702][VL] Introduce shouldIgnoreInFallbackStats to skip certain plan nodes in fallback counting

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/AutoAdjustStageResourceProfileSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/AutoAdjustStageResourceProfileSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.execution.{ApplyResourceProfileExec, ColumnarShuffleExchangeExec, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.internal.SQLConf
 
 @Experimental
 class AutoAdjustStageResourceProfileSuite
@@ -127,6 +128,40 @@ class AutoAdjustStageResourceProfileSuite
           // with dynamic allocation enabled. In testing mode, we apply
           // default resource profile to make sure ut works.
           assert(applyResourceProfileExec == 1)
+      }
+    }
+  }
+
+  test("Structural Spark nodes should not be counted as fallback nodes") {
+    withSQLConf(
+      GlutenConfig.AUTO_ADJUST_STAGE_RESOURCES_FALLEN_NODE_RATIO_THRESHOLD.key -> "0.5",
+      SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "true"
+    ) {
+      runQueryAndCompare(
+        """
+          |SELECT /*+ BROADCAST(t2) */ t1.c1, t2.c1
+          |FROM tmp1 t1
+          |JOIN (
+          |  SELECT /*+ REBALANCE(c1) */ c1
+          |  FROM tmp2
+          |) t2
+          |ON t1.c1 = t2.c1
+          |""".stripMargin) {
+        // scalastyle:off
+        // format: off
+        /*
+        ColumnarBroadcastExchange HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1267]
+          +- AQEShuffleRead coalesced
+            +- ShuffleQueryStage 0
+                +- ColumnarExchange hashpartitioning(c1#10, 5), REBALANCE_PARTITIONS_BY_COL, [c1#10], [plan_id=1194], [shuffle_writer_type=hash], [output=[c1#10: int]]
+                    +- VeloxResizeBatches
+                      +- ^(1) ProjectExecTransformer [hash(c1#10, 42) AS hash_partition_key#31, c1#10]
+                        +- ^(1) FilterExecTransformer isnotnull(c1#10)
+                          +- ^(1) FileFileSourceScanExecTransformer parquet spark_catalog.default.tmp2[c1#10] Batched: true, DataFilters: [isnotnull(c1#10)]
+        */
+        // format: on
+        // scalastyle:on
+        df => assert(collectApplyResourceProfileExec(df.queryExecution.executedPlan) == 0)
       }
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution
 import org.apache.gluten.config.{GlutenConfig, GlutenCoreConfig}
 import org.apache.gluten.execution.{ColumnarToRowExecBase, CudfTag, GlutenPlan, WholeStageTransformer}
 import org.apache.gluten.logging.LogLevelUtil
+import org.apache.gluten.utils.PlanUtil
 
 import org.apache.spark.SparkConf
 import org.apache.spark.annotation.Experimental
@@ -29,6 +30,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{GlutenAutoAdjustStageResourceProfile => GlutenResourceProfile}
 import org.apache.spark.sql.execution.adaptive.QueryStageExec
+import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
 import org.apache.spark.sql.execution.exchange.Exchange
 import org.apache.spark.sql.internal.SQLConf
@@ -146,7 +148,11 @@ case class GlutenAutoAdjustStageResourceProfile(glutenConf: GlutenConfig, spark:
     // case 2: check whether fallback exists and decide whether increase heap memory
     // and decrease offheap memory.
     val countedPlanNodes = planNodes.filterNot(GlutenExplainUtils.isFallbackInsensitivePlan)
-    val fallenNodeCnt = countedPlanNodes.count(!_.isInstanceOf[GlutenPlan])
+    val fallenNodeCnt = countedPlanNodes.count {
+      case _: GlutenPlan => false
+      case i: InMemoryTableScanExec => !PlanUtil.isGlutenTableCache(i)
+      case _ => true
+    }
     val totalCount = countedPlanNodes.size
 
     if (1.0 * fallenNodeCnt / totalCount >= glutenConf.autoAdjustStageFallenNodeThreshold) {

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
@@ -147,7 +147,7 @@ case class GlutenAutoAdjustStageResourceProfile(glutenConf: GlutenConfig, spark:
 
     // case 2: check whether fallback exists and decide whether increase heap memory
     // and decrease offheap memory.
-    val countedPlanNodes = planNodes.filterNot(GlutenExplainUtils.isFallbackInsensitivePlan)
+    val countedPlanNodes = planNodes.filterNot(GlutenExplainUtils.shouldIgnoreInFallbackStats)
     val fallenNodeCnt = countedPlanNodes.count {
       case _: GlutenPlan => false
       case i: InMemoryTableScanExec => !PlanUtil.isGlutenTableCache(i)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
@@ -145,8 +145,8 @@ case class GlutenAutoAdjustStageResourceProfile(glutenConf: GlutenConfig, spark:
 
     // case 2: check whether fallback exists and decide whether increase heap memory
     // and decrease offheap memory.
-    val fallenNodeCnt = planNodes.count(p => !p.isInstanceOf[GlutenPlan])
-    val totalCount = planNodes.size
+    val fallenNodeCnt = planNodes.count(GlutenExplainUtils.isFallbackNode(_))
+    val totalCount = fallenNodeCnt + planNodes.count(_.isInstanceOf[GlutenPlan])
 
     if (1.0 * fallenNodeCnt / totalCount >= glutenConf.autoAdjustStageFallenNodeThreshold) {
       val newMemoryAmount = memoryRequest.get.amount * glutenConf.autoAdjustStageRPHeapRatio

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenAutoAdjustStageResourceProfile.scala
@@ -145,8 +145,9 @@ case class GlutenAutoAdjustStageResourceProfile(glutenConf: GlutenConfig, spark:
 
     // case 2: check whether fallback exists and decide whether increase heap memory
     // and decrease offheap memory.
-    val fallenNodeCnt = planNodes.count(GlutenExplainUtils.isFallbackNode(_))
-    val totalCount = fallenNodeCnt + planNodes.count(_.isInstanceOf[GlutenPlan])
+    val countedPlanNodes = planNodes.filterNot(GlutenExplainUtils.isFallbackInsensitivePlan)
+    val fallenNodeCnt = countedPlanNodes.count(!_.isInstanceOf[GlutenPlan])
+    val totalCount = countedPlanNodes.size
 
     if (1.0 * fallenNodeCnt / totalCount >= glutenConf.autoAdjustStageFallenNodeThreshold) {
       val newMemoryAmount = memoryRequest.get.amount * glutenConf.autoAdjustStageRPHeapRatio

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.gluten.execution.GlutenPlan
+import org.apache.gluten.execution.{GlutenPlan, WholeStageTransformer}
 import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.PlanUtil
@@ -46,32 +46,33 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
   type FallbackInfo = (Int, Map[String, String])
 
   /**
-   * Returns whether a plan is an actual Spark fallback operator.
+   * Returns whether a plan should be ignored when collecting fallback statistics.
    *
-   * Gluten operators, their implementation wrappers, and Spark execution-framework wrappers do not
-   * represent fallback work and return false.
+   * Such plans are structural wrappers rather than execution operators: they are neither fallback
+   * Spark operators nor native Gluten operators.
    */
-  def isFallbackNode(plan: SparkPlan): Boolean = plan match {
-    case _: GlutenPlan => false
-    case _: ExecutedCommandExec => false
-    case _: CommandResultExec => false
+  def isFallbackInsensitivePlan(plan: SparkPlan): Boolean = plan match {
+    case _: ExecutedCommandExec => true
+    case _: CommandResultExec => true
     case p: V2CommandExec =>
-      FallbackTags.nonEmpty(p) || p.logicalLink.exists(FallbackTags.getOption(_).nonEmpty)
-    case _: DataWritingCommandExec => false
-    case _: WholeStageCodegenExec => false
-    case _: InputAdapter => false
-    case _: ColumnarInputAdapter => false
-    case _: ColumnarToRowTransition => false
-    case _: RowToColumnarTransition => false
-    case _: ReusedExchangeExec => false
-    case _: NoopLeaf => false
-    case w: WriteFilesExec => !w.child.isInstanceOf[NoopLeaf]
-    case _: AdaptiveSparkPlanExec => false
-    case _: QueryStageExec => false
-    case _: AQEShuffleReadExec => false
-    case _: ColumnarAQEShuffleReadExec => false
-    case i: InMemoryTableScanExec => !PlanUtil.isGlutenTableCache(i)
-    case _ => true
+      !FallbackTags.nonEmpty(p) && p.logicalLink.forall(FallbackTags.getOption(_).isEmpty)
+    case _: DataWritingCommandExec => true
+    case _: WholeStageCodegenExec => true
+    case _: WholeStageTransformer => true
+    case _: InputAdapter => true
+    case _: ColumnarInputAdapter => true
+    case _: InputIteratorTransformer => true
+    case _: ColumnarToRowTransition => true
+    case _: RowToColumnarTransition => true
+    case _: ReusedExchangeExec => true
+    case _: NoopLeaf => true
+    case w: WriteFilesExec => w.child.isInstanceOf[NoopLeaf]
+    case _: AdaptiveSparkPlanExec => true
+    case _: QueryStageExec => true
+    case _: AQEShuffleReadExec => true
+    case _: ColumnarAQEShuffleReadExec => true
+    case i: InMemoryTableScanExec => PlanUtil.isGlutenTableCache(i)
+    case _ => false
   }
 
   def addFallbackNodeWithReason(
@@ -118,8 +119,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
    *   - native Gluten operator: invokes `onGluten`
    *   - vanilla Spark operator considered a fallback: invokes `onFallback` with the reason resolved
    *     from physical or logical [[FallbackTags]], or a synthetic default when no tag is present
-   *   - structural / non-operator nodes (commands, transitions, codegen wrappers, query stages, AQE
-   *     shuffle reads, reused exchanges, etc.): no callback
+   *   - [[isFallbackInsensitivePlan]] structural nodes: no callback
    *
    * Recurses into AQE subqueries and query stages, and into each visited operator's
    * `innerChildren`. Subqueries reached purely via expressions on a vanilla Spark plan are not
@@ -142,20 +142,20 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
       tmp.foreachUp {
         case cmd: CommandResultExec => visit(cmd.commandPhysicalPlan)
         case p: V2CommandExec
-            if isFallbackNode(p) =>
+            if !isFallbackInsensitivePlan(p) =>
           onFallback(p, fallbackReason(p))
         case sub: AdaptiveSparkPlanExec if sub.isSubquery => visit(sub.executedPlan)
         case p: QueryStageExec => visit(p.plan)
-        case p: GlutenPlan =>
-          onGluten(p)
-          p.innerChildren.foreach(visit)
         case i: InMemoryTableScanExec =>
           if (PlanUtil.isGlutenTableCache(i)) {
             onGluten(i)
           } else {
             onFallback(i, "Columnar table cache is disabled")
           }
-        case p: SparkPlan if !isFallbackNode(p) => // Ignore
+        case p: SparkPlan if isFallbackInsensitivePlan(p) => // Ignore
+        case p: GlutenPlan =>
+          onGluten(p)
+          p.innerChildren.foreach(visit)
         case p: SparkPlan =>
           onFallback(p, fallbackReason(p))
           p.innerChildren.foreach(visit)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -50,7 +50,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
    *
    * Such plans may be execution-framework or implementation wrappers.
    */
-  def isFallbackInsensitivePlan(plan: SparkPlan): Boolean = plan match {
+  def shouldIgnoreInFallbackStats(plan: SparkPlan): Boolean = plan match {
     case _: ExecutedCommandExec => true
     case _: CommandResultExec => true
     case p: V2CommandExec =>
@@ -117,7 +117,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
    *   - native Gluten operator: invokes `onGluten`
    *   - vanilla Spark operator considered a fallback: invokes `onFallback` with the reason resolved
    *     from physical or logical [[FallbackTags]], or a synthetic default when no tag is present
-   *   - [[isFallbackInsensitivePlan]] structural nodes: no callback
+   *   - nodes ignored by [[shouldIgnoreInFallbackStats]]: no callback
    *
    * Recurses into AQE subqueries and query stages, and into each visited operator's
    * `innerChildren`. Subqueries reached purely via expressions on a vanilla Spark plan are not
@@ -140,7 +140,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
       tmp.foreachUp {
         case cmd: CommandResultExec => visit(cmd.commandPhysicalPlan)
         case p: V2CommandExec
-            if !isFallbackInsensitivePlan(p) =>
+            if !shouldIgnoreInFallbackStats(p) =>
           onFallback(p, fallbackReason(p))
         case sub: AdaptiveSparkPlanExec if sub.isSubquery => visit(sub.executedPlan)
         case p: QueryStageExec => visit(p.plan)
@@ -150,7 +150,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
           } else {
             onFallback(i, "Columnar table cache is disabled")
           }
-        case p: SparkPlan if isFallbackInsensitivePlan(p) => // Ignore
+        case p: SparkPlan if shouldIgnoreInFallbackStats(p) => // Ignore
         case p: GlutenPlan =>
           onGluten(p)
           p.innerChildren.foreach(visit)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.sql.execution
 
-import org.apache.gluten.execution.{GlutenPlan, WholeStageTransformer}
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.FallbackTags
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.PlanUtil
@@ -44,6 +44,35 @@ import scala.collection.mutable.{ArrayBuffer, BitSet}
 // 3. remove codegen id
 object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
   type FallbackInfo = (Int, Map[String, String])
+
+  /**
+   * Returns whether a plan is an actual Spark fallback operator.
+   *
+   * Gluten operators, their implementation wrappers, and Spark execution-framework wrappers do not
+   * represent fallback work and return false.
+   */
+  def isFallbackNode(plan: SparkPlan): Boolean = plan match {
+    case _: GlutenPlan => false
+    case _: ExecutedCommandExec => false
+    case _: CommandResultExec => false
+    case p: V2CommandExec =>
+      FallbackTags.nonEmpty(p) || p.logicalLink.exists(FallbackTags.getOption(_).nonEmpty)
+    case _: DataWritingCommandExec => false
+    case _: WholeStageCodegenExec => false
+    case _: InputAdapter => false
+    case _: ColumnarInputAdapter => false
+    case _: ColumnarToRowTransition => false
+    case _: RowToColumnarTransition => false
+    case _: ReusedExchangeExec => false
+    case _: NoopLeaf => false
+    case w: WriteFilesExec => !w.child.isInstanceOf[NoopLeaf]
+    case _: AdaptiveSparkPlanExec => false
+    case _: QueryStageExec => false
+    case _: AQEShuffleReadExec => false
+    case _: ColumnarAQEShuffleReadExec => false
+    case i: InMemoryTableScanExec => !PlanUtil.isGlutenTableCache(i)
+    case _ => true
+  }
 
   def addFallbackNodeWithReason(
       p: SparkPlan,
@@ -111,26 +140,11 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
 
     def visit(tmp: QueryPlan[_]): Unit = {
       tmp.foreachUp {
-        case _: ExecutedCommandExec =>
         case cmd: CommandResultExec => visit(cmd.commandPhysicalPlan)
         case p: V2CommandExec
-            if FallbackTags.nonEmpty(p) ||
-              p.logicalLink.exists(FallbackTags.getOption(_).nonEmpty) =>
+            if isFallbackNode(p) =>
           onFallback(p, fallbackReason(p))
-        case _: V2CommandExec =>
-        case _: DataWritingCommandExec =>
-        case _: WholeStageCodegenExec =>
-        case _: WholeStageTransformer =>
-        case _: InputAdapter =>
-        case _: ColumnarInputAdapter =>
-        case _: InputIteratorTransformer =>
-        case _: ColumnarToRowTransition =>
-        case _: RowToColumnarTransition =>
-        case _: ReusedExchangeExec =>
-        case _: NoopLeaf =>
-        case w: WriteFilesExec if w.child.isInstanceOf[NoopLeaf] =>
         case sub: AdaptiveSparkPlanExec if sub.isSubquery => visit(sub.executedPlan)
-        case _: AdaptiveSparkPlanExec =>
         case p: QueryStageExec => visit(p.plan)
         case p: GlutenPlan =>
           onGluten(p)
@@ -141,8 +155,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
           } else {
             onFallback(i, "Columnar table cache is disabled")
           }
-        case _: AQEShuffleReadExec => // Ignore
-        case _: ColumnarAQEShuffleReadExec => // Ignore
+        case p: SparkPlan if !isFallbackNode(p) => // Ignore
         case p: SparkPlan =>
           onFallback(p, fallbackReason(p))
           p.innerChildren.foreach(visit)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenExplainUtils.scala
@@ -48,8 +48,7 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
   /**
    * Returns whether a plan should be ignored when collecting fallback statistics.
    *
-   * Such plans are structural wrappers rather than execution operators: they are neither fallback
-   * Spark operators nor native Gluten operators.
+   * Such plans may be execution-framework or implementation wrappers.
    */
   def isFallbackInsensitivePlan(plan: SparkPlan): Boolean = plan match {
     case _: ExecutedCommandExec => true
@@ -71,7 +70,6 @@ object GlutenExplainUtils extends AdaptiveSparkPlanHelper {
     case _: QueryStageExec => true
     case _: AQEShuffleReadExec => true
     case _: ColumnarAQEShuffleReadExec => true
-    case i: InMemoryTableScanExec => PlanUtil.isGlutenTableCache(i)
     case _ => false
   }
 

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -17,8 +17,7 @@
 package org.apache.spark.sql.execution
 
 import org.apache.gluten.exception.GlutenException
-import org.apache.gluten.execution.{GlutenPlan, WholeStageTransformer}
-import org.apache.gluten.extension.columnar.FallbackTags
+import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.utils.PlanUtil
 
@@ -27,13 +26,9 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{CommandResult, LogicalPlan}
 import org.apache.spark.sql.catalyst.util.StringUtils.PlanStringConcat
 import org.apache.spark.sql.classic.ClassicConversions._
-import org.apache.spark.sql.execution.ColumnarWriteFilesExec.NoopLeaf
-import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AQEShuffleReadExec, ColumnarAQEShuffleReadExec, QueryStageExec}
+import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, QueryStageExec}
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
-import org.apache.spark.sql.execution.command.{DataWritingCommandExec, ExecutedCommandExec}
-import org.apache.spark.sql.execution.datasources.WriteFilesExec
 import org.apache.spark.sql.execution.datasources.v2.V2CommandExec
-import org.apache.spark.sql.execution.exchange.ReusedExchangeExec
 import org.apache.spark.sql.internal.SQLConf
 
 import scala.collection.mutable
@@ -108,24 +103,10 @@ object GlutenImplicits {
 
     def collect(tmp: QueryPlan[_]): Unit = {
       tmp.foreachUp {
-        case _: ExecutedCommandExec =>
         case cmd: CommandResultExec => collect(cmd.commandPhysicalPlan)
         case p: V2CommandExec
-            if FallbackTags.nonEmpty(p) ||
-              p.logicalLink.exists(FallbackTags.getOption(_).nonEmpty) =>
+            if GlutenExplainUtils.isFallbackNode(p) =>
           GlutenExplainUtils.handleVanillaSparkPlan(p, fallbackNodeToReason)
-        case _: V2CommandExec =>
-        case _: DataWritingCommandExec =>
-        case _: WholeStageCodegenExec =>
-        case _: WholeStageTransformer =>
-        case _: InputAdapter =>
-        case _: ColumnarInputAdapter =>
-        case _: InputIteratorTransformer =>
-        case _: ColumnarToRowTransition =>
-        case _: RowToColumnarTransition =>
-        case p: ReusedExchangeExec =>
-        case _: NoopLeaf =>
-        case w: WriteFilesExec if w.child.isInstanceOf[NoopLeaf] =>
         case p: AdaptiveSparkPlanExec if isFinalAdaptivePlan(p) =>
           collect(p.executedPlan)
         case p: AdaptiveSparkPlanExec =>
@@ -162,8 +143,7 @@ object GlutenImplicits {
               fallbackNodeToReason)
           }
           collect(i.relation.cachedPlan)
-        case _: AQEShuffleReadExec => // Ignore
-        case _: ColumnarAQEShuffleReadExec => // Ignore
+        case p: SparkPlan if !GlutenExplainUtils.isFallbackNode(p) => // Ignore
         case p: SparkPlan =>
           GlutenExplainUtils.handleVanillaSparkPlan(p, fallbackNodeToReason)
           p.innerChildren.foreach(collect)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -105,7 +105,7 @@ object GlutenImplicits {
       tmp.foreachUp {
         case cmd: CommandResultExec => collect(cmd.commandPhysicalPlan)
         case p: V2CommandExec
-            if !GlutenExplainUtils.isFallbackInsensitivePlan(p) =>
+            if !GlutenExplainUtils.shouldIgnoreInFallbackStats(p) =>
           GlutenExplainUtils.handleVanillaSparkPlan(p, fallbackNodeToReason)
         case p: AdaptiveSparkPlanExec if isFinalAdaptivePlan(p) =>
           collect(p.executedPlan)
@@ -140,7 +140,7 @@ object GlutenImplicits {
               fallbackNodeToReason)
           }
           collect(i.relation.cachedPlan)
-        case p: SparkPlan if GlutenExplainUtils.isFallbackInsensitivePlan(p) => // Ignore
+        case p: SparkPlan if GlutenExplainUtils.shouldIgnoreInFallbackStats(p) => // Ignore
         case p: GlutenPlan =>
           numGlutenNodes += 1
           p.innerChildren.foreach(collect)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -105,7 +105,7 @@ object GlutenImplicits {
       tmp.foreachUp {
         case cmd: CommandResultExec => collect(cmd.commandPhysicalPlan)
         case p: V2CommandExec
-            if GlutenExplainUtils.isFallbackNode(p) =>
+            if !GlutenExplainUtils.isFallbackInsensitivePlan(p) =>
           GlutenExplainUtils.handleVanillaSparkPlan(p, fallbackNodeToReason)
         case p: AdaptiveSparkPlanExec if isFinalAdaptivePlan(p) =>
           collect(p.executedPlan)
@@ -130,9 +130,6 @@ object GlutenImplicits {
           numGlutenNodes += innerNumGlutenNodes
           fallbackNodeToReason.++=(innerFallbackNodeToReason)
         case p: QueryStageExec => collect(p.plan)
-        case p: GlutenPlan =>
-          numGlutenNodes += 1
-          p.innerChildren.foreach(collect)
         case i: InMemoryTableScanExec =>
           if (PlanUtil.isGlutenTableCache(i)) {
             numGlutenNodes += 1
@@ -143,7 +140,10 @@ object GlutenImplicits {
               fallbackNodeToReason)
           }
           collect(i.relation.cachedPlan)
-        case p: SparkPlan if !GlutenExplainUtils.isFallbackNode(p) => // Ignore
+        case p: SparkPlan if GlutenExplainUtils.isFallbackInsensitivePlan(p) => // Ignore
+        case p: GlutenPlan =>
+          numGlutenNodes += 1
+          p.innerChildren.foreach(collect)
         case p: SparkPlan =>
           GlutenExplainUtils.handleVanillaSparkPlan(p, fallbackNodeToReason)
           p.innerChildren.foreach(collect)


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Add `GlutenExplainUtils.shouldIgnoreInFallbackStats` to distinguish structural wrappers and execution operators.
- Reuse the helper in `GlutenExplainUtils` and `GlutenImplicits` fallback walkers and `GlutenAutoAdjustStageResourceProfile`.

Fix https://github.com/apache/gluten/issues/12702.

## How was this patch tested?
Add a new UT.

## Was this patch authored or co-authored using generative AI tooling?
Generated-by: Codex GPT-5
