### PR TITLE
[DNM][VL] Upgrade Arrow Java to 18.1.0 for Spark 3.5+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1259,6 +1259,7 @@
         <antlr4.version>4.9.3</antlr4.version>
         <slf4j.version>2.0.7</slf4j.version>
         <log4j.version>2.20.0</log4j.version>
+        <arrow.version>18.1.0</arrow.version>
       </properties>
       <dependencies>
         <dependency>


### PR DESCRIPTION
Test-only. Raises `arrow.version` to 18.1.0 in the `spark-3.5` profile (Spark 3.3 / 3.4 keep 15.0.0; `spark-4.0` / `spark-4.1` are already on 18.1.0).

Arrow 18 targets Java 11 (class file 55) with no multi-release fallback, so the Spark 3.5 + JDK 8 lanes are expected to fail. Opened to see the full GHA picture.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-4.7