### PR TITLE
[GLUTEN-12412][VL] Add AlmaLinux 8 vcpkg static build CI image

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -371,6 +371,56 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-vcpkg-almalinux-8-gcc13:
+    if: ${{ startsWith(github.repository, 'apache/') }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: ${{ env.DOCKERHUB_REPO }}
+          tags: vcpkg-almalinux-8-gcc13
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          file: dev/docker/Dockerfile.almalinux8-gcc13-static-build
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }}",push-by-digest=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-vcpkg-almalinux-8-gcc13-${{ matrix.os }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   merge:
     if: ${{ startsWith(github.repository, 'apache/') }}
     runs-on: ubuntu-latest
@@ -498,3 +548,46 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}
+
+  merge-almalinux-8-gcc13:
+    if: ${{ startsWith(github.repository, 'apache/') }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        digests: [ vcpkg-almalinux-8-gcc13 ]
+    needs:
+      - build-vcpkg-almalinux-8-gcc13
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.digests }}-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: ${{ env.DOCKERHUB_REPO }}
+          tags: ${{ matrix.digests }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.DOCKERHUB_REPO }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKERHUB_REPO }}:${{ steps.meta.outputs.version }}
+

--- a/dev/ci-velox-buildstatic-centos-8-enhanced-features.sh
+++ b/dev/ci-velox-buildstatic-centos-8-enhanced-features.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if [ "$(uname -m)" = "aarch64" ]; then
+    export CPU_TARGET="aarch64";
+    export VCPKG_FORCE_SYSTEM_BINARIES=1;
+fi
+
+export NUM_THREADS=2
+./dev/builddeps-veloxbe.sh --enable_vcpkg=ON --build_arrow=OFF --build_tests=ON --build_benchmarks=ON \
+                           --build_examples=OFF --enable_s3=ON --enable_gcs=ON --enable_hdfs=ON --enable_abfs=ON --enable_enhanced_features=ON

--- a/dev/docker/Dockerfile.almalinux8-gcc13-static-build
+++ b/dev/docker/Dockerfile.almalinux8-gcc13-static-build
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# vcpkg-based static build image for Gluten on AlmaLinux 8 + GCC 13.
+# Produces the apache/gluten:vcpkg-almalinux-8-gcc13 image.
+#
+# AlmaLinux 8 is a 1:1 RHEL 8 binary-compatible rebuild that replaces CentOS 8
+# (EOL Dec 2021). glibc 2.28 allows Velox's modern Folly/FBThrift/MVFST stack
+# to build without the socket.h workaround required on CentOS 7 (glibc 2.17).
+#
+# Modelled on dev/docker/Dockerfile.centos7-gcc13-static-build, which is the
+# reference requested in https://github.com/apache/gluten/issues/12412.
+
+FROM almalinux:8
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
+ENV PATH=$JAVA_HOME/bin:$PATH
+
+# An actual path used for vcpkg cache.
+ENV VCPKG_PATH=/var/cache/vcpkg
+# Set vcpkg cache path.
+ENV VCPKG_BINARY_SOURCES=clear;files,${VCPKG_PATH},readwrite
+
+RUN set -ex; \
+    # AlmaLinux 8 repos are live — no mirror fixup needed. \
+    dnf update -y; \
+    dnf install -y epel-release sudo; \
+    # ccache is in EPEL — install after epel-release is registered. \
+    dnf install -y ccache; \
+    # gcc-toolset-13 ships GCC 13 on RHEL8-family via Red Hat Software Collections. \
+    dnf install -y --setopt=install_weak_deps=False gcc-toolset-13; \
+    dnf install -y java-1.8.0-openjdk-devel patch git wget perl python3 automake libtool flex; \
+    dnf -y --enablerepo=powertools install autoconf-archive ninja-build; \
+    # Install a recent CMake binary — the version in EPEL 8 is too old for Velox. \
+    wget https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-linux-$(uname -m).sh; \
+    chmod +x cmake-3.31.12-linux-$(uname -m).sh; \
+    ./cmake-3.31.12-linux-$(uname -m).sh --skip-license --prefix=/usr/local; \
+    rm -f cmake-3.31.12-linux-$(uname -m).sh; \
+    echo "check_certificate = off" >> ~/.wgetrc; \
+    dnf clean all; \
+    git clone --depth=1 https://github.com/apache/gluten /opt/gluten; \
+    mkdir -p ${VCPKG_PATH}; \
+    echo "Build arrow, then install the native libs to system paths and jar package to .m2/ directory."; \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        export CPU_TARGET="aarch64"; \
+        export VCPKG_FORCE_SYSTEM_BINARIES=1; \
+    fi; \
+    source /opt/rh/gcc-toolset-13/enable; \
+    cd /opt/gluten; \
+    export SSL_VERIFY=false; \
+    bash ./dev/builddeps-veloxbe.sh --enable_vcpkg=ON --build_tests=ON --enable_s3=ON --enable_gcs=ON \
+                                    --enable_hdfs=ON --enable_abfs=ON  build_arrow; \
+    ./build/mvn dependency:go-offline -Pbackends-velox -Piceberg -Pdelta -Pspark-3.5 -DskipTests; \
+    rm -rf /opt/gluten; \
+    rm -rf /root/.cache/ccache;

--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -154,7 +154,7 @@ function apply_provided_velox_patch {
 
 function apply_compilation_fixes {
   local SUDO_CMD=""
-  if [ "$OS" == "Linux" ]; then
+  if [ "$OS" == "Linux" ] && [ "${EUID:-$(id -u)}" -ne 0 ]; then
     SUDO_CMD="sudo"
   fi
   $SUDO_CMD cp ${CURRENT_DIR}/modify_arrow.patch ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/

--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -212,6 +212,7 @@ function setup_linux {
     "$LINUX_DISTRIBUTION" == "almalinux" ]]; then
     case "${LINUX_VERSION_ID%%.*}" in
       9) ;;
+      8) ;;
       *)
         echo "Unsupported ${LINUX_DISTRIBUTION} version: $LINUX_VERSION_ID"
         exit 1


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes #12412 (1)

CentOS 7 (glibc 2.17) is increasingly difficult to maintain as a vcpkg build base due to Velox's growing dependency on modern Folly/FBThrift/MVFST versions. This PR adds the AlmaLinux 8 (glibc 2.28) Docker image — a 1:1 RHEL 8-compatible rebuild of the EOL CentOS 8 — as the new vcpkg static build base, in preparation for migrating the x86/arm native lib CI jobs.

Add AlmaLinux 8 vcpkg static build CI image:

- Add `dev/docker/Dockerfile.almalinux8-gcc13-static-build` to produce `apache/gluten:vcpkg-almalinux-8-gcc13`, modelled on the existing `Dockerfile.centos7-gcc13-static-build`. 
Uses `FROM almalinux:8` (live repos, no mirror fixups needed) with GCC 13 via `gcc-toolset-13` and a pinned CMake 3.31.12.
- Add dev/ci-velox-buildstatic-centos-8-enhanced-features.sh — the CentOS 8 equivalent of the existing ci-velox-buildstatic-centos-7-enhanced-features.sh, omitting the socket.h workaround required on CentOS 7.
- Add build-vcpkg-almalinux-8-gcc13 and merge-almalinux-8-gcc13 jobs to docker_image.yml to build and publish the multi-arch image.

## How was this patch tested?
The Dockerfile.almalinux8-gcc13-static-build follows the same structure as the existing Dockerfile.centos8-gcc13-static-build. The docker_image.yml workflow will publish the image to Docker Hub on merge.

## Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Sonnet 4.5