### PR TITLE
[GLUTEN-12597][CORE] Migrate AggregateRel.Grouping to expression references (Substrait 0.98)

### DIFF
--- a/backends-clickhouse/src/test/resources/substrait-plans/covar_samp-covar_pop-final-agg-stage.json
+++ b/backends-clickhouse/src/test/resources/substrait-plans/covar_samp-covar_pop-final-agg-stage.json
@@ -130,22 +130,23 @@
                 }
               },
               "groupings": [{
-                "groupingExpressions": [{
-                  "selection": {
-                    "directReference": {
-                      "structField": {
-                      }
+                "expressionReferences": [0, 1]
+              }],
+              "groupingExpressions": [{
+                "selection": {
+                  "directReference": {
+                    "structField": {
                     }
                   }
-                }, {
-                  "selection": {
-                    "directReference": {
-                      "structField": {
-                        "field": 1
-                      }
+                }
+              }, {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
                     }
                   }
-                }]
+                }
               }],
               "measures": [{
                 "measure": {

--- a/backends-clickhouse/src/test/resources/substrait-plans/covar_samp-covar_pop-partial-agg-stage.json
+++ b/backends-clickhouse/src/test/resources/substrait-plans/covar_samp-covar_pop-partial-agg-stage.json
@@ -355,22 +355,23 @@
             }
           },
           "groupings": [{
-            "groupingExpressions": [{
-              "selection": {
-                "directReference": {
-                  "structField": {
-                  }
+            "expressionReferences": [0, 1]
+          }],
+          "groupingExpressions": [{
+            "selection": {
+              "directReference": {
+                "structField": {
                 }
               }
-            }, {
-              "selection": {
-                "directReference": {
-                  "structField": {
-                    "field": 1
-                  }
+            }
+          }, {
+            "selection": {
+              "directReference": {
+                "structField": {
+                  "field": 1
                 }
               }
-            }]
+            }
           }],
           "measures": [{
             "measure": {

--- a/backends-clickhouse/src/test/resources/substrait-plans/tpch-q1-final-agg-stage.json
+++ b/backends-clickhouse/src/test/resources/substrait-plans/tpch-q1-final-agg-stage.json
@@ -139,22 +139,23 @@
                 }
               },
               "groupings": [{
-                "groupingExpressions": [{
-                  "selection": {
-                    "directReference": {
-                      "structField": {
-                      }
+                "expressionReferences": [0, 1]
+              }],
+              "groupingExpressions": [{
+                "selection": {
+                  "directReference": {
+                    "structField": {
                     }
                   }
-                }, {
-                  "selection": {
-                    "directReference": {
-                      "structField": {
-                        "field": 1
-                      }
+                }
+              }, {
+                "selection": {
+                  "directReference": {
+                    "structField": {
+                      "field": 1
                     }
                   }
-                }]
+                }
               }],
               "measures": [{
                 "measure": {

--- a/backends-clickhouse/src/test/resources/substrait-plans/tpch-q2-in-one-wholestage.json
+++ b/backends-clickhouse/src/test/resources/substrait-plans/tpch-q2-in-one-wholestage.json
@@ -750,14 +750,15 @@
                                                                                     }
                                                                                   },
                                                                                   "groupings": [{
-                                                                                    "groupingExpressions": [{
-                                                                                      "selection": {
-                                                                                        "directReference": {
-                                                                                          "structField": {
-                                                                                          }
+                                                                                    "expressionReferences": [0]
+                                                                                  }],
+                                                                                  "groupingExpressions": [{
+                                                                                    "selection": {
+                                                                                      "directReference": {
+                                                                                        "structField": {
                                                                                         }
                                                                                       }
-                                                                                    }]
+                                                                                    }
                                                                                   }],
                                                                                   "measures": [{
                                                                                     "measure": {
@@ -784,14 +785,15 @@
                                                                                 }
                                                                               },
                                                                               "groupings": [{
-                                                                                "groupingExpressions": [{
-                                                                                  "selection": {
-                                                                                    "directReference": {
-                                                                                      "structField": {
-                                                                                      }
+                                                                                "expressionReferences": [0]
+                                                                              }],
+                                                                              "groupingExpressions": [{
+                                                                                "selection": {
+                                                                                  "directReference": {
+                                                                                    "structField": {
                                                                                     }
                                                                                   }
-                                                                                }]
+                                                                                }
                                                                               }],
                                                                               "measures": [{
                                                                                 "measure": {

--- a/backends-clickhouse/src/test/resources/substrait-plans/tpch-q4-shj-stage.json
+++ b/backends-clickhouse/src/test/resources/substrait-plans/tpch-q4-shj-stage.json
@@ -170,14 +170,15 @@
             }
           },
           "groupings": [{
-            "groupingExpressions": [{
-              "selection": {
-                "directReference": {
-                  "structField": {
-                  }
+            "expressionReferences": [0]
+          }],
+          "groupingExpressions": [{
+            "selection": {
+              "directReference": {
+                "structField": {
                 }
               }
-            }]
+            }
           }],
           "measures": [{
             "measure": {

--- a/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/AggregateRelParser.cpp
@@ -100,7 +100,7 @@ AggregateRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & re
     }
 
     /// If the groupings is empty, we still need to return one row with default values even if the input is empty.
-    if ((rel.aggregate().groupings().empty() || rel.aggregate().groupings()[0].grouping_expressions().empty())
+    if ((rel.aggregate().groupings().empty() || rel.aggregate().groupings()[0].expression_references().empty())
         && (has_final_stage || has_complete_stage || rel.aggregate().measures().empty()))
     {
         LOG_TRACE(&Poco::Logger::get("AggregateRelParser"), "default aggregate result step");
@@ -185,8 +185,10 @@ void AggregateRelParser::setup(DB::QueryPlanPtr query_plan, const substrait::Rel
 
     if (aggregate_rel->groupings_size() == 1)
     {
-        for (const auto & expr : aggregate_rel->groupings(0).grouping_expressions())
+        /// Grouping expressions live in the rel-level pool; the grouping references them by index.
+        for (const auto & ref : aggregate_rel->groupings(0).expression_references())
         {
+            const auto & expr = aggregate_rel->grouping_expressions(ref);
             auto field_index = SubstraitParserUtils::getStructFieldIndex(expr);
             if (field_index)
                 grouping_keys.push_back(input_header.getByPosition(*field_index).name);

--- a/cpp-ch/local-engine/Parser/RelParsers/ExpandRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/ExpandRelParser.cpp
@@ -168,7 +168,7 @@ DB::QueryPlanPtr ExpandRelParser::lazyAggregateExpandParse(
     auto aggregate_rel = rel.expand().input().aggregate();
     auto aggregate_descriptions = buildAggregations(*input_header, expand_field, aggregate_rel);
 
-    size_t grouping_keys = aggregate_rel.groupings(0).grouping_expressions_size();
+    size_t grouping_keys = aggregate_rel.groupings(0).expression_references_size();
 
     auto expand_step
         = std::make_unique<AdvancedExpandStep>(getContext(), input_header, grouping_keys, aggregate_descriptions, expand_field);

--- a/cpp-ch/local-engine/tests/json/native_write_plan_1_spark33.json
+++ b/cpp-ch/local-engine/tests/json/native_write_plan_1_spark33.json
@@ -47,15 +47,18 @@
             },
             "groupings": [
               {
-                "groupingExpressions": [
-                  {
-                    "selection": {
-                      "directReference": {
-                        "structField": {}
-                      }
-                    }
-                  }
+                "expressionReferences": [
+                  0
                 ]
+              }
+            ],
+            "groupingExpressions": [
+              {
+                "selection": {
+                  "directReference": {
+                    "structField": {}
+                  }
+                }
               }
             ],
             "measures": [

--- a/cpp/velox/benchmarks/data/generic_q1/q1_first_stage_0.json
+++ b/cpp/velox/benchmarks/data/generic_q1/q1_first_stage_0.json
@@ -190,24 +190,28 @@
                                 },
                                 "groupings": [
                                     {
-                                        "groupingExpressions": [
-                                            {
-                                                "selection": {
-                                                    "directReference": {
-                                                        "structField": {}
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "selection": {
-                                                    "directReference": {
-                                                        "structField": {
-                                                            "field": 1
-                                                        }
-                                                    }
+                                        "expressionReferences": [
+                                            0,
+                                            1
+                                        ]
+                                    }
+                                ],
+                                "groupingExpressions": [
+                                    {
+                                        "selection": {
+                                            "directReference": {
+                                                "structField": {}
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "selection": {
+                                            "directReference": {
+                                                "structField": {
+                                                    "field": 1
                                                 }
                                             }
-                                        ]
+                                        }
                                     }
                                 ]
                             }

--- a/cpp/velox/benchmarks/data/plan/q17_joins.json
+++ b/cpp/velox/benchmarks/data/plan/q17_joins.json
@@ -310,15 +310,18 @@
                                     },
                                     "groupings": [
                                       {
-                                        "groupingExpressions": [
-                                          {
-                                            "selection": {
-                                              "directReference": {
-                                                "structField": {}
-                                              }
-                                            }
-                                          }
+                                        "expressionReferences": [
+                                          0
                                         ]
+                                      }
+                                    ],
+                                    "groupingExpressions": [
+                                      {
+                                        "selection": {
+                                          "directReference": {
+                                            "structField": {}
+                                          }
+                                        }
                                       }
                                     ],
                                     "measures": [

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -573,7 +573,10 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
   VELOX_CHECK(
       aggRel.groupings().size() <= 1, "At most one grouping is supported, but got {}.", aggRel.groupings().size());
   if (aggRel.groupings().size() == 1) {
-    for (const auto& groupingExpr : aggRel.groupings()[0].grouping_expressions()) {
+    // Grouping expressions live in the rel-level pool; each grouping references
+    // them by index.
+    for (const auto& ref : aggRel.groupings()[0].expression_references()) {
+      const auto& groupingExpr = aggRel.grouping_expressions(ref);
       // Velox's groupings are limited to be Field.
       veloxGroupingExprs.emplace_back(exprConverter_->toVeloxExpr(groupingExpr.selection(), inputType));
     }

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -1252,10 +1252,11 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
     }
   }
 
-  // Validate groupings.
+  // Validate groupings. Grouping expressions live in the rel-level pool; each
+  // grouping references them by index.
   for (const auto& grouping : aggRel.groupings()) {
-    for (const auto& groupingExpr : grouping.grouping_expressions()) {
-      const auto& typeCase = groupingExpr.rex_type_case();
+    for (const auto& ref : grouping.expression_references()) {
+      const auto& typeCase = aggRel.grouping_expressions(ref).rex_type_case();
       switch (typeCase) {
         case ::substrait::Expression::RexTypeCase::kSelection:
           break;
@@ -1365,7 +1366,7 @@ bool SubstraitToVeloxPlanValidator::validate(const ::substrait::AggregateRel& ag
   if (aggRel.measures_size() == 0) {
     bool hasExpr = false;
     for (const auto& grouping : aggRel.groupings()) {
-      if (grouping.grouping_expressions().size() > 0) {
+      if (grouping.expression_references_size() > 0) {
         hasExpr = true;
         break;
       }

--- a/cpp/velox/substrait/VeloxToSubstraitPlan.cc
+++ b/cpp/velox/substrait/VeloxToSubstraitPlan.cc
@@ -247,9 +247,12 @@ void VeloxToSubstraitPlanConvertor::toSubstrait(
   int64_t groupingKeySize = groupingKeys.size();
   ::substrait::AggregateRel_Grouping* aggGroupings = aggregateRel->add_groupings();
 
+  // Populate the rel-level grouping expression pool in declaration order and
+  // have the single grouping reference every entry by index.
   for (int64_t i = 0; i < groupingKeySize; i++) {
-    aggGroupings->add_grouping_expressions()->mutable_selection()->MergeFrom(
+    aggregateRel->add_grouping_expressions()->mutable_selection()->MergeFrom(
         exprConvertor_->toSubstraitExpr(arena, groupingKeys.at(i), inputType));
+    aggGroupings->add_expression_references(i);
   }
 
   // AggregatesSize should be equal to or greater than the aggregateMasks Size.

--- a/cpp/velox/tests/data/q1_first_stage.json
+++ b/cpp/velox/tests/data/q1_first_stage.json
@@ -536,28 +536,32 @@
                         },
                         "groupings": [
                             {
-                                "grouping_expressions": [
-                                    {
-                                        "selection": {
-                                            "direct_reference": {
-                                                "struct_field": {
-                                                    "field": 0
-                                                }
-                                            },
-                                            "root_reference": {}
+                                "expression_references": [
+                                    0,
+                                    1
+                                ]
+                            }
+                        ],
+                        "grouping_expressions": [
+                            {
+                                "selection": {
+                                    "direct_reference": {
+                                        "struct_field": {
+                                            "field": 0
                                         }
                                     },
-                                    {
-                                        "selection": {
-                                            "direct_reference": {
-                                                "struct_field": {
-                                                    "field": 1
-                                                }
-                                            },
-                                            "root_reference": {}
+                                    "root_reference": {}
+                                }
+                            },
+                            {
+                                "selection": {
+                                    "direct_reference": {
+                                        "struct_field": {
+                                            "field": 1
                                         }
-                                    }
-                                ]
+                                    },
+                                    "root_reference": {}
+                                }
                             }
                         ],
                         "measures": [

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/AggregateRelNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/AggregateRelNode.java
@@ -55,13 +55,18 @@ public class AggregateRelNode implements RelNode, Serializable {
     RelCommon.Builder relCommonBuilder = RelCommon.newBuilder();
     relCommonBuilder.setDirect(RelCommon.Direct.newBuilder());
 
-    AggregateRel.Grouping.Builder groupingBuilder = AggregateRel.Grouping.newBuilder();
-    for (ExpressionNode exprNode : groupings) {
-      groupingBuilder.addGroupingExpressions(exprNode.toProtobuf());
-    }
-
     AggregateRel.Builder aggBuilder = AggregateRel.newBuilder();
     aggBuilder.setCommon(relCommonBuilder.build());
+
+    // Gluten always emits a single grouping set with a flat list of grouping
+    // expressions (GROUPING SETS / CUBE / ROLLUP are expanded into an ExpandRel
+    // upstream). Populate the rel-level grouping expression pool in declaration
+    // order and have the single grouping reference every entry by index.
+    AggregateRel.Grouping.Builder groupingBuilder = AggregateRel.Grouping.newBuilder();
+    for (int i = 0; i < groupings.size(); i++) {
+      aggBuilder.addGroupingExpressions(groupings.get(i).toProtobuf());
+      groupingBuilder.addExpressionReferences(i);
+    }
     aggBuilder.addGroupings(groupingBuilder.build());
 
     for (int i = 0; i < aggregateFunctionNodes.size(); i++) {

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -344,16 +344,29 @@ message AggregateRel {
   // Input of the aggregation
   Rel input = 2;
 
-  // A list of expression grouping that the aggregation measured should be calculated for.
+  // A list of zero or more grouping sets that the aggregation measures should
+  // be calculated for. There must be at least one grouping set if there are no
+  // measures (but it can be the empty grouping set).
   repeated Grouping groupings = 3;
 
   // A list of one or more aggregate expressions along with an optional filter.
+  // Required if there are no groupings.
   repeated Measure measures = 4;
+
+  // A list of zero or more grouping expressions that grouping sets (i.e.,
+  // `Grouping` messages in the `groupings` field) can reference. Each
+  // expression in this list must be referred to by at least one
+  // `Grouping.expression_references`.
+  repeated Expression grouping_expressions = 5;
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 
   message Grouping {
-    repeated Expression grouping_expressions = 1;
+    reserved 1;
+
+    // A list of zero or more references to grouping expressions, i.e., indices
+    // into the `grouping_expression` list.
+    repeated uint32 expression_references = 2;
   }
 
   message Measure {

--- a/gluten-substrait/src/test/scala/org/apache/gluten/utils/AggregateRelProtoSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/utils/AggregateRelProtoSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.utils
+
+import org.apache.gluten.substrait.SubstraitContext
+import org.apache.gluten.substrait.expression.{AggregateFunctionNode, ExpressionBuilder, ExpressionNode}
+import org.apache.gluten.substrait.rel.RelBuilder
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Locks the AggregateRel producer contract after the Substrait 0.98 migration. 0.98 moved the
+ * grouping expressions out of the per-grouping `Grouping.grouping_expressions` (field 1) into a
+ * rel-level pool `AggregateRel.grouping_expressions` (field 5) that each grouping set references by
+ * index through `Grouping.expression_references` (field 2). Gluten only ever emits a single
+ * grouping set with a flat list of grouping expressions (GROUPING SETS / CUBE / ROLLUP are expanded
+ * into an ExpandRel upstream), so the producer populates the pool in declaration order and has the
+ * single grouping reference every entry as `[0, 1, ..., n - 1]`. This suite pins that mapping.
+ */
+class AggregateRelProtoSuite extends AnyFunSuite {
+
+  test("makeAggregateRel emits a rel-level pool referenced by the single grouping") {
+    val context = new SubstraitContext
+    val groupings: java.util.List[ExpressionNode] =
+      java.util.Arrays.asList[ExpressionNode](
+        ExpressionBuilder.makeSelection(0),
+        ExpressionBuilder.makeSelection(1))
+    val rel = RelBuilder.makeAggregateRel(
+      null,
+      groupings,
+      java.util.Collections.emptyList[AggregateFunctionNode](),
+      java.util.Collections.emptyList[ExpressionNode](),
+      null,
+      context,
+      0L)
+    val aggRel = rel.toProtobuf.getAggregate
+
+    // The flat grouping list becomes the rel-level pool, in declaration order.
+    def poolField(i: Int): Int =
+      aggRel.getGroupingExpressions(i).getSelection.getDirectReference.getStructField.getField
+    assert(aggRel.getGroupingExpressionsCount === 2)
+    assert(poolField(0) === 0)
+    assert(poolField(1) === 1)
+
+    // A single grouping references every pool entry by index.
+    assert(aggRel.getGroupingsCount === 1)
+    assert(aggRel.getGroupings(0).getExpressionReferencesCount === 2)
+    assert(aggRel.getGroupings(0).getExpressionReferences(0) === 0)
+    assert(aggRel.getGroupings(0).getExpressionReferences(1) === 1)
+  }
+
+  test("makeAggregateRel with no grouping keys emits one empty grouping (global aggregation)") {
+    val context = new SubstraitContext
+    val rel = RelBuilder.makeAggregateRel(
+      null,
+      java.util.Collections.emptyList[ExpressionNode](),
+      java.util.Collections.emptyList[AggregateFunctionNode](),
+      java.util.Collections.emptyList[ExpressionNode](),
+      null,
+      context,
+      0L
+    )
+    val aggRel = rel.toProtobuf.getAggregate
+
+    assert(aggRel.getGroupingExpressionsCount === 0)
+    assert(aggRel.getGroupingsCount === 1)
+    assert(aggRel.getGroupings(0).getExpressionReferencesCount === 0)
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Substrait 0.98 moved the grouping expressions out of the per-grouping `Grouping.grouping_expressions` (field 1) into a rel-level pool `AggregateRel.grouping_expressions = 5` that each grouping set references by index through `Grouping.expression_references = 2`. This migrates Gluten's vendored proto, the JVM producer, and both native consumers in lockstep, as one step of the Substrait `v0.23.0` → `0.98.0` proto rebase (#12597).

Gluten only ever emits a single grouping set with a flat list of grouping expressions — GROUPING SETS / CUBE / ROLLUP are expanded into an `ExpandRel` upstream, and both native consumers enforce at-most-one grouping. So the mapping is order-preserving: the flat list becomes the rel-level pool in declaration order, and the single grouping references every entry as `[0, 1, ..., n-1]`. Empty grouping (global aggregation) stays one empty grouping with zero references — no behavior change. `AggregateRel` stays at Rel-oneof field 3, so there is no oneof renumbering.

- **Proto:** reserve `Grouping` field 1, add `Grouping.expression_references = 2` and rel-level `AggregateRel.grouping_expressions = 5` (vendored verbatim from 0.98).
- **Producer:** `AggregateRelNode` populates the pool in declaration order and has the single grouping reference every entry by index.
- **Velox:** `SubstraitToVeloxPlan` and `SubstraitToVeloxPlanValidator` resolve references against the pool; `VeloxToSubstraitPlan` (the Velox→Substrait reverse converter) emits pool + references.
- **ClickHouse:** `AggregateRelParser` and `ExpandRelParser` read grouping keys through the pool via `expression_references`.

## How was this patch tested?

- New `AggregateRelProtoSuite` pins the producer contract (flat grouping list → rel-level pool + single grouping referencing `[0, 1]`; empty grouping → one empty grouping with zero references).
- Migrated the static Substrait plan JSON fixtures to the pooled shape so protobuf JSON parsing (which rejects the now-reserved inline field) still loads them: the Velox `q1_first_stage.json` consumer fixture, the ClickHouse metrics-suite plans (`covar_samp`/`covar_pop` partial + final, `tpch-q1`/`q2`/`q4`), and the Velox benchmark plans (`generic_q1`, `q17_joins`).
- Locally verified: `protoc` dup-field check; `gluten-substrait` builds and the new suite passes (`mvn -Pspark-3.5`); the Velox native backend compiles (consumer, validator, and reverse converter); `clang-format` (v15) clean on all changed C++ files.
- Existing end-to-end group-by suites exercise the consumer resolution on both backends.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)

🤖 Generated with AI
