### PR TITLE
[VL] Support format_number function

### DIFF
--- a/backends-clickhouse/src/main/scala/org/apache/gluten/utils/CHExpressionUtil.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/utils/CHExpressionUtil.scala
@@ -214,6 +214,7 @@ object CHExpressionUtil {
     DIV -> DefaultValidator(),
     REGEXP_INSTR -> DefaultValidator(),
     DAY_NAME -> DefaultValidator(),
-    MONTH_NAME -> DefaultValidator()
+    MONTH_NAME -> DefaultValidator(),
+    FORMAT_NUMBER -> DefaultValidator()
   )
 }

--- a/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionRestrictions.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/expression/ExpressionRestrictions.scala
@@ -101,6 +101,21 @@ object RaiseErrorRestrictions extends ExpressionRestrictions {
   override val restrictionMessages: Array[String] = Array(ONLY_SUPPORT_ERROR_MESSAGE)
 }
 
+object FormatNumberRestrictions extends ExpressionRestrictions {
+  val NOT_SUPPORT_DECIMAL_INPUT: String =
+    s"${ExpressionNames.FORMAT_NUMBER} only supports tinyint, smallint, integer, bigint, " +
+      s"float and double input; DecimalType input is not supported in Velox"
+
+  val NOT_SUPPORT_STRING_FORMAT: String =
+    s"${ExpressionNames.FORMAT_NUMBER} with a string format argument (e.g. '#,###.##') is not " +
+      s"supported in Velox; only an integer number of decimal places is supported"
+
+  override val functionName: String = ExpressionNames.FORMAT_NUMBER
+
+  override val restrictionMessages: Array[String] =
+    Array(NOT_SUPPORT_DECIMAL_INPUT, NOT_SUPPORT_STRING_FORMAT)
+}
+
 object ExpressionRestrictions {
   // Called by gen-function-support-docs.py to get all restrictions.
   def listAllRestrictions(): Array[ExpressionRestrictions] = {
@@ -109,7 +124,8 @@ object ExpressionRestrictions {
       FromJsonRestrictions,
       ToJsonRestrictions,
       Unbase64Restrictions,
-      Base64Restrictions
+      Base64Restrictions,
+      FormatNumberRestrictions
     )
   }
 }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -749,6 +749,36 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
+  test("format_number") {
+    // Integer / bigint input with different decimal places.
+    runQueryAndCompare("SELECT format_number(l_partkey, 0) FROM lineitem limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    runQueryAndCompare("SELECT format_number(l_orderkey, 2) FROM lineitem limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    // Floating-point input, exercising HALF_EVEN rounding and thousands separators.
+    runQueryAndCompare(
+      "SELECT format_number(cast(l_quantity as double), 1) FROM lineitem limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    runQueryAndCompare(
+      "SELECT format_number(cast(l_discount as double), 3) FROM lineitem limit 50") {
+      checkGlutenPlan[ProjectExecTransformer]
+    }
+    // Velox format_number only supports tinyint/smallint/integer/bigint/float/double.
+    // Decimal input has no matching signature, so it must fall back to vanilla Spark.
+    runQueryAndCompare("SELECT format_number(l_quantity, 1) FROM lineitem limit 50") {
+      checkSparkPlan[ProjectExec]
+    }
+    // Velox only implements the integer decimal-places form. The string-format form
+    // (e.g. '#,###.##') has no matching signature, so it must fall back to vanilla Spark.
+    runQueryAndCompare(
+      "SELECT format_number(cast(l_quantity as double), '#,###.##') FROM lineitem limit 50") {
+      checkSparkPlan[ProjectExec]
+    }
+  }
+
   testWithMinSparkVersion("mask", "3.4") {
     runQueryAndCompare("SELECT mask(c_comment) FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]

--- a/docs/velox-backend-scalar-function-support.md
+++ b/docs/velox-backend-scalar-function-support.md
@@ -1,6 +1,6 @@
 # Scalar Functions Support Status
 
-**Out of 357 scalar functions in Spark 3.5, Gluten currently fully supports 245 functions and partially supports 27 functions.**
+**Out of 357 scalar functions in Spark 3.5, Gluten currently fully supports 245 functions and partially supports 28 functions.**
 
 ## Array Functions
 
@@ -370,7 +370,7 @@
 | encode             | Encode                      |          |                                                         |
 | endswith           | EndsWithExpressionBuilder   | PS       | BinaryType unsupported                                  |
 | find_in_set        | FindInSet                   | S        |                                                         |
-| format_number      | FormatNumber                |          |                                                         |
+| format_number      | FormatNumber                | PS       | format_number only supports tinyint, smallint, integer, bigint, float and double input; DecimalType input is not supported in Velox<br>format_number with a string format argument (e.g. '#,###.##') is not supported in Velox; only an integer number of decimal places is supported |
 | format_string      | FormatString                |          |                                                         |
 | initcap            | InitCap                     | S        |                                                         |
 | instr              | StringInstr                 | S        |                                                         |

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionMappings.scala
@@ -107,6 +107,7 @@ object ExpressionMappings {
     Sig[UnBase64](UNBASE64),
     Sig[Base64](BASE64),
     Sig[FormatString](FORMAT_STRING),
+    Sig[FormatNumber](FORMAT_NUMBER),
 
     // URL functions
     Sig[ParseUrl](PARSE_URL),

--- a/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/expression/ExpressionNames.scala
@@ -143,6 +143,7 @@ object ExpressionNames {
   final val BASE64 = "base64"
   final val MASK = "mask"
   final val FORMAT_STRING = "format_string"
+  final val FORMAT_NUMBER = "format_number"
   final val LUHN_CHECK = "luhn_check"
   final val TO_PRETTY_STRING = "to_pretty_string"
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Velox already registers the sparksql `format_number(number, decimalPlaces)` function (thousands separators, fixed decimal digits, HALF_EVEN rounding), so wire it up on the Gluten side.

- https://facebookincubator.github.io/velox/functions/spark/string.html#format_number

Unlike CAST(number AS VARCHAR), this adds thousands separators and fixed decimal places. Supports tinyint, smallint, integer, bigint, float, and double.

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
New UTs.

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, Assisted-by: Claude:claude-opus-4-8
