### PR TITLE
[GLUTEN-12377][VL][DO NOT MERGE] Run the Delta suite with Velox operator output validation

### DIFF
--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
@@ -55,6 +55,19 @@ trait DeltaSQLCommandTest extends SharedSparkSession {
       .set(VeloxDeltaConfig.ENABLE_NATIVE_WRITE.key, "true")
       .set("spark.databricks.delta.snapshotPartitions", "2")
       .set("spark.gluten.sql.fallbackUnexpectedMetadataParquet", "true")
+      // Validate every operator's output vector. A Delta deletion-vector write scans only
+      // synthesized columns with a pushed-down filter, and on that path Velox emits a
+      // RowVector whose row-index child has no rows; the child is then wrapped in a
+      // dictionary, and reading it goes out of bounds and yields arbitrary heap values.
+      // Without this the failure is intermittent and reports a meaningless row index, which
+      // is how it went unnoticed for so long. With it, the scan is caught the moment it
+      // produces the malformed vector, so the suite fails deterministically and names the
+      // operator responsible.
+      //   Velox issue: https://github.com/facebookincubator/velox/issues/18535
+      //   Velox fix:   https://github.com/facebookincubator/velox/pull/18536
+      // Remove this once that fix is picked up, at which point the suite must go green
+      // again -- which is what validates the fix.
+      .set("spark.gluten.sql.columnar.backend.velox.validateOutputFromOperators", "true")
   }
 }
 // spotless:on

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -525,6 +525,8 @@ void WholeStageResultIterator::collectMetrics() {
 std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryContextConf() {
   std::unordered_map<std::string, std::string> configs = {};
   // Find batch size from Spark confs. If found, set the preferred and max batch size.
+  configs[velox::core::QueryConfig::kValidateOutputFromOperators] =
+      veloxCfg_->get<bool>(kValidateOutputFromOperators, kValidateOutputFromOperatorsDefault) ? "true" : "false";
   configs[velox::core::QueryConfig::kPreferredOutputBatchRows] =
       std::to_string(veloxCfg_->get<uint32_t>(kSparkBatchSize, 4096));
   configs[velox::core::QueryConfig::kMaxOutputBatchRows] =

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -107,6 +107,14 @@ const std::string kValueStreamDynamicFilterEnabled =
     "spark.gluten.sql.columnar.backend.velox.valueStream.dynamicFilter.enabled";
 const bool kValueStreamDynamicFilterEnabledDefault = false;
 
+/// Turns on Velox's per-operator output vector validation
+/// (`debug.validate_output_from_operators`). Every operator's output is checked for
+/// structural consistency -- among other things that a dictionary's indexes address rows its
+/// base vector actually has -- and the first operator to emit a malformed vector is named.
+/// Debugging aid only: it costs a pass over every output batch, so it is off by default.
+const std::string kValidateOutputFromOperators = "spark.gluten.sql.columnar.backend.velox.validateOutputFromOperators";
+const bool kValidateOutputFromOperatorsDefault = false;
+
 const std::string kShowTaskMetricsWhenFinished = "spark.gluten.sql.columnar.backend.velox.showTaskMetricsWhenFinished";
 const bool kShowTaskMetricsWhenFinishedDefault = false;
 


### PR DESCRIPTION
## What this does

Exposes Velox's `debug.validate_output_from_operators` as a Gluten config and turns it on for the Delta Spark UT.

## Why

The DV bitmap row-index failures in #12377 are intermittent and report a meaningless value. The reason is that by the time anything notices, the damage is an out-of-bounds read: a Delta deletion-vector write scans only synthesized columns with a pushed-down filter, and on that path Velox emits a `RowVector` whose row-index child has **no rows**. That empty child is then wrapped in a dictionary, and reading it returns whatever heap memory follows. Whether that memory happens to land outside Delta's valid range decides whether the query aborts or silently accepts a wrong row index — which is why the failure moved from test to test and the reported value differed every time (`9223372036854775807`, `-1`, `0xe43315c000007f00`, ...).

Velox can catch this at the source instead. The validation checks every operator's output for structural consistency — among other things, that a dictionary's indexes address rows its base vector actually has — and names the first operator to emit a malformed vector.

## Companion PR

#12808 is this change plus one line pointing `UPSTREAM_VELOX_PR_ID` at the upstream fix, branched from the same commit on `main`. It is expected to be **green**. Red here and green there is the before/after evidence.

## Expected result

**This PR is expected to make the Delta suite fail**, and that is the point. It should fail deterministically, naming the responsible operator:

```
Output validation failed for [operator: TableScan, plan node ID: 0]:
  Child vector has size 0 less than parent and parent has no nulls 10.
```

instead of intermittently with an arbitrary row index.

Once the upstream fix is picked up — via a Velox bump, or `UPSTREAM_VELOX_PR_ID` in `ep/build-velox/src/get-velox.sh` — the suite must go green again, which is what validates the fix.

* Velox issue: https://github.com/facebookincubator/velox/issues/18535
* Velox fix: https://github.com/facebookincubator/velox/pull/18536

## Verification

This repo pins `VELOX_BRANCH=dft-2026_08_17`, in which the defect is confirmed still present: `SelectiveStructColumnReaderBase::next()` still passes `outputRows()` to `setRowNumberField()`, and `useOutputRows()` is still `scanSpec_->hasFilter() || hasDeletion()`. The fix from velox#18536 also applies cleanly to that revision, which is what #12808 relies on.

The evidence is this PR against #12808, which is identical to it except for one line that applies velox#18536 — same base commit, same pinned Velox, so the fix is the only variable.

From the first pair of runs:

| Delta suite run | shards failed | `Output validation failed` | regressions |
|---|---|---|---|
| this PR (defect present) | 7 of 8 | present | — |
| #12808 (+ velox#18536) | 2 of 8 | **0** | **0** |

Both of #12808's two failing shards reported `Regressions (new failures): 0` and failed only because `FAIL_ON_FIXED=true` and two `ImplicitStreamingMergeCastingSuite` baseline entries now pass — unrelated to this change, caused by the cast-mode fix in #12051. Both PRs now carry the cherry-pick that removes those stale entries, and a fresh pair of runs is in flight.

So with the Velox fix applied, every failure attributable to this defect disappears across the whole Delta suite, and no unrelated invariant violations surface — which also answers whether enabling validation suite-wide is safe.

Separately, the same suite with deletion vectors but **predicate pushdown off** (`...DVsPredPushOffSuite`) shows no violation at all, consistent with the upstream analysis: the defect needs a filter on the scan.

## How do we know this is the same defect as #12377, and not a different one?

The error text differs — validation reports `Child vector has size 0 less than parent`, while #12377 reports a bad row index — so it is worth stating why they are the same defect:

* **The original failure's own diagnostic showed this exact vector.** A capture of `Delta bitmap row index cannot be negative: -5163232936757035008` carried `encoding=DICTIONARY size=1 baseSize=0 valuesBytes=0 baseIndex=0`: the aggregator was reading a dictionary indexing into an empty base. Same column, same `TableScan[0]` -> `PartialAggregation[9]` plan.
* **The differing message is expected.** Instrumenting the malformed read rather than the value showed ~176 out-of-bounds reads per suite pass, against roughly one crash per 25 passes. The old message only fires when the out-of-bounds read lands outside Delta's range; pointer-shaped values (~1.4e14) are positive and inside it, so they were accepted silently. Validation catches the cause every time and upstream of the symptom.
* **Same trigger.** Both occur only with predicate pushdown on, and neither occurs with it off.
* **The fix removes both, and not by masking.** `flaky-error-patterns.txt` quarantines the original error, so "0 regressions" alone would not settle this. In #12808's run the sampled shards report `Quarantined flaky failures (ignored) | 0` together with zero occurrences of the original bitmap error — it did not happen, rather than happening and being hidden.

## Scope

The config defaults to off, so nothing outside the Delta suite changes.

Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI (Claude Opus 5)
