### PR TITLE
[GLUTEN-12716][CORE] Make AppendableSpillerList safe to append during a spill

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/Spillers.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/Spillers.java
@@ -16,7 +16,10 @@
  */
 package org.apache.gluten.memory.memtarget;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public final class Spillers {
   private Spillers() {
@@ -61,8 +64,13 @@ public final class Spillers {
     }
   }
 
+  @ThreadSafe
   public static class AppendableSpillerList implements Spiller {
-    private final List<Spiller> spillers = new ArrayList<>();
+    // Callers keep appending after the list is registered with the task's memory tree, and the walk
+    // below runs on whichever thread hit the memory limit, holding the iteration open across a JNI
+    // spill. So an append can land mid-walk, and the two sides share no lock. Copy-on-write also
+    // stays correct if a spiller ever appends during its own spill, which a lock would not cover.
+    private final CopyOnWriteArrayList<Spiller> spillers = new CopyOnWriteArrayList<>();
 
     private AppendableSpillerList() {}
 

--- a/gluten-core/src/test/java/org/apache/gluten/memory/memtarget/SpillersTest.java
+++ b/gluten-core/src/test/java/org/apache/gluten/memory/memtarget/SpillersTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.memory.memtarget;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SpillersTest {
+
+  private static Spiller countingSpiller(AtomicInteger counter) {
+    return new Spiller() {
+      @Override
+      public long spill(MemoryTarget self, Phase phase, long size) {
+        counter.incrementAndGet();
+        // Reclaim nothing, so the caller walks the rest of the list.
+        return 0L;
+      }
+    };
+  }
+
+  private static Spiller recordingSpiller(String name, List<String> order, AtomicInteger counter) {
+    return new Spiller() {
+      @Override
+      public long spill(MemoryTarget self, Phase phase, long size) {
+        order.add(name);
+        counter.incrementAndGet();
+        return 0L;
+      }
+    };
+  }
+
+  @Test
+  public void testAppendFromAnotherThreadDuringSpill() throws Exception {
+    // Callers append after the list is registered with the task's memory tree, and a spill runs on
+    // whichever thread hit the limit. The latches pin that interleaving: the appending thread runs
+    // while the spilling thread sits between two entries.
+    final Spillers.AppendableSpillerList spillers = Spillers.appendable();
+    final MemoryTarget target = new NoopMemoryTarget();
+    final AtomicInteger spillCount = new AtomicInteger(0);
+    final AtomicInteger appendedSpills = new AtomicInteger(0);
+    final List<String> order = new CopyOnWriteArrayList<>();
+    final CountDownLatch reachedMiddle = new CountDownLatch(1);
+    final CountDownLatch appended = new CountDownLatch(1);
+    final AtomicReference<Throwable> appendFailure = new AtomicReference<>();
+
+    spillers.append(recordingSpiller("first", order, spillCount));
+    spillers.append(
+        new Spiller() {
+          @Override
+          public long spill(MemoryTarget self, Phase phase, long size) {
+            order.add("blocking");
+            spillCount.incrementAndGet();
+            reachedMiddle.countDown();
+            try {
+              Assert.assertTrue(
+                  "appending thread did not finish within 30s",
+                  appended.await(30, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new IllegalStateException(e);
+            }
+            return 0L;
+          }
+        });
+    spillers.append(recordingSpiller("third", order, spillCount));
+
+    final Thread appender =
+        new Thread(
+            () -> {
+              try {
+                Assert.assertTrue(
+                    "spilling thread did not reach the middle spiller within 30s",
+                    reachedMiddle.await(30, TimeUnit.SECONDS));
+                spillers.append(countingSpiller(appendedSpills));
+              } catch (Throwable t) {
+                appendFailure.compareAndSet(null, t);
+              } finally {
+                appended.countDown();
+              }
+            },
+            "spiller-appender");
+    appender.setDaemon(true);
+    appender.start();
+    final List<String> firstWalk;
+    try {
+      Assert.assertEquals(0, spillers.spill(target, Spiller.Phase.SPILL, 100));
+    } finally {
+      // Snapshot before the second walk records into the same list.
+      firstWalk = Arrays.asList(order.toArray(new String[0]));
+      appender.join(TimeUnit.SECONDS.toMillis(30));
+    }
+
+    if (appendFailure.get() != null) {
+      Assert.fail("Appending thread failed: " + appendFailure.get());
+    }
+    Assert.assertFalse("appender thread is still running after join", appender.isAlive());
+    // The walk covers the three entries present when it started, in registration order.
+    Assert.assertEquals(Arrays.asList("first", "blocking", "third"), firstWalk);
+    Assert.assertEquals(3, spillCount.get());
+    Assert.assertEquals(0, appendedSpills.get());
+
+    // The spiller appended mid-walk did reach the list: it takes part in the next walk.
+    Assert.assertEquals(0, spillers.spill(target, Spiller.Phase.SPILL, 100));
+    Assert.assertEquals(1, appendedSpills.get());
+    Assert.assertEquals(6, spillCount.get());
+  }
+
+  @Test
+  public void testAppendDuringOwnSpill() {
+    // No production spiller appends today, but a lock around append would not cover one that did,
+    // so pin the re-entrant case as well.
+    final Spillers.AppendableSpillerList spillers = Spillers.appendable();
+    final MemoryTarget target = new NoopMemoryTarget();
+    final AtomicInteger appendedSpills = new AtomicInteger(0);
+    final AtomicInteger spillCount = new AtomicInteger(0);
+
+    spillers.append(
+        new Spiller() {
+          @Override
+          public long spill(MemoryTarget self, Phase phase, long size) {
+            spillCount.incrementAndGet();
+            spillers.append(countingSpiller(appendedSpills));
+            return 0L;
+          }
+        });
+    spillers.append(countingSpiller(spillCount));
+
+    Assert.assertEquals(0, spillers.spill(target, Spiller.Phase.SPILL, 100));
+    Assert.assertEquals(2, spillCount.get());
+    Assert.assertEquals(0, appendedSpills.get());
+    // The appended spiller takes part in the next walk.
+    Assert.assertEquals(0, spillers.spill(target, Spiller.Phase.SPILL, 100));
+    Assert.assertEquals(1, appendedSpills.get());
+  }
+
+  @Test
+  public void testSpillStopsOnceTheRequestIsMet() {
+    // Pins the pre-existing short-circuit in AppendableSpillerList#spill, not this fix: once the
+    // request is met the walk stops, so later entries are never consulted.
+    final Spillers.AppendableSpillerList spillers = Spillers.appendable();
+    final MemoryTarget target = new NoopMemoryTarget();
+    final AtomicInteger laterSpills = new AtomicInteger(0);
+
+    spillers.append(
+        new Spiller() {
+          @Override
+          public long spill(MemoryTarget self, Phase phase, long size) {
+            return size;
+          }
+        });
+    spillers.append(countingSpiller(laterSpills));
+
+    Assert.assertEquals(100, spillers.spill(target, Spiller.Phase.SPILL, 100));
+    Assert.assertEquals(0, laterSpills.get());
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

`Spillers.AppendableSpillerList` holds a plain `ArrayList` that `append` mutates and `spill` iterates, with no lock on either side, and the two run on different threads.

`NativeMemoryManager` hands the list to `ReservationListeners`, which registers it as a node of the task's memory tree, before anything is appended to it. The shuffle writers then append their own spiller on the first non-empty batch, which is well after `records.next()` started driving the upstream pipeline. On the other side `TreeMemoryTargets#spillTree` walks every consumer of the task by design, per the comment at its root-level caller in `MemoryTargets`: "Spill from root node so other consumers also get spilled". So a spill triggered by any consumer reaches every other consumer's list, across runtime boundaries. The triggering thread need not be the task thread: an allocation on a Velox io thread goes through that runtime's `ReservationListener`, so an async split prefetch can fail to reserve and start a root-level walk while the task thread is back in Java appending. The walk also stays inside the loop across a JNI shrink or reclaim call, so the window is milliseconds rather than one instruction.

Five call sites append to such a list, and they are not equally exposed. `NativeMemoryManager.scala:59` and `NativePlanEvaluator.java:94` append while their `NativeMemoryManager` is still being constructed, when no other thread of the task is allocating yet. The three shuffle writers (`ColumnarShuffleWriter.scala:194`, and the Celeborn and Uniffle variants) are the reachable ones, because their list is registered when the writer is built and appended to only on the first non-empty batch. The fix is in `gluten-core`, so it covers all five regardless.

This switches the field to `CopyOnWriteArrayList`. The two sides cannot be brought under one lock cheaply, iteration is held open across a JNI spill, and appends are two per list per task while walks are on the reclaim path, so the copy is cheap. Snapshot iteration also stays correct if a spiller ever appends during its own spill, which locking `append` would not cover. The field is declared as the concrete type so a revert to `ArrayList` is a compile error, and the class is marked `@ThreadSafe` because `MemoryTarget` documents the opposite default for its implementations.

Worth naming what this does not change: a copy-on-write iterator is a snapshot, so an append landing mid-walk still misses that round, and `SpillersTest` asserts exactly that. `ThrowOnOomMemoryTarget.borrow` retries the reservation and each retry re-enters `spillTree` on a fresh snapshot, so the skip defers one round of reclaim rather than losing it. An index walk over the same list would be equally thread-safe and would pick up mid-walk appends, but it would also let a self-appending spiller extend a single walk without bound; snapshot iteration fixes the work per round instead.

GLUTEN-11509 was this race one field over, on `TreeMemoryConsumer#children`, with a production stack trace from the Delta statistics writer thread. Its fix (#11553) switched that map to `ConcurrentHashMap` and left this list alone. That issue noted the main branch had no asynchronous use of the memory tree yet; the per-runtime hooked executor for Velox io threads (#11882, #12302) and the Delta native statistics writer (#11419) both supply one now. `NativeMemoryManager`'s `mutableStats` map has the same publish-then-mutate shape and is still unguarded; it is read only by `Node#stats()` on the OOM-message path, never by `spillTree`, so it does not affect reclaim and is tracked separately.

### How was this patch tested?

New `SpillersTest` with three tests. `testAppendFromAnotherThreadDuringSpill` uses two latches to pin the interleaving deterministically: the appending thread runs while the spilling thread sits between two entries. It then asserts the appended spiller was not lost by running a second walk, and asserts the first walk visited the three registered entries in order. `testAppendDuringOwnSpill` covers a spiller that appends during its own spill, the case a lock around `append` would not cover. `testSpillStopsOnceTheRequestIsMet` pins the pre-existing short-circuit and is a boundary assertion, not a guardrail for this change.

Each assertion was checked against a mutant, restoring the source after every run:

| mutant | caught by |
| --- | --- |
| `CopyOnWriteArrayList` back to `ArrayList` | both concurrency tests, `ConcurrentModificationException` |
| `append` silently drops once the list holds three (keeps COW, no CME) | the appended-spiller assertion, `expected:<1> but was:<0>` |
| walk order reversed | the order assertion, `expected:<[first, blocking, third]> but was:<[third, blocking, first]>` |

`mvn -Pspark-3.5 -pl gluten-core test` gives 33 Java and 39 Scala tests passing. Cross-version `test-compile` passes on spark-3.3, spark-3.4, spark-4.0 with scala-2.13, and spark-4.1 with scala-2.13.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code(Opus 5)

Closes #12716
