### PR TITLE
[DO NOT MERGE] Same as #12783, plus the upstream Velox fix (expected green)

### DIFF
--- a/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
+++ b/backends-velox/src-delta40/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
@@ -55,6 +55,19 @@ trait DeltaSQLCommandTest extends SharedSparkSession {
       .set(VeloxDeltaConfig.ENABLE_NATIVE_WRITE.key, "true")
       .set("spark.databricks.delta.snapshotPartitions", "2")
       .set("spark.gluten.sql.fallbackUnexpectedMetadataParquet", "true")
+      // Validate every operator's output vector. A Delta deletion-vector write scans only
+      // synthesized columns with a pushed-down filter, and on that path Velox emits a
+      // RowVector whose row-index child has no rows; the child is then wrapped in a
+      // dictionary, and reading it goes out of bounds and yields arbitrary heap values.
+      // Without this the failure is intermittent and reports a meaningless row index, which
+      // is how it went unnoticed for so long. With it, the scan is caught the moment it
+      // produces the malformed vector, so the suite fails deterministically and names the
+      // operator responsible.
+      //   Velox issue: https://github.com/facebookincubator/velox/issues/18535
+      //   Velox fix:   https://github.com/facebookincubator/velox/pull/18536
+      // Remove this once that fix is picked up, at which point the suite must go green
+      // again -- which is what validates the fix.
+      .set("spark.gluten.sql.columnar.backend.velox.validateOutputFromOperators", "true")
   }
 }
 // spotless:on

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -525,6 +525,8 @@ void WholeStageResultIterator::collectMetrics() {
 std::unordered_map<std::string, std::string> WholeStageResultIterator::getQueryContextConf() {
   std::unordered_map<std::string, std::string> configs = {};
   // Find batch size from Spark confs. If found, set the preferred and max batch size.
+  configs[velox::core::QueryConfig::kValidateOutputFromOperators] =
+      veloxCfg_->get<bool>(kValidateOutputFromOperators, kValidateOutputFromOperatorsDefault) ? "true" : "false";
   configs[velox::core::QueryConfig::kPreferredOutputBatchRows] =
       std::to_string(veloxCfg_->get<uint32_t>(kSparkBatchSize, 4096));
   configs[velox::core::QueryConfig::kMaxOutputBatchRows] =

--- a/cpp/velox/config/VeloxConfig.h
+++ b/cpp/velox/config/VeloxConfig.h
@@ -107,6 +107,14 @@ const std::string kValueStreamDynamicFilterEnabled =
     "spark.gluten.sql.columnar.backend.velox.valueStream.dynamicFilter.enabled";
 const bool kValueStreamDynamicFilterEnabledDefault = false;
 
+/// Turns on Velox's per-operator output vector validation
+/// (`debug.validate_output_from_operators`). Every operator's output is checked for
+/// structural consistency -- among other things that a dictionary's indexes address rows its
+/// base vector actually has -- and the first operator to emit a malformed vector is named.
+/// Debugging aid only: it costs a pass over every output batch, so it is off by default.
+const std::string kValidateOutputFromOperators = "spark.gluten.sql.columnar.backend.velox.validateOutputFromOperators";
+const bool kValidateOutputFromOperatorsDefault = false;
+
 const std::string kShowTaskMetricsWhenFinished = "spark.gluten.sql.columnar.backend.velox.showTaskMetricsWhenFinished";
 const bool kShowTaskMetricsWhenFinishedDefault = false;
 

--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -25,7 +25,13 @@ RUN_SETUP_SCRIPT=ON
 ENABLE_ENHANCED_FEATURES=OFF
 
 # Developer use only for testing Velox PR.
-UPSTREAM_VELOX_PR_ID=""
+# TEMPORARY -- DO NOT MERGE. Pulls in the upstream fix for the defect that this
+# branch's Delta suite run is designed to expose, so that the same run goes
+# green:
+#   https://github.com/facebookincubator/velox/pull/18536
+# apache/gluten#12783 is this change without this line, and is expected to be
+# red. The pair is the before/after evidence for apache/gluten#12377.
+UPSTREAM_VELOX_PR_ID="18536"
 
 OS=`uname -s`
 


### PR DESCRIPTION
> **Do not merge.** This pins the native build to an unmerged upstream pull request. It exists to produce a CI result, not to land.

## What this is

This is #12783 plus **one line**: it sets `UPSTREAM_VELOX_PR_ID="18536"` in `ep/build-velox/src/get-velox.sh`, so `get-velox.sh` applies the upstream Velox fix before the native build.

| | change | Delta suite expected |
|---|---|---|
| #12783 | enable Velox per-operator output validation | 🔴 **red** |
| this PR | same, **+ the upstream Velox fix** | 🟢 **green** |

Both are branched from the same commit on `main`, so the fix is the only difference between them.

## Why

#12377 has been hard to act on because the failure is intermittent and reports a meaningless row index. Root cause: on a Delta deletion-vector write the scan projects only synthesized columns with a pushed-down filter, and Velox emits a `RowVector` whose row-index child has no rows. That child is wrapped in a dictionary and read out of bounds, so the "row index" is whatever heap memory follows.

* Velox issue: https://github.com/facebookincubator/velox/issues/18535
* Velox fix: https://github.com/facebookincubator/velox/pull/18536

Red on #12783 and green here is the before/after evidence, available now rather than after the upstream fix merges and a Velox bump lands.

## Notes

* `--build_tests=OFF` in the CI native build, so the patch's `TableScanTest.cpp` hunk is applied but never compiled; only the fix is.
* The patch was verified to apply cleanly to the pinned revision `dft-2026_08_17` (`b99dd5720`), which is what `get-velox.sh` checks with `git apply --check` before applying. The defect is also confirmed still present there, so #12783 is expected to be red on the same base.
* Once the fix is merged and picked up by a Velox bump, both this branch and the config in #12783 should be dropped.

Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI (Claude Opus 5)
