### PR TITLE
[MINOR] Use GlutenCoreConfig API in GlobalOffHeapMemoryTarget#mode

### DIFF
--- a/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemoryTarget.scala
+++ b/gluten-core/src/main/scala/org/apache/spark/memory/GlobalOffHeapMemoryTarget.scala
@@ -36,10 +36,7 @@ class GlobalOffHeapMemoryTarget private[memory]
   private val targetName = MemoryTargetUtil.toUniqueName("GlobalOffHeap")
   private val recorder: MemoryUsageRecorder = new SimpleMemoryUsageRecorder()
   private def mode: MemoryMode = {
-    val enabled = Option(SparkEnv.get)
-      .map(_.conf.getBoolean(GlutenCoreConfig.DYNAMIC_OFFHEAP_SIZING_ENABLED.key, false))
-      .getOrElse(false)
-    if (enabled) MemoryMode.ON_HEAP
+    if (GlutenCoreConfig.get.dynamicOffHeapSizingEnabled) MemoryMode.ON_HEAP
     else MemoryMode.OFF_HEAP
   }
 


### PR DESCRIPTION
  Description:                                                                                                                                                                   
                                                                                                                                                                                 
  ## What changes were proposed in this pull request?                                                                                                                            
                                                                                                                                                                                 
  Simplify `GlobalOffHeapMemoryTarget#mode` by using `GlutenCoreConfig.get.dynamicOffHeapSizingEnabled`                                                                          
  instead of manually reading the config key via `SparkEnv.get.conf.getBoolean(...)`.                                                                                            
                                                                                                                                                                                 
  ## Why are the changes needed?                                                                                                                                                 
                                                                                                                                                                                 
  `GlutenCoreConfig` already provides a type-safe accessor for this config with                                                                                                  
  the default value defined in one place. Using the raw key duplicates the default                                                                                               
  value and bypasses the existing abstraction.                                                                                                                                   
                                                                                                                                                                                 
  ## Does this PR introduce any user-facing change?                                                                                                                              
                                                                                                                                                                                 
  No.                                                                                                                                                                            
                                                                                                                                                                                 
  ## How was this patch tested?                                                                                                                                                  
                                                                                                                                                                                 
  Existing tests. No behavior change.  