### PR TITLE
[GLUTEN-12743][CI] Let contributors trigger the Delta Spark UT with a /delta-test PR comment

### DIFF
--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -201,12 +201,21 @@ jobs:
     # A maintainer who wants a run on someone else's PR asks the author to
     # comment.
     #
-    # `startsWith`, not `contains`, so quoting the command while discussing it
-    # does not spend ~11 job-hours.
+    # The command must be the FIRST TOKEN of the comment, so neither quoting it
+    # while discussing it (`contains` would match) nor a longer command that
+    # merely starts the same way (`/delta-test-arm`, `/delta-testers` -- plain
+    # `startsWith` would match both) can spend ~11 job-hours. GHA expressions
+    # have no regex, so spell out the four ways the token can legally end:
+    # end-of-body, a space, or a newline (`fromJSON` is the only way to write a
+    # control character in an expression; GitHub stores comment bodies CRLF, and
+    # bare LF arrives via the API).
     if: >-
       github.event_name != 'issue_comment' ||
       (github.event.issue.pull_request &&
-       startsWith(github.event.comment.body, '/delta-test') &&
+       (github.event.comment.body == '/delta-test' ||
+        startsWith(github.event.comment.body, '/delta-test ') ||
+        startsWith(github.event.comment.body, format('/delta-test{0}', fromJSON('"\r"'))) ||
+        startsWith(github.event.comment.body, format('/delta-test{0}', fromJSON('"\n"')))) &&
        github.event.comment.user.login == github.event.issue.user.login)
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -209,6 +209,10 @@ jobs:
       # nothing happen for ~2.5 h.
       - name: Acknowledge the request
         if: ${{ github.event_name == 'issue_comment' }}
+        # Purely informational: this job is what the whole pipeline hangs off, so
+        # a transient API failure here must not fail it and silently skip an
+        # authorised ~2.5 h run.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -60,6 +60,16 @@ on:
       # Negated patterns are evaluated in order and override the positives
       # above, so this must stay last.
       - '!.github/workflows/util/delta-spark-ut/**/*.md'
+  # Escape hatch from the `paths:` filter: comment `/delta-test` on a PR to force
+  # a full run. A Velox/core/native change does not match the filter but can
+  # still break Delta offload, and the nightly is not always soon enough.
+  #
+  # A comment rather than a label, because labelling needs write/triage
+  # permission -- a PR author on a fork, the person who most needs this, cannot
+  # apply one. And an ADDITIONAL `on:` key rather than a change to the trigger
+  # above, so PRs that do not ask for a run still cost zero jobs.
+  issue_comment:
+    types: [created]
   workflow_dispatch:
     inputs:
       delta_ref:
@@ -92,10 +102,23 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+# Unlike `pull_request`, an `issue_comment` run is a base-repo run with a
+# base-repo token, and the jobs below build and execute code from the PR. Nothing
+# here needs write access, so pin the default to read-only.
+permissions:
+  contents: read
+
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   MVN_CMD: 'build/mvn -ntp'
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  # What every job below checks out. Empty on all events except `issue_comment`,
+  # whose run is created against the DEFAULT BRANCH -- so without this a
+  # `/delta-test` comment would test main, not the PR. An empty `ref` is exactly
+  # what actions/checkout does by default, so the other events are unaffected.
+  # The merge ref is what `pull_request` tests too; a conflicted PR has none, and
+  # checkout then fails with a clear git error.
+  DELTA_CHECKOUT_REF: ${{ github.event.issue.number && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
   # Gluten profile / bundle naming for the build-gluten-bundle and
   # delta-spark-test jobs. `spark_version` is the single source of truth for the
   # Spark version: it drives the Gluten bundle profile (-Pspark-<v>), the bundle
@@ -139,19 +162,63 @@ env:
 # Now that this is a standalone workflow (not called by velox_backend_x86.yml),
 # `github.workflow` resolves to THIS workflow, so a concurrency group is both safe
 # and necessary: without it every push to a PR branch stacks another full ~2.5 h
-# Delta run instead of superseding the previous one. Keyed on the branch for PRs
-# and the sha otherwise, matching velox_backend_x86.yml's group.
+# Delta run instead of superseding the previous one. Keyed on the PR number when
+# there is one, so a `pull_request` run and a `/delta-test` run on the same PR
+# supersede each other -- `github.head_ref` is empty on `issue_comment`, which
+# would otherwise lump every commented-on PR into one shared group.
 concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  group: ${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
+  # Gate + acknowledgement for `/delta-test`, and nothing else: the ref to check
+  # out is computed in `env.DELTA_CHECKOUT_REF` above, so this job has no outputs
+  # and the rest of the pipeline just hangs off it via `needs`.
+  #
+  # Every other event passes straight through (the `if` short-circuits), leaving
+  # their behaviour unchanged.
+  #
+  # Kept as its own job so that `pull-requests: write` -- needed to comment back
+  # -- is never granted to a job that builds and runs the PR's code.
+  delta-test-requested:
+    # The PR author (the whole point: a fork author cannot label their own PR,
+    # but can always comment on it) or anyone with write access. `startsWith`,
+    # not `contains`, so quoting the command while discussing it does not spend
+    # ~11 job-hours.
+    if: >-
+      github.event_name != 'issue_comment' ||
+      (github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/delta-test') &&
+       (github.event.comment.user.login == github.event.issue.user.login ||
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)))
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+    steps:
+      # An `issue_comment` run belongs to the default branch, so GitHub cannot
+      # attach it to the PR's Checks tab. Leave a link, or the contributor sees
+      # nothing happen for ~2.5 h.
+      - name: Acknowledge the request
+        if: ${{ github.event_name == 'issue_comment' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          TRIGGER_USER: ${{ github.event.comment.user.login }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+            "🔄 Delta Spark UT started by @${TRIGGER_USER} (~2.5 h). [View run](${RUN_URL})"
+
   build-native-lib-centos-7:
+    needs: delta-test-requested
     # This workflow always builds its own native lib -- there is no caller to
     # provide one, and the `paths:` filter already decided whether the run happens.
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DELTA_CHECKOUT_REF }}
       - name: Get Ccache from Apache Stash
         uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -172,7 +239,15 @@ jobs:
             ccache -s
           "
       - name: Save Ccache to Apache Stash
-        if: always()
+        # A stash is saved as an artifact named `<key>-<github.ref_name>`, and is
+        # restored by matching `head_branch` + `head_repository_id` -- so the
+        # scope is the branch, exactly as with actions/cache. On `issue_comment`
+        # that branch is the DEFAULT BRANCH, not the PR, and these jobs execute
+        # the PR's code; with the save action's `overwrite: true` default a
+        # comment-triggered run would *replace* main's stash, which the nightly
+        # then restores. So comment runs restore but never save. Same for the
+        # Maven and sbt stashes below.
+        if: ${{ always() && github.event_name != 'issue_comment' }}
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: '${{ env.CCACHE_DIR }}'
@@ -190,6 +265,8 @@ jobs:
     container: apache/gluten:centos-9-jdk17
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DELTA_CHECKOUT_REF }}
       - name: Download native artifacts
         uses: actions/download-artifact@v4
         with:
@@ -232,6 +309,8 @@ jobs:
             -Pbackends-velox -Pdelta \
             -DskipTests -Dmaven.compiler.release=17
       - name: Save Maven repository to Apache Stash
+        # Trusted runs only -- see the Save Ccache step above.
+        if: ${{ github.event_name != 'issue_comment' }}
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: /root/.m2/repository
@@ -282,6 +361,8 @@ jobs:
       SHARD_ID: ${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DELTA_CHECKOUT_REF }}
 
       - name: Resolve workflow inputs
         id: resolve
@@ -394,8 +475,9 @@ jobs:
 
       - name: Save sbt / Ivy / Coursier to Apache Stash
         # All shards have the same dependencies; one writer avoids matrix jobs
-        # overwriting the same stash artifact.
-        if: ${{ success() && matrix.shard == 0 }}
+        # overwriting the same stash artifact. Trusted runs only -- see the Save
+        # Ccache step in build-native-lib-centos-7.
+        if: ${{ success() && matrix.shard == 0 && github.event_name != 'issue_comment' }}
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
           path: |
@@ -478,6 +560,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DELTA_CHECKOUT_REF }}
       - name: Download per-shard gate lists
         uses: actions/download-artifact@v4
         continue-on-error: true

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -60,9 +60,9 @@ on:
       # Negated patterns are evaluated in order and override the positives
       # above, so this must stay last.
       - '!.github/workflows/util/delta-spark-ut/**/*.md'
-  # Escape hatch from the `paths:` filter: comment `/delta-test` on a PR to force
-  # a full run. A Velox/core/native change does not match the filter but can
-  # still break Delta offload, and the nightly is not always soon enough.
+  # Escape hatch from the `paths:` filter: the PR author comments `/delta-test`
+  # to force a full run. A Velox/core/native change does not match the filter but
+  # can still break Delta offload, and the nightly is not always soon enough.
   #
   # A comment rather than a label, because labelling needs write/triage
   # permission -- a PR author on a fork, the person who most needs this, cannot
@@ -181,16 +181,25 @@ jobs:
   # Kept as its own job so that `pull-requests: write` -- needed to comment back
   # -- is never granted to a job that builds and runs the PR's code.
   delta-test-requested:
-    # The PR author (the whole point: a fork author cannot label their own PR,
-    # but can always comment on it) or anyone with write access. `startsWith`,
-    # not `contains`, so quoting the command while discussing it does not spend
-    # ~11 job-hours.
+    # Only the PR author may spend a run on their own PR -- which is exactly the
+    # gap this closes: a fork author cannot label their own PR, but can always
+    # comment on it.
+    #
+    # Deliberately NOT an `author_association` allow-list for maintainers: on an
+    # ASF repo write access comes from Gitbox, not from GitHub org/collaborator
+    # membership, so `COLLABORATOR` matches nobody here and all but two of the
+    # Gluten committers report `CONTRIBUTOR` -- an OWNER/MEMBER/COLLABORATOR list
+    # would reject nearly every maintainer while accepting any apache org member.
+    # A maintainer who wants a run on someone else's PR asks the author to
+    # comment.
+    #
+    # `startsWith`, not `contains`, so quoting the command while discussing it
+    # does not spend ~11 job-hours.
     if: >-
       github.event_name != 'issue_comment' ||
       (github.event.issue.pull_request &&
        startsWith(github.event.comment.body, '/delta-test') &&
-       (github.event.comment.user.login == github.event.issue.user.login ||
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)))
+       github.event.comment.user.login == github.event.issue.user.login)
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -105,8 +105,16 @@ on:
 # Unlike `pull_request`, an `issue_comment` run is a base-repo run with a
 # base-repo token, and the jobs below build and execute code from the PR. Nothing
 # here needs write access, so pin the default to read-only.
+#
+# `actions: read` is required, not optional: setting this block at all sets every
+# unlisted scope to `none`, and the Apache Stash restore action reads the caches
+# through the artifacts REST API (`gh api repos/.../actions/artifacts` plus
+# `gh run download`), which 403s without it. The other Stash-using workflows here
+# declare no `permissions:` block and so inherit the repo default, which is why
+# they do not need to say this.
 permissions:
   contents: read
+  actions: read
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -60,15 +60,7 @@ on:
       # Negated patterns are evaluated in order and override the positives
       # above, so this must stay last.
       - '!.github/workflows/util/delta-spark-ut/**/*.md'
-  # Escape hatch from the `paths:` filter: comment `/delta-test` on a PR to force
-  # a full run. A Velox/core/native change does not match the filter but
-  # can still break Delta offload, and the nightly is not always soon enough.
-  #
-  # A comment rather than a label, because labelling needs write/triage
-  # permission -- a PR author on a fork, the person who most needs this, cannot
-  # apply one. Same mechanism as velox_backend_ansi.yml's `/ansi-test`. And an
-  # ADDITIONAL `on:` key rather than a change to the trigger above, so PRs that
-  # do not ask for a run still cost zero jobs.
+  # Force a run skipped by `paths:` without requiring label permissions.
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -103,16 +95,7 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
-# Unlike `pull_request`, an `issue_comment` run is a base-repo run with a
-# base-repo token, and the jobs below build and execute code from the PR. Nothing
-# here needs write access, so pin the default to read-only.
-#
-# `actions: read` is required, not optional: setting this block at all sets every
-# unlisted scope to `none`, and the Apache Stash restore action reads the caches
-# through the artifacts REST API (`gh api repos/.../actions/artifacts` plus
-# `gh run download`), which 403s without it. The other Stash-using workflows here
-# declare no `permissions:` block and so inherit the repo default, which is why
-# they do not need to say this.
+# Comment runs execute PR code; keep the token read-only. Stash needs artifacts access.
 permissions:
   contents: read
   actions: read
@@ -121,12 +104,7 @@ env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   MVN_CMD: 'build/mvn -ntp'
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
-  # What every job below checks out. Empty on all events except `issue_comment`,
-  # whose run is created against the DEFAULT BRANCH -- so without this a
-  # `/delta-test` comment would test main, not the PR. An empty `ref` is exactly
-  # what actions/checkout does by default, so the other events are unaffected.
-  # The merge ref is what `pull_request` tests too; a conflicted PR has none, and
-  # checkout then fails with a clear git error.
+  # `issue_comment` runs on the default branch, so explicitly select the PR merge ref.
   DELTA_CHECKOUT_REF: ${{ github.event.issue.number && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
   # Gluten profile / bundle naming for the build-gluten-bundle and
   # delta-spark-test jobs. `spark_version` is the single source of truth for the
@@ -168,47 +146,14 @@ env:
   # granularity for the split to stay balanced.
   DELTA_NUM_SHARDS: '8'
 
-# Now that this is a standalone workflow (not called by velox_backend_x86.yml),
-# `github.workflow` resolves to THIS workflow, so a concurrency group is both safe
-# and necessary: without it every push to a PR branch stacks another full ~2.5 h
-# Delta run instead of superseding the previous one. Keyed on the PR number when
-# there is one, so a `pull_request` run and a `/delta-test` run on the same PR
-# supersede each other -- `github.head_ref` is empty on `issue_comment`, which
-# would otherwise lump every commented-on PR into one shared group.
+# Cancel older `pull_request` and `/delta-test` runs for the same PR.
 concurrency:
   group: ${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number || github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
-  # Gate + acknowledgement for `/delta-test`, and nothing else: the ref to check
-  # out is computed in `env.DELTA_CHECKOUT_REF` above, so this job has no outputs
-  # and the rest of the pipeline just hangs off it via `needs`.
-  #
-  # Every other event passes straight through (the `if` short-circuits), leaving
-  # their behaviour unchanged.
-  #
-  # Kept as its own job so that `pull-requests: write` -- needed to comment back
-  # -- is never granted to a job that builds and runs the PR's code.
   delta-test-requested:
-    # Anyone may ask for a run, matching velox_backend_ansi.yml's `/ansi-test`
-    # (and take.yml), which are the repo's existing comment triggers and gate on
-    # the command alone. The PR author is the party this exists for -- labelling
-    # a PR needs write/triage, so a fork author cannot opt into their own PR --
-    # but there is no reason to be stricter here than the pipeline next door.
-    #
-    # Note this makes the "restore but never save" cache guards below load
-    # bearing rather than belt-and-braces: any user can now start a run that
-    # builds and executes the PR's code.
-    #
-    # The command must still be the FIRST TOKEN of the comment, so neither
-    # quoting it while discussing it (`/ansi-test` uses `contains`, which does
-    # match a mention mid-sentence) nor a longer command that merely starts the
-    # same way (`/delta-test-arm`, `/delta-testers` -- plain `startsWith` would
-    # match both) can spend ~11 job-hours by accident. GHA expressions have no
-    # regex, so spell out the ways the token can legally end: end-of-body, a
-    # space, or a newline (`fromJSON` is the only way to write a control
-    # character in an expression; GitHub stores comment bodies CRLF, and bare LF
-    # arrives via the API).
+    # Match `/delta-test` as the first token; pass other event types through.
     if: >-
       github.event_name != 'issue_comment' ||
       (github.event.issue.pull_request &&
@@ -220,14 +165,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      # An `issue_comment` run belongs to the default branch, so GitHub cannot
-      # attach it to the PR's Checks tab. Leave a link, or the contributor sees
-      # nothing happen for ~2.5 h.
       - name: Acknowledge the request
         if: ${{ github.event_name == 'issue_comment' }}
-        # Purely informational: this job is what the whole pipeline hangs off, so
-        # a transient API failure here must not fail it and silently skip an
-        # authorised ~2.5 h run.
+        # The informational comment must not block the run.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -268,14 +208,7 @@ jobs:
             ccache -s
           "
       - name: Save Ccache to Apache Stash
-        # A stash is saved as an artifact named `<key>-<github.ref_name>`, and is
-        # restored by matching `head_branch` + `head_repository_id` -- so the
-        # scope is the branch, exactly as with actions/cache. On `issue_comment`
-        # that branch is the DEFAULT BRANCH, not the PR, and these jobs execute
-        # the PR's code; with the save action's `overwrite: true` default a
-        # comment-triggered run would *replace* main's stash, which the nightly
-        # then restores. So comment runs restore but never save. Same for the
-        # Maven and sbt stashes below.
+        # Comment runs use main's Stash scope; never overwrite it with PR output.
         if: ${{ always() && github.event_name != 'issue_comment' }}
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -338,7 +271,6 @@ jobs:
             -Pbackends-velox -Pdelta \
             -DskipTests -Dmaven.compiler.release=17
       - name: Save Maven repository to Apache Stash
-        # Trusted runs only -- see the Save Ccache step above.
         if: ${{ github.event_name != 'issue_comment' }}
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:
@@ -504,8 +436,7 @@ jobs:
 
       - name: Save sbt / Ivy / Coursier to Apache Stash
         # All shards have the same dependencies; one writer avoids matrix jobs
-        # overwriting the same stash artifact. Trusted runs only -- see the Save
-        # Ccache step in build-native-lib-centos-7.
+        # overwriting the same stash artifact.
         if: ${{ success() && matrix.shard == 0 && github.event_name != 'issue_comment' }}
         uses: apache/infrastructure-actions/stash/save@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
         with:

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -60,14 +60,15 @@ on:
       # Negated patterns are evaluated in order and override the positives
       # above, so this must stay last.
       - '!.github/workflows/util/delta-spark-ut/**/*.md'
-  # Escape hatch from the `paths:` filter: the PR author comments `/delta-test`
-  # to force a full run. A Velox/core/native change does not match the filter but
+  # Escape hatch from the `paths:` filter: comment `/delta-test` on a PR to force
+  # a full run. A Velox/core/native change does not match the filter but
   # can still break Delta offload, and the nightly is not always soon enough.
   #
   # A comment rather than a label, because labelling needs write/triage
   # permission -- a PR author on a fork, the person who most needs this, cannot
-  # apply one. And an ADDITIONAL `on:` key rather than a change to the trigger
-  # above, so PRs that do not ask for a run still cost zero jobs.
+  # apply one. Same mechanism as velox_backend_ansi.yml's `/ansi-test`. And an
+  # ADDITIONAL `on:` key rather than a change to the trigger above, so PRs that
+  # do not ask for a run still cost zero jobs.
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -189,44 +190,32 @@ jobs:
   # Kept as its own job so that `pull-requests: write` -- needed to comment back
   # -- is never granted to a job that builds and runs the PR's code.
   delta-test-requested:
-    # Only the PR author may spend a run on their own PR -- which is exactly the
-    # gap this closes: a fork author cannot label their own PR, but can always
-    # comment on it.
+    # Anyone may ask for a run, matching velox_backend_ansi.yml's `/ansi-test`
+    # (and take.yml), which are the repo's existing comment triggers and gate on
+    # the command alone. The PR author is the party this exists for -- labelling
+    # a PR needs write/triage, so a fork author cannot opt their own PR in --
+    # but there is no reason to be stricter here than the pipeline next door.
     #
-    # Deliberately NOT an `author_association` allow-list for maintainers: on an
-    # ASF repo write access comes from Gitbox, not from GitHub org/collaborator
-    # membership, so `COLLABORATOR` matches nobody here and all but two of the
-    # Gluten committers report `CONTRIBUTOR` -- an OWNER/MEMBER/COLLABORATOR list
-    # would reject nearly every maintainer while accepting any apache org member.
+    # Note this makes the "restore but never save" cache guards below load
+    # bearing rather than belt-and-braces: any user can now start a run that
+    # builds and executes the PR's code.
     #
-    # Nor is there a `collaborators/{user}/permission` lookup, which WOULD be
-    # accurate: maintainers do not need one. They can already start this suite
-    # from Actions -> Run workflow (`workflow_dispatch`), which is precisely why
-    # the trigger is author-scoped -- the author is the only party that had no
-    # way in (labelling a PR needs write/triage, so a fork author cannot). A
-    # maintainer who wants a run on someone else's PR uses workflow_dispatch or
-    # asks the author to comment.
-    #
-    # This is stricter than the repo's other comment triggers -- velox_backend_ansi.yml
-    # (`/ansi-test`) and take.yml gate on nothing at all -- which is deliberate,
-    # given a run here costs ~11 job-hours.
-    #
-    # The command must be the FIRST TOKEN of the comment, so neither quoting it
-    # while discussing it (`contains` would match) nor a longer command that
-    # merely starts the same way (`/delta-test-arm`, `/delta-testers` -- plain
-    # `startsWith` would match both) can spend ~11 job-hours. GHA expressions
-    # have no regex, so spell out the four ways the token can legally end:
-    # end-of-body, a space, or a newline (`fromJSON` is the only way to write a
-    # control character in an expression; GitHub stores comment bodies CRLF, and
-    # bare LF arrives via the API).
+    # The command must still be the FIRST TOKEN of the comment, so neither
+    # quoting it while discussing it (`/ansi-test` uses `contains`, which does
+    # match a mention mid-sentence) nor a longer command that merely starts the
+    # same way (`/delta-test-arm`, `/delta-testers` -- plain `startsWith` would
+    # match both) can spend ~11 job-hours by accident. GHA expressions have no
+    # regex, so spell out the ways the token can legally end: end-of-body, a
+    # space, or a newline (`fromJSON` is the only way to write a control
+    # character in an expression; GitHub stores comment bodies CRLF, and bare LF
+    # arrives via the API).
     if: >-
       github.event_name != 'issue_comment' ||
       (github.event.issue.pull_request &&
        (github.event.comment.body == '/delta-test' ||
         startsWith(github.event.comment.body, '/delta-test ') ||
         startsWith(github.event.comment.body, format('/delta-test{0}', fromJSON('"\r"'))) ||
-        startsWith(github.event.comment.body, format('/delta-test{0}', fromJSON('"\n"')))) &&
-       github.event.comment.user.login == github.event.issue.user.login)
+        startsWith(github.event.comment.body, format('/delta-test{0}', fromJSON('"\n"')))))
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -198,8 +198,18 @@ jobs:
     # membership, so `COLLABORATOR` matches nobody here and all but two of the
     # Gluten committers report `CONTRIBUTOR` -- an OWNER/MEMBER/COLLABORATOR list
     # would reject nearly every maintainer while accepting any apache org member.
-    # A maintainer who wants a run on someone else's PR asks the author to
-    # comment.
+    #
+    # Nor is there a `collaborators/{user}/permission` lookup, which WOULD be
+    # accurate: maintainers do not need one. They can already start this suite
+    # from Actions -> Run workflow (`workflow_dispatch`), which is precisely why
+    # the trigger is author-scoped -- the author is the only party that had no
+    # way in (labelling a PR needs write/triage, so a fork author cannot). A
+    # maintainer who wants a run on someone else's PR uses workflow_dispatch or
+    # asks the author to comment.
+    #
+    # This is stricter than the repo's other comment triggers -- velox_backend_ansi.yml
+    # (`/ansi-test`) and take.yml gate on nothing at all -- which is deliberate,
+    # given a run here costs ~11 job-hours.
     #
     # The command must be the FIRST TOKEN of the comment, so neither quoting it
     # while discussing it (`contains` would match) nor a longer command that

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -193,7 +193,7 @@ jobs:
     # Anyone may ask for a run, matching velox_backend_ansi.yml's `/ansi-test`
     # (and take.yml), which are the repo's existing comment triggers and gate on
     # the command alone. The PR author is the party this exists for -- labelling
-    # a PR needs write/triage, so a fork author cannot opt their own PR in --
+    # a PR needs write/triage, so a fork author cannot opt into their own PR --
     # but there is no reason to be stricter here than the pipeline next door.
     #
     # Note this makes the "restore but never save" cache guards below load

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -97,35 +97,18 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   filter before creating the run, so an unrelated PR costs nothing at all.
   Changes to general Velox/core/native code can also affect Delta offload, but
   they're touched on most PRs, so per-PR they skip the suite — the nightly run is
-  the safety net, and `/delta-test` below forces a run on any PR the filter
-  skipped.
+  the safety net.
 - **Nightly** — the **full** suite runs against the latest default branch on a
   `schedule` (05:00 UTC), so regressions from general Velox/core changes are
   still caught daily. The nightly run enforces the baseline **and** fails on
   now-passing tests (`fail_on_fixed=true`), so baseline drift surfaces as a red
   nightly — the signal to refresh `known-failures.txt`.
-- **On demand, from a PR** — comment **`/delta-test`** to
-  force a full run on a PR the `paths:` filter skipped. The command must be the
-  comment's first token — it may be followed by a space or a newline and then
-  any text, but `/delta-test-arm` or `/delta-testers` will *not* match, so a
-  future command that starts the same way cannot fire this one by accident.
-  Anyone can use it, as with `velox_backend_ansi.yml`'s `/ansi-test`; a comment
-  rather than a label because labelling needs write/triage permission, so a fork
-  author — the person who most needs this — cannot opt into their own PR. It runs the
-  PR's merge ref with the default settings and the baseline **enforced**;
-  `update_baseline` stays reachable only from `workflow_dispatch`, so no comment
-  can rewrite the baseline. The workflow replies with a link to the run, because
-  an `issue_comment` run belongs to the default branch and so cannot appear in
-  the PR's Checks tab. Two consequences: `/delta-test` reads the workflow file
-  from the default branch (so it cannot test changes to this pipeline itself —
-  those match the `paths:` filter anyway), and comment-triggered runs **restore
-  but never save** the ccache/Maven/sbt stashes. A stash is stored as an
-  artifact named `<key>-<branch>` and looked up by branch, and for an
-  `issue_comment` run that branch is the **default branch**, not the PR — so a
-  save would overwrite (Stash defaults to `overwrite: true`) a stash that the
-  nightly restores. The ccache key is shared with `velox_backend_x86.yml`, so
-  that would reach beyond this pipeline. Reads are unaffected: a comment run
-  still restores `main`'s stashes, so it is no slower.
+- **On demand, from a PR** — anyone can comment **`/delta-test`** as the first
+  token to run the default configuration against the PR merge ref. This covers
+  PRs skipped by `paths:` without requiring label permissions. The workflow
+  posts the run link on the PR and enforces the committed baseline. Comment runs
+  restore but never save main-scoped Stash caches; use `workflow_dispatch` for
+  custom inputs or baseline updates.
 - **Manually** — **Actions → Delta Spark UT (Gluten) → Run workflow**
   (`workflow_dispatch`), e.g. to refresh the baseline (see below). This is also
   how you validate a Velox/core change against Delta before merging: run it on

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -116,8 +116,13 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   the PR's Checks tab. Two consequences: `/delta-test` reads the workflow file
   from the default branch (so it cannot test changes to this pipeline itself —
   those match the `paths:` filter anyway), and comment-triggered runs **restore
-  but never save** the ccache/Maven/sbt caches, since their cache scope is the
-  default branch and they execute the PR's code.
+  but never save** the ccache/Maven/sbt stashes. A stash is stored as an
+  artifact named `<key>-<branch>` and looked up by branch, and for an
+  `issue_comment` run that branch is the **default branch**, not the PR — so a
+  save would overwrite (Stash defaults to `overwrite: true`) a stash that the
+  nightly restores. The ccache key is shared with `velox_backend_x86.yml`, so
+  that would reach beyond this pipeline. Reads are unaffected: a comment run
+  still restores `main`'s stashes, so it is no slower.
 - **Manually** — **Actions → Delta Spark UT (Gluten) → Run workflow**
   (`workflow_dispatch`), e.g. to refresh the baseline (see below). This is also
   how you validate a Velox/core change against Delta before merging: run it on

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -111,7 +111,7 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   future command that starts the same way cannot fire this one by accident.
   Anyone can use it, as with `velox_backend_ansi.yml`'s `/ansi-test`; a comment
   rather than a label because labelling needs write/triage permission, so a fork
-  author — the person who most needs this — cannot opt their own PR in. It runs the
+  author — the person who most needs this — cannot opt into their own PR. It runs the
   PR's merge ref with the default settings and the baseline **enforced**;
   `update_baseline` stays reachable only from `workflow_dispatch`, so no comment
   can rewrite the baseline. The workflow replies with a link to the run, because

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -104,16 +104,14 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   still caught daily. The nightly run enforces the baseline **and** fails on
   now-passing tests (`fail_on_fixed=true`), so baseline drift surfaces as a red
   nightly — the signal to refresh `known-failures.txt`.
-- **On demand, from a PR** — the **PR author** comments **`/delta-test`** to
+- **On demand, from a PR** — comment **`/delta-test`** to
   force a full run on a PR the `paths:` filter skipped. The command must be the
   comment's first token — it may be followed by a space or a newline and then
   any text, but `/delta-test-arm` or `/delta-testers` will *not* match, so a
   future command that starts the same way cannot fire this one by accident.
-  Restricted to the author, who is the one this exists for: a fork
-  author cannot label their own PR, but can always comment on it, whereas a
-  maintainer can already start the suite from **Run workflow**
-  (`workflow_dispatch`). A maintainer who wants a run on someone else's PR uses
-  that, or asks the author to comment. It runs the
+  Anyone can use it, as with `velox_backend_ansi.yml`'s `/ansi-test`; a comment
+  rather than a label because labelling needs write/triage permission, so a fork
+  author — the person who most needs this — cannot opt their own PR in. It runs the
   PR's merge ref with the default settings and the baseline **enforced**;
   `update_baseline` stays reachable only from `workflow_dispatch`, so no comment
   can rewrite the baseline. The workflow replies with a link to the run, because

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -110,8 +110,10 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   any text, but `/delta-test-arm` or `/delta-testers` will *not* match, so a
   future command that starts the same way cannot fire this one by accident.
   Restricted to the author, who is the one this exists for: a fork
-  author cannot label their own PR, but can always comment on it. A maintainer
-  who wants a run on someone else's PR asks the author to comment. It runs the
+  author cannot label their own PR, but can always comment on it, whereas a
+  maintainer can already start the suite from **Run workflow**
+  (`workflow_dispatch`). A maintainer who wants a run on someone else's PR uses
+  that, or asks the author to comment. It runs the
   PR's merge ref with the default settings and the baseline **enforced**;
   `update_baseline` stays reachable only from `workflow_dispatch`, so no comment
   can rewrite the baseline. The workflow replies with a link to the run, because

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -97,12 +97,26 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   filter before creating the run, so an unrelated PR costs nothing at all.
   Changes to general Velox/core/native code can also affect Delta offload, but
   they're touched on most PRs, so per-PR they skip the suite — the nightly run is
-  the safety net.
+  the safety net, and `/delta-test` below forces a run on any PR the filter
+  skipped.
 - **Nightly** — the **full** suite runs against the latest default branch on a
   `schedule` (05:00 UTC), so regressions from general Velox/core changes are
   still caught daily. The nightly run enforces the baseline **and** fails on
   now-passing tests (`fail_on_fixed=true`), so baseline drift surfaces as a red
   nightly — the signal to refresh `known-failures.txt`.
+- **On demand, from a PR** — comment **`/delta-test`** (as the first thing in the
+  comment) to force a full run on a PR the `paths:` filter skipped. The **PR
+  author** — including from a fork, which is why this is a comment and not a
+  label — or anyone with write access can use it. It runs the PR's merge ref with
+  the default settings and the baseline **enforced**; `update_baseline` stays
+  reachable only from `workflow_dispatch`, so no comment can rewrite the
+  baseline. The workflow replies with a link to the run, because an
+  `issue_comment` run belongs to the default branch and so cannot appear in the
+  PR's Checks tab. Two consequences: `/delta-test` reads the workflow file from
+  the default branch (so it cannot test changes to this pipeline itself — those
+  match the `paths:` filter anyway), and comment-triggered runs **restore but
+  never save** the ccache/Maven/sbt caches, since their cache scope is the
+  default branch and they execute the PR's code.
 - **Manually** — **Actions → Delta Spark UT (Gluten) → Run workflow**
   (`workflow_dispatch`), e.g. to refresh the baseline (see below). This is also
   how you validate a Velox/core change against Delta before merging: run it on

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -104,9 +104,12 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   still caught daily. The nightly run enforces the baseline **and** fails on
   now-passing tests (`fail_on_fixed=true`), so baseline drift surfaces as a red
   nightly — the signal to refresh `known-failures.txt`.
-- **On demand, from a PR** — the **PR author** comments **`/delta-test`** (as the
-  first thing in the comment) to force a full run on a PR the `paths:` filter
-  skipped. Restricted to the author, who is the one this exists for: a fork
+- **On demand, from a PR** — the **PR author** comments **`/delta-test`** to
+  force a full run on a PR the `paths:` filter skipped. The command must be the
+  comment's first token — it may be followed by a space or a newline and then
+  any text, but `/delta-test-arm` or `/delta-testers` will *not* match, so a
+  future command that starts the same way cannot fire this one by accident.
+  Restricted to the author, who is the one this exists for: a fork
   author cannot label their own PR, but can always comment on it. A maintainer
   who wants a run on someone else's PR asks the author to comment. It runs the
   PR's merge ref with the default settings and the baseline **enforced**;

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -104,18 +104,19 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   still caught daily. The nightly run enforces the baseline **and** fails on
   now-passing tests (`fail_on_fixed=true`), so baseline drift surfaces as a red
   nightly — the signal to refresh `known-failures.txt`.
-- **On demand, from a PR** — comment **`/delta-test`** (as the first thing in the
-  comment) to force a full run on a PR the `paths:` filter skipped. The **PR
-  author** — including from a fork, which is why this is a comment and not a
-  label — or anyone with write access can use it. It runs the PR's merge ref with
-  the default settings and the baseline **enforced**; `update_baseline` stays
-  reachable only from `workflow_dispatch`, so no comment can rewrite the
-  baseline. The workflow replies with a link to the run, because an
-  `issue_comment` run belongs to the default branch and so cannot appear in the
-  PR's Checks tab. Two consequences: `/delta-test` reads the workflow file from
-  the default branch (so it cannot test changes to this pipeline itself — those
-  match the `paths:` filter anyway), and comment-triggered runs **restore but
-  never save** the ccache/Maven/sbt caches, since their cache scope is the
+- **On demand, from a PR** — the **PR author** comments **`/delta-test`** (as the
+  first thing in the comment) to force a full run on a PR the `paths:` filter
+  skipped. Restricted to the author, who is the one this exists for: a fork
+  author cannot label their own PR, but can always comment on it. A maintainer
+  who wants a run on someone else's PR asks the author to comment. It runs the
+  PR's merge ref with the default settings and the baseline **enforced**;
+  `update_baseline` stays reachable only from `workflow_dispatch`, so no comment
+  can rewrite the baseline. The workflow replies with a link to the run, because
+  an `issue_comment` run belongs to the default branch and so cannot appear in
+  the PR's Checks tab. Two consequences: `/delta-test` reads the workflow file
+  from the default branch (so it cannot test changes to this pipeline itself —
+  those match the `paths:` filter anyway), and comment-triggered runs **restore
+  but never save** the ccache/Maven/sbt caches, since their cache scope is the
   default branch and they execute the PR's code.
 - **Manually** — **Actions → Delta Spark UT (Gluten) → Run workflow**
   (`workflow_dispatch`), e.g. to refresh the baseline (see below). This is also


### PR DESCRIPTION
Part of #12743.

## What changes are proposed in this pull request?

The Delta Spark UT pipeline added in #12388 runs per-PR only when its `paths:` filter matches (`gluten-delta/**`, `backends-velox/src-delta*/**`, and the pipeline's own files). A change to general Velox/core/native code does not match that filter but can still break Delta offload, and today there is no way for a contributor to force a run — `workflow_dispatch` needs write access to this repo, and the nightly is not always soon enough.

#12743 lists a `run-delta-ci` **label** as the candidate. That does not work for the people who need it most: changing labels requires write/triage permission, so a PR author working from a fork cannot opt their own PR in. A label also cannot be expressed as a `paths:` filter, so it would need a gate job running `git diff` on *every* PR.

This PR adds a **`/delta-test` PR comment** instead — the same mechanism `velox_backend_ansi.yml` already uses for `/ansi-test`:

- **Anyone can comment**, so a fork author can trigger the suite on their own PR — which is the whole point, since labelling needs write/triage permission and a fork author has neither. The gate is the **command alone**, matching the repo's existing comment triggers (`velox_backend_ansi.yml`'s `/ansi-test` and `take.yml`), so a reviewer can also run it against someone else's PR. No `author_association` check: it does not track write access on an ASF repo (write comes from Gitbox), so an `OWNER/MEMBER/COLLABORATOR` allow-list would reject 16 of the 18 `apache/gluten` maintainers sampled while accepting any `apache` org member.
- It is an **additional `on:` key**, not a change to the `pull_request` trigger, so the `paths:` filter is untouched and PRs that don't ask for a run still cost **zero jobs** — no per-PR gate job.
- `startsWith`, not `contains`, so quoting the command while discussing it doesn't spend ~11 job-hours.

### How it works

An `issue_comment` run is created against the **default branch**, so `github.ref` points at `main`, not the PR. One workflow-level `env` resolves what to check out:

```yaml
DELTA_CHECKOUT_REF: ${{ github.event.issue.number && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
```

Every job then checks out `ref: ${{ env.DELTA_CHECKOUT_REF }}`. It is **empty on every other event**, which is exactly what `actions/checkout` does by default, so `pull_request`, `schedule` and `workflow_dispatch` behave precisely as before. Using the PR's merge ref (what `pull_request` itself tests) avoids any API call, job outputs or SHA plumbing.

A small `delta-test-requested` job holds the authorisation `if:` and posts a link to the run — an `issue_comment` run belongs to the default branch, so GitHub cannot attach it to the PR's Checks tab, and without the link the contributor sees nothing happen for ~2.5 h. It is a separate job so that `pull-requests: write` is never granted to a job that builds and runs the PR's code. Everything else hangs off it via `needs`, so a comment that isn't authorised skips the whole pipeline.

`update_baseline` stays reachable only from `workflow_dispatch`, so **no comment can rewrite the committed baseline**.

### Cache scoping (why the cache steps changed)

A cache write is scoped to the run's `GITHUB_REF`. For `pull_request` that is `refs/pull/N/merge`, isolated to the PR — but for `issue_comment` it is the **default branch**, shared with every trusted run. Since these jobs compile and execute the PR's code, saving there would let a PR plant a ccache/Maven/sbt entry that the nightly on `main` later restores (the prefixed `restore-keys` make it reachable), i.e. attacker-controlled compiler output in a trusted build.

So the three caches are split into restore + save, and comment-triggered runs **restore but never save**. They still read the shared caches, so they are no slower; they just don't contribute back. Workflow permissions are additionally pinned to `contents: read`.

### Files

| File | Change |
|---|---|
| `.github/workflows/delta_spark_ut.yml` | `issue_comment` trigger, `DELTA_CHECKOUT_REF`, `delta-test-requested` gate job, `ref:` on the 4 checkouts, cache restore/save split, `permissions`, PR-number concurrency key. |
| `.github/workflows/util/delta-spark-ut/README.md` | Documents `/delta-test` under "When it runs". |

58 functional lines (the rest of the diff is comments and docs).

## How was this patch tested?

This change *is* CI, and the trigger can only be exercised once the workflow is on the default branch. Verified statically instead:

- **actionlint** clean on `delta_spark_ut.yml`.
- **Trigger truth table**, 12 cases: `pull_request` / `schedule` / `workflow_dispatch` all pass through; a comment on an issue (not a PR), the command quoted mid-sentence, a longer command (`/delta-test-arm`, `/delta-testers`), and ordinary PR chatter are all rejected; `/delta-test` is accepted from any user, bare, with trailing text, or as the first line of a multi-line comment (CRLF and LF).
- **`DELTA_CHECKOUT_REF`** resolves to `''` on `pull_request` / `schedule` / `workflow_dispatch` and to `refs/pull/N/merge` on `issue_comment`; confirmed against `actions/checkout`'s source that an empty `ref` reproduces its default (`github.context.ref` + `github.context.sha`), so existing events are unaffected.
- **Skip propagation**: with the gate skipped, all five downstream jobs skip (verified against each job's existing `if:`).
- **Cache read/write split** asserted programmatically: every `save` is gated on `issue_comment`, every `restore` is not.
- **No untrusted data** (`github.event.comment.*` / `github.event.issue.*`) is interpolated into any `run:` block; it is passed via `env:` only.
- Confirmed `actions/checkout`'s `assertSafePrCheckout` guard only fires on `pull_request_target` / `workflow_run`, so `issue_comment` needs no `allow-unsafe-pr-checkout`.

Once merged, `/delta-test` on any PR is the end-to-end test.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI


