### PR TITLE
[GLUTEN-12748][CORE] Compare transition node name hash codes instead of subtracting

### DIFF
--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -136,12 +136,12 @@ object TransitionGraph {
             if (diff != 0) {
               diff
             } else {
-              // Break the tie on the node names so the chosen path is stable across JVM runs.
-              // Integer.compare rather than a subtraction: hash codes far enough apart overflow
-              // Int, and a wrapped sign makes FloydWarshallGraph replace the incumbent path with a
-              // more expensive one. Note two distinct name sequences can still share a hash code,
-              // and mkString joins without a separator, so ties are possible; the winner then comes
-              // down to map iteration order, as it did before.
+              // Break the tie on the node names, so that as long as the names distinguish the two
+              // paths the same one wins on every JVM run. Integer.compare rather than a
+              // subtraction: hash codes far enough apart overflow Int, and a wrapped sign hands the
+              // tie to the other path of the same cost. Two distinct name sequences can still share
+              // a hash code, and mkString joins without a separator, so a tie remains possible; the
+              // winner then comes down to map iteration order, as it did before.
               Integer.compare(nodeNames1.mkString.hashCode, nodeNames2.mkString.hashCode)
             }
         }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -59,6 +59,12 @@ object TransitionGraph {
     new TransitionCostModel(base)
   }
 
+  private[transition] def transitionCostForTesting(
+      value: GlutenCost,
+      nodeNames: Seq[String]): FloydWarshallGraph.Cost = {
+    TransitionCost(value, nodeNames)
+  }
+
   implicit class TransitionGraphOps(val graph: TransitionGraph) {
     import TransitionGraphOps._
     def hasTransition(from: TransitionGraph.Vertex, to: TransitionGraph.Vertex): Boolean = {
@@ -130,8 +136,13 @@ object TransitionGraph {
             if (diff != 0) {
               diff
             } else {
-              // To make the output order stable.
-              nodeNames1.mkString.hashCode - nodeNames2.mkString.hashCode
+              // Break the tie on the node names so the chosen path is stable across JVM runs.
+              // Integer.compare rather than a subtraction: hash codes far enough apart overflow
+              // Int, and a wrapped sign makes FloydWarshallGraph replace the incumbent path with a
+              // more expensive one. Note two distinct name sequences can still share a hash code,
+              // and mkString joins without a separator, so ties are possible; the winner then comes
+              // down to map iteration order, as it did before.
+              Integer.compare(nodeNames1.mkString.hashCode, nodeNames2.mkString.hashCode)
             }
         }
     }

--- a/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
+++ b/gluten-core/src/main/scala/org/apache/gluten/extension/columnar/transition/TransitionGraph.scala
@@ -59,12 +59,6 @@ object TransitionGraph {
     new TransitionCostModel(base)
   }
 
-  private[transition] def transitionCostForTesting(
-      value: GlutenCost,
-      nodeNames: Seq[String]): FloydWarshallGraph.Cost = {
-    TransitionCost(value, nodeNames)
-  }
-
   implicit class TransitionGraphOps(val graph: TransitionGraph) {
     import TransitionGraphOps._
     def hasTransition(from: TransitionGraph.Vertex, to: TransitionGraph.Vertex): Boolean = {

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionCostModelSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionCostModelSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension.columnar.transition
+
+import org.apache.gluten.extension.columnar.cost.LongCostModel
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class TransitionCostModelSuite extends AnyFunSuite {
+  import TransitionCostModelSuite._
+
+  test("costComparator does not overflow on distant node name hash codes") {
+    // The tiebreaker used to subtract the two hash codes. "RowToVeloxColumnar" hashes to
+    // 2056048280 and "CHColumnarToCarrierRow" to -2037667767, so the true difference is
+    // 4093716047, past Int.MaxValue, and the subtraction wrapped to -201251249. That inverted
+    // sign makes FloydWarshallGraph#build replace an incumbent path with an equal-cost one it
+    // should have kept. 46 of the 110 ordered pairs of Gluten transition node names invert.
+    val comparator = TransitionGraph.asTransitionCostModel(TestCostModel).costComparator()
+    val higherHash = costOf(Seq("RowToVeloxColumnar"))
+    val lowerHash = costOf(Seq("CHColumnarToCarrierRow"))
+
+    assert("RowToVeloxColumnar".hashCode - "CHColumnarToCarrierRow".hashCode < 0)
+    assert(comparator.compare(higherHash, lowerHash) > 0)
+    assert(comparator.compare(lowerHash, higherHash) < 0)
+  }
+
+  test("costComparator prefers the cheaper cost before consulting node names") {
+    val comparator = TransitionGraph.asTransitionCostModel(TestCostModel).costComparator()
+    val cheap = TransitionGraph.transitionCostForTesting(TestCostModel.costOf(Leaf()), Seq("zzzz"))
+    val expensive =
+      TransitionGraph.transitionCostForTesting(TestCostModel.costOf(Unary(Leaf())), Seq("AAAA"))
+    assert(comparator.compare(cheap, expensive) < 0)
+    assert(comparator.compare(expensive, cheap) > 0)
+  }
+
+  test("costComparator treats identical node name sequences as equal") {
+    val comparator = TransitionGraph.asTransitionCostModel(TestCostModel).costComparator()
+    val names = Seq("LoadArrowData", "ColumnarToRow")
+    assert(comparator.compare(costOf(names), costOf(names)) == 0)
+  }
+}
+
+object TransitionCostModelSuite {
+  private def costOf(nodeNames: Seq[String]): FloydWarshallGraph.Cost =
+    TransitionGraph.transitionCostForTesting(TestCostModel.makeZeroCost(), nodeNames)
+
+  /** Charges one per node, so a deeper plan costs more. */
+  private object TestCostModel extends LongCostModel {
+    override def selfLongCostOf(node: SparkPlan): Long = 1L
+  }
+
+  private case class Leaf() extends LeafExecNode {
+    override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
+    override def output: Seq[Attribute] = Nil
+  }
+
+  private case class Unary(child: SparkPlan) extends UnaryExecNode {
+    override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
+    override def output: Seq[Attribute] = Nil
+    override protected def withNewChildInternal(newChild: SparkPlan): Unary = copy(newChild)
+  }
+}

--- a/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionCostModelSuite.scala
+++ b/gluten-core/src/test/scala/org/apache/gluten/extension/columnar/transition/TransitionCostModelSuite.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.extension.columnar.cost.LongCostModel
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -32,11 +32,11 @@ class TransitionCostModelSuite extends AnyFunSuite {
     // The tiebreaker used to subtract the two hash codes. "RowToVeloxColumnar" hashes to
     // 2056048280 and "CHColumnarToCarrierRow" to -2037667767, so the true difference is
     // 4093716047, past Int.MaxValue, and the subtraction wrapped to -201251249. That inverted
-    // sign makes FloydWarshallGraph#build replace an incumbent path with an equal-cost one it
-    // should have kept. 46 of the 110 ordered pairs of Gluten transition node names invert.
-    val comparator = TransitionGraph.asTransitionCostModel(TestCostModel).costComparator()
-    val higherHash = costOf(Seq("RowToVeloxColumnar"))
-    val lowerHash = costOf(Seq("CHColumnarToCarrierRow"))
+    // sign hands an equal-cost tie to the wrong path in FloydWarshallGraph#build. 46 of the 110
+    // ordered pairs of Gluten transition node names invert this way.
+    val comparator = costModel.costComparator()
+    val higherHash = costOf(plan => RowToVeloxColumnar(plan))
+    val lowerHash = costOf(plan => CHColumnarToCarrierRow(plan))
 
     assert("RowToVeloxColumnar".hashCode - "CHColumnarToCarrierRow".hashCode < 0)
     assert(comparator.compare(higherHash, lowerHash) > 0)
@@ -44,38 +44,44 @@ class TransitionCostModelSuite extends AnyFunSuite {
   }
 
   test("costComparator prefers the cheaper cost before consulting node names") {
-    val comparator = TransitionGraph.asTransitionCostModel(TestCostModel).costComparator()
-    val cheap = TransitionGraph.transitionCostForTesting(TestCostModel.costOf(Leaf()), Seq("zzzz"))
-    val expensive =
-      TransitionGraph.transitionCostForTesting(TestCostModel.costOf(Unary(Leaf())), Seq("AAAA"))
+    // Aaaa sorts and hashes below Zzzz, so a comparator that ignored the base cost would order
+    // these the other way around.
+    val comparator = costModel.costComparator()
+    val cheap = costOf(plan => Zzzz(plan))
+    val expensive = costOf(plan => Aaaa(Aaaa(plan)))
     assert(comparator.compare(cheap, expensive) < 0)
     assert(comparator.compare(expensive, cheap) > 0)
   }
 
-  test("costComparator treats identical node name sequences as equal") {
-    val comparator = TransitionGraph.asTransitionCostModel(TestCostModel).costComparator()
-    val names = Seq("LoadArrowData", "ColumnarToRow")
-    assert(comparator.compare(costOf(names), costOf(names)) == 0)
+  test("costComparator treats the same transition as equal to itself") {
+    val comparator = costModel.costComparator()
+    assert(comparator.compare(costOf(plan => Zzzz(plan)), costOf(plan => Zzzz(plan))) == 0)
   }
 }
 
 object TransitionCostModelSuite {
-  private def costOf(nodeNames: Seq[String]): FloydWarshallGraph.Cost =
-    TransitionGraph.transitionCostForTesting(TestCostModel.makeZeroCost(), nodeNames)
+  private def costModel: FloydWarshallGraph.CostModel[Transition] =
+    TransitionGraph.asTransitionCostModel(TestCostModel)
+
+  /** The cost of a transition, whose node names are those of the nodes it wraps the input in. */
+  private def costOf(f: SparkPlan => SparkPlan): FloydWarshallGraph.Cost =
+    costModel.costOf((plan: SparkPlan) => f(plan))
 
   /** Charges one per node, so a deeper plan costs more. */
   private object TestCostModel extends LongCostModel {
     override def selfLongCostOf(node: SparkPlan): Long = 1L
   }
 
-  private case class Leaf() extends LeafExecNode {
-    override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
-    override def output: Seq[Attribute] = Nil
-  }
+  /** Node names below are the class names: Spark only strips a trailing "Exec". */
+  private case class RowToVeloxColumnar(child: SparkPlan) extends Wrapper
+  private case class CHColumnarToCarrierRow(child: SparkPlan) extends Wrapper
+  private case class Zzzz(child: SparkPlan) extends Wrapper
+  private case class Aaaa(child: SparkPlan) extends Wrapper
 
-  private case class Unary(child: SparkPlan) extends UnaryExecNode {
+  private trait Wrapper extends UnaryExecNode {
     override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
     override def output: Seq[Attribute] = Nil
-    override protected def withNewChildInternal(newChild: SparkPlan): Unary = copy(newChild)
+    override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+      throw new UnsupportedOperationException()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`TransitionCostModel#costComparator` breaks a cost tie on the transited plan's node names, and did so by subtracting two `String` hashCodes. The subtraction overflows: `"RowToVeloxColumnar"` hashes to 2056048280 and `"CHColumnarToCarrierRow"` to -2037667767, so the true difference is 4093716047, past `Int.MaxValue`, and the int result wraps to -201251249. Across the node names Gluten's transitions actually produce, 46 of the 110 ordered pairs invert this way. `FloydWarshallGraph#build` uses the comparator to decide whether a newly found path replaces the incumbent, so an inverted sign can swap in an equal-cost path that should have lost. The graph is built once per driver and cached, so the choice then applies to every query in the session.

This switches the tiebreaker to `Integer.compare` on the same two hash codes. That corrects the sign without changing which path wins any tie that did not overflow, so no query plan changes.

The narrower fix is deliberate. Comparing the joined strings with `String#compareTo` would also remove hash collisions, but it changes the sort key and therefore the winner of every equal-cost tie, not just the overflowing ones. One such tie is real: ArrowNative to VanillaRow has two paths costing 15 each, `LoadArrowData` plus `ColumnarToRow` versus `ArrowColumnarToVeloxColumnar` plus `VeloxColumnarToRow`, and their hash codes are close enough that the subtraction was already correct (-998799209, no overflow). Under `compareTo` the second path wins instead, which breaks five assertions in `VeloxTransitionSuite` and, more importantly, rewrites the plan for every query where an Arrow-native operator feeds a row operator. There is no evidence the new path is cheaper at runtime, so that belongs in a separate change with Velox-side review, not smuggled into an overflow fix.

Two limits stay as they were, since removing either changes tie winners. Distinct name sequences can share a hash code, and `mkString` joins without a separator, so `Seq("Load", "ArrowData")` and `Seq("LoadArrow", "Data")` collapse to one string. A tie then falls back on `mutable.Map` iteration order. The old comment claimed the tiebreaker was there "To make the output order stable"; the new comment says what it does and what it does not.

### How was this patch tested?

New `TransitionCostModelSuite` in `gluten-core`. `costComparator does not overflow on distant node name hash codes` fails before the change and passes after: it asserts the raw subtraction is negative for that pair while the comparator orders it positive. The other two tests pin that the base cost still decides before node names, and that identical sequences stay equal; both pass before and after, so the honest count is one guardrail plus two boundary assertions.

`TransitionCost` is private, so the suite builds one through a new `private[transition]` helper on `TransitionGraph`. The suite's cost model is a three-line subclass of the production `LongCostModel` rather than a hand-rolled stub, so its `sum`, `diff`, and comparator keep production semantics.

`mvn -Pspark-3.5 -pl gluten-core test` gives 54 tests passing. Cross-version `test-compile` passes on spark-3.3, spark-3.4, spark-4.0 with scala-2.13, and spark-4.1 with scala-2.13.

Worth flagging for review: `VeloxTransitionSuite` is the suite that would catch a tie flip, it lives in `backends-velox` and needs the native library, and I could not run it locally. CI covering it is what confirms the "no plan change" claim.

### Was this patch authored or co-authored using generative AI tooling?

No

Closes #12748
