### PR TITLE
[VL] Fail fast when NativeMemoryManager.hold() is called after release() instead of a native SIGSEGV

### DIFF
--- a/gluten-arrow/src/main/scala/org/apache/gluten/memory/NativeMemoryManager.scala
+++ b/gluten-arrow/src/main/scala/org/apache/gluten/memory/NativeMemoryManager.scala
@@ -76,7 +76,15 @@ object NativeMemoryManager {
     private val released: AtomicBoolean = new AtomicBoolean(false)
 
     override def addSpiller(spiller: Spiller): Unit = spillers.append(spiller)
-    override def hold(): Unit = NativeMemoryManagerJniWrapper.hold(handle)
+    override def hold(): Unit = {
+      // hold() must run before release(). Reaching here after release means a broken teardown
+      // ordering, so surface it instead of dereferencing a freed native handle silently.
+      if (released.get()) {
+        throw new GlutenException(
+          s"Cannot hold memory manager instance that has already been released: $handle")
+      }
+      NativeMemoryManagerJniWrapper.hold(handle)
+    }
     override def getHandle(): Long = handle
     override def release(): Unit = {
       if (!released.compareAndSet(false, true)) {


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

`NativeMemoryManager.hold()` called the native `hold(handle)` JNI method without checking whether the manager had already been released. When a task tears down its runtime (`release()` frees the native handle) while another thread is still closing an output iterator via `ColumnarBatchOutIterator.close0() -> memoryManager().hold()`, `hold()` dereferences a freed handle and crashes the JVM with a SIGSEGV (`SEGV_MAPERR` = use-after-free).

This is fundamentally a Spark-level teardown-ordering issue: script transformation starts a daemon "Feed" thread and never joins it, so `resIter.close() -> hold()` can run on that thread after the task thread has already called `Runtime.release() -> nmm.release()`. In vanilla Spark this is relatively benign, but with Gluten it escalates from a Java-level error into a native coredump.

Instead of silently no-op'ing or crashing, `hold()` now detects the already-released state via the existing `released` flag and fails fast with a `GlutenException`, surfacing the broken teardown ordering with a clear JVM-level error instead of a `SEGV_MAPERR` use-after-free.

Surfaced as a flaky native crash in CI running`GlutenSparkScriptTransformationSuite`:

- Failing job: https://github.com/apache/gluten/actions/runs/31071855879/job/92523319304?pr=12697

From `hs_err_pid*.log` :

```
# C  [libgluten.so+0x4fe59e]  Java_org_apache_gluten_memory_NativeMemoryManagerJniWrapper_hold+0x1e
siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR)

Current thread: JavaThread "Thread-SparkScriptTransformationWriterThread-Feed"
C  [libgluten.so+0x4fe59e]  Java_org_apache_gluten_memory_NativeMemoryManagerJniWrapper_hold+0x1e
j  org.apache.gluten.memory.NativeMemoryManager$Impl.hold()V
j  org.apache.gluten.vectorized.ColumnarBatchOutIterator.close0()V
j  org.apache.gluten.iterator.ClosableIterator.close()V
...
j  org.apache.spark.sql.execution.BaseScriptTransformationWriterThread.run()V
```
<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
flaky test, existed test to verify.

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, AI-assisted, Generated-by: Claude claude-opus-4-8.
