### PR TITLE
[GLUTEN-12708][VL] Fix LATERAL VIEW OUTER stack not consuming Velox marker, causing columnar shuffle field0 to become BOOLEAN and crash

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
@@ -333,33 +333,13 @@ object PullOutGenerateProjectHelper extends PullOutProjectHelper {
             }
             ProjectExec(generate.requiredChildOutput ++ newOutput, newGenerate)
           }
-        case Explode(_) if generate.outer =>
-          // Drop the last column of generatorOutput, which is the boolean representing whether
-          // the null value is unnested from the input array/map (e.g. array(1, null)), or the
-          // array/map itself is null or empty (e.g. array(), map(), null).
-          val isPresent =
-            AttributeReference(generatePostAliasName, BooleanType, nullable = true)()
-          val newGenerate =
-            generate.copy(generatorOutput = generate.generatorOutput :+ isPresent)
-          val newOutput = generate.generatorOutput.map {
-            attr =>
-              val caseWhen = CaseWhen(
-                Seq((isPresent, attr)),
-                Literal(null, attr.dataType)
-              )
-              Alias(caseWhen, generatePostAliasName)(attr.exprId, attr.qualifier)
-          }
-          ProjectExec(generate.requiredChildOutput ++ newOutput, newGenerate)
-        case _: Stack if generate.outer =>
-          // Like the outer Explode above, Velox's Unnest appends a trailing boolean marker
-          // column for an OUTER generator (true when the row is a real unnested value, false
-          // for the synthetic padding row of an empty/null input). Stack emits no ordinality
-          // column, so its native output layout (value columns + trailing marker) matches
-          // Explode's. Without consuming the marker here, the native output is one column wider
-          // than the declared schema, every upstream column shifts by one, and a downstream
-          // hash shuffle receives the boolean marker at field 0 instead of the int32 partition
-          // key (VeloxShuffleWriter getFirstColumn aborts). Append a boolean isPresent to absorb
-          // the marker and wrap each output column so the padding row projects NULLs.
+        case (_: Explode | _: Stack) if generate.outer =>
+          // Drop the last column of generatorOutput, which is the boolean marker Velox's Unnest
+          // appends for an OUTER generator (true when the row is a real unnested value, false for
+          // the synthetic padding row of an empty/null input). Explode and Stack share this
+          // layout -- value columns followed by the trailing marker, with no ordinality column --
+          // so the same handling applies to both. Wrap each output column in a CaseWhen on the
+          // marker so the padding row projects NULLs.
           val isPresent =
             AttributeReference(generatePostAliasName, BooleanType, nullable = true)()
           val newGenerate =

--- a/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/execution/GenerateExecTransformer.scala
@@ -350,6 +350,29 @@ object PullOutGenerateProjectHelper extends PullOutProjectHelper {
               Alias(caseWhen, generatePostAliasName)(attr.exprId, attr.qualifier)
           }
           ProjectExec(generate.requiredChildOutput ++ newOutput, newGenerate)
+        case _: Stack if generate.outer =>
+          // Like the outer Explode above, Velox's Unnest appends a trailing boolean marker
+          // column for an OUTER generator (true when the row is a real unnested value, false
+          // for the synthetic padding row of an empty/null input). Stack emits no ordinality
+          // column, so its native output layout (value columns + trailing marker) matches
+          // Explode's. Without consuming the marker here, the native output is one column wider
+          // than the declared schema, every upstream column shifts by one, and a downstream
+          // hash shuffle receives the boolean marker at field 0 instead of the int32 partition
+          // key (VeloxShuffleWriter getFirstColumn aborts). Append a boolean isPresent to absorb
+          // the marker and wrap each output column so the padding row projects NULLs.
+          val isPresent =
+            AttributeReference(generatePostAliasName, BooleanType, nullable = true)()
+          val newGenerate =
+            generate.copy(generatorOutput = generate.generatorOutput :+ isPresent)
+          val newOutput = generate.generatorOutput.map {
+            attr =>
+              val caseWhen = CaseWhen(
+                Seq((isPresent, attr)),
+                Literal(null, attr.dataType)
+              )
+              Alias(caseWhen, generatePostAliasName)(attr.exprId, attr.qualifier)
+          }
+          ProjectExec(generate.requiredChildOutput ++ newOutput, newGenerate)
         case _ => generate
       }
     } else {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1092,6 +1092,50 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     }
   }
 
+  test("test LATERAL VIEW OUTER stack followed by hash shuffle") {
+    // Repro for: `Partition id (field 0) should be integer, but got BOOLEAN`
+    // (VeloxShuffleWriter.h getFirstColumn).
+    //
+    // With OUTER, Velox's Unnest appends a trailing BOOLEAN marker column. The Stack path has
+    // no pullOutPostProject branch to consume that marker (unlike explode/posexplode/inline),
+    // so the native output is one column wider than the declared schema and every upstream
+    // column shifts by one. When the exploded key drives a hash-partition shuffle, the int32
+    // hash_partition_key that must sit at field 0 is displaced by the boolean marker and the
+    // columnar shuffle writer aborts.
+    //
+    // The shuffle must be a *hash-partition* exchange feeding a SortMergeJoin (not a partial
+    // aggregate, not a broadcast join) to reproduce the field-0 crash exactly as production
+    // does: broadcasting the dim table hits a different serializer error, and inserting a
+    // partial HashAggregate crashes earlier in the native input stream. Disable broadcast to
+    // force the SortMergeJoin.
+    withTempView("t1_stack", "t2_dim") {
+      sql("""SELECT * from values
+            |  (1, "james", 10, "lucy"),
+            |  (2, "bond", 20, "lily")
+            |as tbl(id, name, id1, name1)
+         """.stripMargin).createOrReplaceTempView("t1_stack")
+      sql("""SELECT * from values
+            |  (1, "a"), (2, "b"), (10, "c"), (20, "d")
+            |as tbl(k, tag)
+         """.stripMargin).createOrReplaceTempView("t2_dim")
+
+      withSQLConf("spark.sql.autoBroadcastJoinThreshold" -> "-1") {
+        runQueryAndCompare(s"""
+                              |SELECT j.eq_pos, t2.tag
+                              |FROM (
+                              |  SELECT eq_pos, val
+                              |  FROM t1_stack
+                              |  LATERAL VIEW OUTER stack(2, id, name, id1, name1) v AS eq_pos, val
+                              |) j
+                              |JOIN t2_dim t2 ON j.eq_pos = t2.k
+                              |ORDER BY j.eq_pos, t2.tag
+                              |""".stripMargin) {
+          checkGlutenPlan[GenerateExecTransformer]
+        }
+      }
+    }
+  }
+
   test("test inline function") {
     Seq(true, false).foreach {
       isOuter =>

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -1092,10 +1092,7 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     }
   }
 
-  test("test LATERAL VIEW OUTER stack followed by hash shuffle") {
-    // Repro for: `Partition id (field 0) should be integer, but got BOOLEAN`
-    // (VeloxShuffleWriter.h getFirstColumn).
-    //
+  test("LATERAL VIEW OUTER stack followed by hash shuffle") {
     // With OUTER, Velox's Unnest appends a trailing BOOLEAN marker column. The Stack path has
     // no pullOutPostProject branch to consume that marker (unlike explode/posexplode/inline),
     // so the native output is one column wider than the declared schema and every upstream


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #12708

For an **OUTER** generator, Velox's `Unnest` operator appends a trailing `BOOLEAN` marker column (output order: replicated columns → unnest value columns → `[ordinality]` → `[marker]`). `GenerateExecTransformer.pullOutPostProject` already consumes this marker for `PosExplode`, `Inline`/`JsonTupleExplode`, and `Explode`, each by appending a boolean `isPresent` attribute to `generatorOutput` and wrapping every real output column in `CaseWhen(Seq((isPresent, col)), Literal(null, col.dataType))`.

**`Stack` had no such branch** — an OUTER `Stack` fell through to `case _ => generate`, leaving the marker unconsumed. Because Velox binds columns by position, the extra column shifts every upstream column by one index. When the exploded output feeds a columnar hash exchange, the boolean marker displaces the int32 `hash_partition_key` that must sit at field 0, and `VeloxShuffleWriter::getFirstColumn` aborts:

```
Partition id (field 0) should be integer, but got BOOLEAN
```

The crash is deterministic and data-independent. Depending on the operator downstream of the shift, the same root cause can also surface as `values_->capacity() >= byteSize` (partial HashAggregate) or `Expected INT_ARRAY. Got BYTE_ARRAY` (BroadcastHashJoin).

This PR adds a `case _: Stack if generate.outer =>` branch to `pullOutPostProject`, structurally identical to the existing `Explode(_) if generate.outer` branch — `Stack`'s native output layout (value columns, no ordinality, trailing marker) matches `Explode`'s, so no ordinality handling is needed. Inner (non-OUTER) `stack` produces no marker column and is gated out by the `if generate.outer` guard, so it is unchanged.

## How was this patch tested?

Added a regression test `test LATERAL VIEW OUTER stack followed by hash shuffle` in `MiscOperatorSuite` that runs `LATERAL VIEW OUTER stack(...)` whose exploded key drives a hash-partition columnar exchange into a SortMergeJoin (broadcast disabled via `spark.sql.autoBroadcastJoinThreshold=-1`, which reproduces the exact
`field 0 should be integer, but got BOOLEAN` path), and compares results against vanilla Spark. Before this patch the query aborts; after, it returns the correct rows including the NULL-padded columns for OUTER padding rows.

Also verified manually:
- Inner `stack` (drop `OUTER`) is unchanged — same join result, no extra column.
- OUTER `stack` with an argument count that pads a NULL value column projects the NULL at the correct position (no column shift) and still joins correctly.
- The original production query (OUTER `stack` → SortMergeJoin → CUBE + `COUNT(DISTINCT)`), with and without an outer `ORDER BY`, ran to completion with all tasks succeeding.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude-opus-4-8.
