### PR TITLE
[GLUTEN-12790][CORE] Give memory target names one sequence instead of a counter per name

### DIFF
--- a/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargetUtil.java
+++ b/gluten-core/src/main/java/org/apache/gluten/memory/memtarget/MemoryTargetUtil.java
@@ -16,19 +16,28 @@
  */
 package org.apache.gluten.memory.memtarget;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class MemoryTargetUtil {
   private MemoryTargetUtil() {}
 
-  private static final Map<String, Integer> UNIQUE_NAME_LOOKUP = new ConcurrentHashMap<>();
+  // One sequence shared by every name. The suffix only has to make the name unique, since
+  // TreeMemoryConsumer#newChild keys siblings by name and rejects a collision, and a shared
+  // sequence does that while holding no per-name state. Callers pass names that are not drawn from
+  // a fixed set, so a counter per name accumulated an entry per distinct name for the lifetime of
+  // the JVM.
+  private static final AtomicLong SEQUENCE = new AtomicLong(0L);
 
   public static String toUniqueName(String name) {
-    int nextId =
-        UNIQUE_NAME_LOOKUP.compute(
-            name, (s, integer) -> Optional.ofNullable(integer).map(id -> id + 1).orElse(0));
-    return String.format("%s.%d", name, nextId);
+    return name + "." + SEQUENCE.getAndIncrement();
+  }
+
+  // Lets a test assert that naming holds no state beyond this counter. Not for production use;
+  // @VisibleForTesting flags any accidental same-package caller.
+  @VisibleForTesting
+  static long sequenceForTesting() {
+    return SEQUENCE.get();
   }
 }

--- a/gluten-core/src/test/java/org/apache/gluten/memory/memtarget/MemoryTargetUtilTest.java
+++ b/gluten-core/src/test/java/org/apache/gluten/memory/memtarget/MemoryTargetUtilTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.memory.memtarget;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class MemoryTargetUtilTest {
+
+  /** The counter is JVM-global and shared with the rest of the suite, so only compare suffixes. */
+  private static long suffixOf(String uniqueName) {
+    final int dot = uniqueName.lastIndexOf('.');
+    Assert.assertTrue("Name carries no suffix: " + uniqueName, dot > 0);
+    return Long.parseLong(uniqueName.substring(dot + 1));
+  }
+
+  @Test
+  public void testNamingHoldsNoPerNameState() {
+    // This is the property the fix exists for. Counters kept per name meant one entry per distinct
+    // name for the lifetime of the JVM, and callers do not draw names from a fixed set, so the
+    // registry grew without bound. Asserting on the suffixes alone would not catch a registry that
+    // stores an entry per name and takes the suffix from a shared counter, so check that the
+    // sequence is the only state the class keeps, and that it accounts for every call.
+    for (Field f : MemoryTargetUtil.class.getDeclaredFields()) {
+      Assert.assertFalse(
+          "Naming should hold no per-name state, found "
+              + f.getType().getName()
+              + " "
+              + f.getName(),
+          Map.class.isAssignableFrom(f.getType())
+              || Collection.class.isAssignableFrom(f.getType()));
+    }
+
+    final long before = MemoryTargetUtil.sequenceForTesting();
+    MemoryTargetUtil.toUniqueName("Foo");
+    MemoryTargetUtil.toUniqueName("Bar");
+    MemoryTargetUtil.toUniqueName("Foo");
+    Assert.assertEquals(
+        "Every call should consume one number from the shared sequence",
+        3L,
+        MemoryTargetUtil.sequenceForTesting() - before);
+  }
+
+  @Test
+  public void testSuffixesComeFromOneSequenceRatherThanPerNameCounters() {
+    final long first = suffixOf(MemoryTargetUtil.toUniqueName("Foo"));
+    final long second = suffixOf(MemoryTargetUtil.toUniqueName("Bar"));
+    final long third = suffixOf(MemoryTargetUtil.toUniqueName("Foo"));
+
+    Assert.assertTrue(
+        "Suffix did not advance across names: " + first + ", " + second, second > first);
+    Assert.assertTrue(
+        "Suffix did not advance across names: " + second + ", " + third, third > second);
+  }
+
+  @Test
+  public void testRepeatedNamesStayDistinct() {
+    // Sibling memory targets are keyed by name in TreeMemoryConsumer#newChild, which throws on a
+    // collision, so two calls with the same input must never produce the same output.
+    final String one = MemoryTargetUtil.toUniqueName("Gluten.Tree");
+    final String two = MemoryTargetUtil.toUniqueName("Gluten.Tree");
+    Assert.assertNotEquals(one, two);
+    Assert.assertTrue(one.startsWith("Gluten.Tree."));
+    Assert.assertTrue(two.startsWith("Gluten.Tree."));
+  }
+
+  @Test
+  public void testConcurrentCallsAreAllDistinct() throws Exception {
+    final int threads = 8;
+    final int perThread = 500;
+    final ExecutorService executor = Executors.newFixedThreadPool(threads);
+    try {
+      final List<Future<Set<String>>> futures = new ArrayList<>();
+      for (int t = 0; t < threads; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  final Set<String> local = new HashSet<>();
+                  for (int i = 0; i < perThread; i++) {
+                    local.add(MemoryTargetUtil.toUniqueName("Concurrent"));
+                  }
+                  return local;
+                }));
+      }
+      final Set<String> names = new HashSet<>();
+      for (Future<Set<String>> f : futures) {
+        final Set<String> local = f.get(30, TimeUnit.SECONDS);
+        Assert.assertEquals("A thread saw a duplicate name", perThread, local.size());
+        names.addAll(local);
+      }
+      Assert.assertEquals("Two threads got the same name", threads * perThread, names.size());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MemoryTargetUtil.toUniqueName` kept a `ConcurrentHashMap` from name to counter and never evicted from it, so the map grew for as long as the JVM lived. That would be bounded if names came from a fixed set, but they do not: `NativePlanEvaluator.create` derives its runtime name from a JVM-global `AtomicInteger`, and that name reaches `toUniqueName` through `Runtimes.contextInstance`, `NativeMemoryManager`, `ReservationListeners`, and `TreeMemoryConsumer.Node`'s constructor. Each such name appears exactly once, so its entry is written, never read again, and never removed.

Both sides accumulate. On an executor it is one entry per whole-stage transformer per task, from `VeloxIteratorApi`. On the driver it is one per native validation, since `VeloxValidatorApi#doNativeValidateWithFailureReason` and `#doNativeValidateExpression` each build an evaluator inside `TaskResources.runUnsafe` while planning; a long-lived driver such as a Thrift server validates candidate operators for every query, so it accumulates faster per unit time than an executor and releases nothing between queries.

This uses a single `AtomicLong` for all names. The suffix only has to make the name unique, because `TreeMemoryConsumer#newChild` keys siblings by name and throws on a collision, and a shared sequence does that with no per-name state. The `long` also replaces an `Integer` that would wrap after 2^31 targets on the fixed names such as `Gluten.Tree`.

Suffixes are no longer dense per name. The names that change most are the high-cardinality ones that leaked: each appeared once, so its suffix was always `.0`, and `NativePlanEvaluator-7.0` now reads something like `NativePlanEvaluator-7.913`. The fixed names were already climbing JVM-globally, `Gluten.Tree` once per task, so only their scale changes. Nothing depends on the number: it is a label for `SparkMemoryUtil`'s stats map and pretty printer, it is not parsed anywhere in the repo, `memory.proto` carries no name field, and it never crosses JNI, where only `backendName` is passed.

A bounded or weak cache would be worse than either: evicting a live target's entry lets the counter restart and hand a second sibling the same name, turning `newChild`'s collision check from unreachable code into a task failure.

### How was this patch tested?

New `MemoryTargetUtilTest` with four tests. The load-bearing one is `testNamingHoldsNoPerNameState`: it reflects over the class's declared fields and asserts none is a `Map` or `Collection`, then asserts three calls consume exactly three numbers from the shared sequence. Both halves are needed. Asserting only on the suffixes would pass for an implementation that keeps an entry per name and takes the number from a shared counter, which is to say it would pass while still leaking. A `@VisibleForTesting sequenceForTesting()` supports the second half, following the same pattern already used for static state in `DynamicOffHeapSizingMemoryTarget`.

The other three tests cover suffixes advancing across different names, repeated names staying distinct (the property `newChild` depends on), and 8 threads x 500 names all distinct.

Each assertion was checked against a mutant, restoring the source after every run:

| mutant | caught by |
| --- | --- |
| keep the per-name map, take the suffix from the shared sequence (still leaks, no visible symptom) | `Naming should hold no per-name state, found java.util.Map LOOKUP` |
| the original per-name counter | the same assertion, plus `Suffix did not advance across names: 0, 0` |

`mvn -Pspark-3.5 -pl gluten-core test` gives 55 tests passing. Cross-version `test-compile` passes on spark-3.3, spark-3.4, spark-4.0 with scala-2.13, and spark-4.1 with scala-2.13.

One scope note: `RegularMemoryConsumer` calls `toUniqueName` with an externally supplied name, which is the pattern that made the growth unbounded. It has no production construction site today, and after this change an external name is no longer a hazard anyway, since there is no per-name state left to accumulate. Removing the dead class is a separate concern.

### Was this patch authored or co-authored using generative AI tooling?

No

Closes #12790
