### PR TITLE
[VL] Re-enable SPARK-36286 timestamp cast test

### DIFF
--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -103,7 +103,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // Excluded in favour of the GlutenCastSuite rewrite, which drops the Long.MinValue
     // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
-    .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
   enableSuite[GlutenTryCastSuite]
     .exclude(

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -107,7 +107,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // Excluded in favour of the GlutenCastSuite rewrite, which drops the Long.MinValue
     // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
-    .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
   enableSuite[GlutenTryCastSuite]
     .exclude(

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -117,7 +117,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // Excluded in favour of the GlutenCastWithAnsiOffSuite rewrite, which drops the Long.MinValue
     // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
-    .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
   enableSuite[GlutenTryCastSuite]
     .exclude(

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -120,7 +120,6 @@ class VeloxTestSettings extends BackendTestSettings {
     // Excluded in favour of the GlutenCastWithAnsiOffSuite rewrite, which drops the Long.MinValue
     // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
-    .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
   enableSuite[GlutenTryCastSuite]
     .exclude(


### PR DESCRIPTION
## What

Re-enables the `SPARK-36286: invalid string cast to timestamp` test, which was excluded
in the Velox test settings across the Spark version shims.

The test was excluded because Velox accepted `CAST('2015-03-18T' AS TIMESTAMP)` as a
valid date with a zeroed time (`2015-03-18 00:00:00`), while Spark returns `NULL`: a
date-time separator must be followed by a time component.

Velox now rejects a trailing separator, and Gluten's pinned Velox baseline already
contains that fix, so the exclusion is no longer needed.

## Change

- Remove `.exclude("SPARK-36286: invalid string cast to timestamp")` from
  `VeloxTestSettings.scala` in the spark34, spark35, spark40 and spark41 shims.

The earlier revision of this PR also edited a spark33 shim; that shim has since been removed
from main, so only four remain.

An earlier revision of this PR also set `UPSTREAM_VELOX_PR_ID` so that CI would apply
the Velox fix as a patch on top of the pinned baseline. That is unnecessary now that the
fix is in the baseline, so `get-velox.sh` is left untouched.

## Testing

Ran `GlutenCastSuite` (Spark 3.5, Velox backend) against a local build of the currently
pinned Velox baseline, before and after this change:

| | tests run | passed | failed | ignored |
|---|---|---|---|---|
| baseline (`main`) | 85 | 82 | 3 | 6 |
| with this change | 86 | 83 | 3 | 5 |

Exactly one additional test runs, `SPARK-36286: invalid string cast to timestamp`, and it
passes. The 3 failures are identical in both runs and are local-environment artifacts
(this host's timezone; e.g. `SPARK-35719` expects `0001-01-01T00:00` and gets a
local-mean-time offset), not related to this change.

## Related

- Velox fix: https://github.com/facebookincubator/velox/pull/18502
- Gluten issue: https://github.com/apache/gluten/issues/8984
