### PR TITLE
[HOTFIX][GHA] Fix labeler.yml YAML indentation for actions/labeler v7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,86 +16,76 @@
 
 INFRA:
   - changed-files:
-    - any-glob-to-any-file: [
-      '.github/**/*',
-      '.asf.yaml',
-      '.gitattributes',
-      'LICENSE',
-      'LICENSE-binary',
-      'NOTICE',
-      'NOTICE-binary'
-    ]
+      - any-glob-to-any-file:
+          - '.github/**/*'
+          - '.asf.yaml'
+          - '.gitattributes'
+          - 'LICENSE'
+          - 'LICENSE-binary'
+          - 'NOTICE'
+          - 'NOTICE-binary'
 
 BUILD:
   - changed-files:
-    - any-glob-to-any-file: [
-      'dev/**/*',
-      'ep/build-velox/src/get-velox.sh',
-      'ep/build-velox/src/build-velox.sh',
-      'ep/build-clickhouse/src/build-clickhouse.sh'
-    ]
+      - any-glob-to-any-file:
+          - 'dev/**/*'
+          - 'ep/build-velox/src/get-velox.sh'
+          - 'ep/build-velox/src/build-velox.sh'
+          - 'ep/build-clickhouse/src/build-clickhouse.sh'
 
 DOCS:
   - changed-files:
-    - any-glob-to-any-file: [
-      'docs/**/*',
-      '**/README.md',
-      '**/CONTRIBUTING.md'
-    ]
+      - any-glob-to-any-file:
+          - 'docs/**/*'
+          - '**/README.md'
+          - '**/CONTRIBUTING.md'
 
 CORE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'gluten-core/**/*',
-      'gluten-substrait/**/*',
-      'shims/**/*',
-      'gluten-ras/**/*',
-      'gluten-ui/**/*',
-      'gluten-ut/**/*',
-      'package/**/*',
-      'pom.xml'
-    ]
+      - any-glob-to-any-file:
+          - 'gluten-core/**/*'
+          - 'gluten-substrait/**/*'
+          - 'shims/**/*'
+          - 'gluten-ras/**/*'
+          - 'gluten-ui/**/*'
+          - 'gluten-ut/**/*'
+          - 'package/**/*'
+          - 'pom.xml'
 
 VELOX:
   - changed-files:
-    - any-glob-to-any-file: [
-      'gluten-arrow/**/*',
-      'backends-velox/**/*',
-      'ep/build-velox/**/*',
-      'cpp/**/*'
-    ]
+      - any-glob-to-any-file:
+          - 'gluten-arrow/**/*'
+          - 'backends-velox/**/*'
+          - 'ep/build-velox/**/*'
+          - 'cpp/**/*'
 
 CLICKHOUSE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'backends-clickhouse/**/*',
-      'ep/build-clickhouse/**/*',
-      'cpp-ch/**/*'
-    ]
+      - any-glob-to-any-file:
+          - 'backends-clickhouse/**/*'
+          - 'ep/build-clickhouse/**/*'
+          - 'cpp-ch/**/*'
 
 DATA_LAKE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'gluten-iceberg/**/*',
-      'gluten-delta/**/*',
-      'gluten-hudi/**/*'
-    ]
+      - any-glob-to-any-file:
+          - 'gluten-iceberg/**/*'
+          - 'gluten-delta/**/*'
+          - 'gluten-hudi/**/*'
 
 RSS:
   - changed-files:
-    - any-glob-to-any-file: [
-     'gluten-celeborn/**/*',
-     'gluten-uniffle/**/*'
-    ]
+      - any-glob-to-any-file:
+          - 'gluten-celeborn/**/*'
+          - 'gluten-uniffle/**/*'
 
 TOOLS:
   - changed-files:
-    - any-glob-to-any-file: [
-      'tools/**/*'
-    ]
+      - any-glob-to-any-file:
+          - 'tools/**/*'
 
 FLINK:
   - changed-files:
-    - any-glob-to-any-file: [
-      'gluten-flink/**/*'
-    ]
+      - any-glob-to-any-file:
+          - 'gluten-flink/**/*'


### PR DESCRIPTION
## What changes are proposed in this pull request?

`label-pull-requests` is currently failing on every PR whose branch has picked up
`main`, breaking PR auto-labeling repo-wide:

```
##[error]YAMLException: deficient indentation (20:7)
 17 | INFRA:
 18 |   - changed-files:
 19 |     - any-glob-to-any-file: [
 20 |       '.github/**/*',
------------^
```

**Root cause.** #12684 bumped `actions/labeler` from v5 to v7, which upgrades its
`js-yaml` dependency from `^4.1.0` to `^5.1.0`. js-yaml v5 enforces strict
block-mapping indentation, and rejects the multi-line flow-sequence style
`.github/labeler.yml` has always used — the opening bracket sits on the mapping
line and the continuation lines are not indented past the parent node:

```yaml
  - changed-files:
    - any-glob-to-any-file: [
      '.github/**/*',      # js-yaml 5: "deficient indentation"
    ]
```

js-yaml v4 tolerated this, so the file worked fine under labeler v5. The config
content itself was never wrong; only the parser got stricter.

**Fix.** Convert every glob list from a flow sequence to a block sequence, which is
unambiguous under both parsers and matches the style used in the `actions/labeler`
README:

```yaml
  - changed-files:
      - any-glob-to-any-file:
          - '.github/**/*'
```

No labels, globs, or matching semantics change — this is purely a YAML notation fix.

## How was this patch tested?

Reproduced the failure and verified the fix locally by parsing the file with both
parser versions directly:

| file | js-yaml 4 (labeler v5) | js-yaml 5.2.3 (labeler v7) |
|---|---|---|
| before | parses | **`YAMLException: deficient indentation` at 20:7** — matches CI exactly |
| after | parses | parses |

Also verified semantic equivalence by parsing both revisions and comparing the
normalized `{label: sorted(globs)}` structure — identical across all 10 labels
(INFRA 7, BUILD 4, DOCS 3, CORE 8, VELOX 4, CLICKHOUSE 3, DATA_LAKE 3, RSS 2,
TOOLS 1, FLINK 1 globs).

This PR touches `.github/**`, so a successful `label-pull-requests` run applying the
`INFRA` label to this PR is itself an end-to-end confirmation.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-4.7
