### PR TITLE
[VL] Support dayname and monthname functions

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/utils/CHExpressionUtil.scala
@@ -213,6 +213,8 @@ object CHExpressionUtil {
     CHAR_TYPE_WRITE_SIDE_CHECK -> DefaultValidator(),
     READ_SIDE_PADDING -> DefaultValidator(),
     DIV -> DefaultValidator(),
-    REGEXP_INSTR -> DefaultValidator()
+    REGEXP_INSTR -> DefaultValidator(),
+    DAY_NAME -> DefaultValidator(),
+    MONTH_NAME -> DefaultValidator()
   )
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -737,6 +737,18 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  testWithMinSparkVersion("dayname", "4.0") {
+    runQueryAndCompare("SELECT dayname(l_shipdate) FROM lineitem limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+  }
+
+  testWithMinSparkVersion("monthname", "4.0") {
+    runQueryAndCompare("SELECT monthname(l_shipdate) FROM lineitem limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+  }
+
   testWithMinSparkVersion("mask", "3.4") {
     runQueryAndCompare("SELECT mask(c_comment) FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -646,7 +646,8 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           replaceWithExpressionTransformer0(expr.children.head, attributeSeq, expressionsMap),
           expr
         )
-      case _: GetDateField | _: GetTimeField =>
+      case e @ (_: GetDateField | _: GetTimeField)
+          if DateTimeExpressionsTransformer.EXTRACT_DATE_FIELD_MAPPING.contains(e.getClass) =>
         ExtractDateTransformer(
           substraitExprName,
           replaceWithExpressionTransformer0(expr.children.head, attributeSeq, expressionsMap),

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -228,6 +228,8 @@ object ExpressionNames {
   final val TIMESTAMP_DIFF = "timestampdiff"
   final val NEXT_DAY = "next_day"
   final val LAST_DAY = "last_day"
+  final val DAY_NAME = "dayname"
+  final val MONTH_NAME = "monthname"
   final val MONTHS_BETWEEN = "months_between"
   final val DATE_FROM_UNIX_DATE = "date_from_unix_date"
   final val UNIX_DATE = "unix_date"

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -79,7 +79,9 @@ class Spark40Shims extends SparkShims {
       Sig[UrlDecode](ExpressionNames.URL_DECODE),
       Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING),
       Sig[RandStr](ExpressionNames.RANDSTR),
-      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR)
+      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR),
+      Sig[DayName](ExpressionNames.DAY_NAME),
+      Sig[MonthName](ExpressionNames.MONTH_NAME)
     )
   }
 

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -78,7 +78,9 @@ class Spark41Shims extends SparkShims {
       Sig[UrlDecode](ExpressionNames.URL_DECODE),
       Sig[ToPrettyString](ExpressionNames.TO_PRETTY_STRING),
       Sig[RandStr](ExpressionNames.RANDSTR),
-      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR)
+      Sig[RegExpInStr](ExpressionNames.REGEXP_INSTR),
+      Sig[DayName](ExpressionNames.DAY_NAME),
+      Sig[MonthName](ExpressionNames.MONTH_NAME)
     )
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Velox already registers the sparksql `dayname(date)` and `monthname(date)` functions.
- https://facebookincubator.github.io/velox/functions/spark/datetime.html#dayname
- https://facebookincubator.github.io/velox/functions/spark/datetime.html#monthname

This PR aims to support them up on the Gluten side. Both Spark expressions (`DayName`, `MonthName`) are single-child `GetDateField` expressions introduced in Spark 4.0, so the mappings are added to the spark40/spark41 shims.


<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
New UTs.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, AI assistance.
