### PR TITLE
[GLUTEN-12288][CI] Move more jobs to nightly

### DIFF
--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -190,17 +190,8 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # Only the installed libs (libgluten.so / libvelox.so): every consumer
-          # in this workflow either packages ${cpp.releases.dir} into the
-          # backends-velox jar (backends-velox/pom.xml) or runs tests against
-          # that jar -- nothing reads the rest of cpp/build, which is gigabytes
-          # of CMake intermediates downloaded by ~40 jobs per run. (The udf
-          # example libs are not in this artifact either way: the static build
-          # runs with --build_examples=OFF, and UDFTest is tags-excluded in
-          # every spark-test job; cpp-test-udf-test builds its own natively.)
           path: ./cpp/build/releases/
           if-no-files-found: error
-          # Pure inter-job hand-off; nothing needs it after the run ends.
           retention-days: 1
 
   tpc-test-ubuntu:
@@ -263,7 +254,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Setup tzdata
         run: |
@@ -396,7 +386,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Update mirror list
         run: |
@@ -463,7 +452,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Build and run TPCH/DS tests
         run: |
@@ -525,7 +513,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Setup java
         run: |
@@ -644,7 +631,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Setup java
         run: |
@@ -687,7 +673,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Install Uniffle ${{ matrix.uniffle }}
         run: |
@@ -745,7 +730,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Update mirror list
         run: |
@@ -819,7 +803,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Prepare
         run: |
@@ -877,7 +860,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
 
       - name: Build and Run unit test for Spark 3.3.1 (slow tests)
@@ -927,7 +909,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Prepare spark.test.home for Spark 3.4.4 (other tests)
         run: |
@@ -999,7 +980,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 3.4.4 (slow tests, ${{ matrix.suite }})
         run: |
@@ -1054,7 +1034,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Prepare
         run: |
@@ -1127,7 +1106,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Prepare
         run: |
@@ -1194,7 +1172,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 3.5.5 (slow tests, ${{ matrix.suite }})
         run: |
@@ -1433,7 +1410,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Prepare
         run: |
@@ -1500,7 +1476,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 4.0 (slow tests, ${{ matrix.suite }})
         run: |
@@ -1558,7 +1533,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Prepare
         run: |
@@ -1631,7 +1605,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          # The artifact root is the releases/ dir (see the upload step).
           path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 4.1 (slow tests, ${{ matrix.suite }})
         run: |

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -106,11 +106,12 @@ jobs:
       - name: Detect changed paths
         id: filter
         run: |
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          event="${{ github.event_name }}"
+          if [ "$event" = "schedule" ] || [ "$event" = "workflow_dispatch" ]; then
             # schedule / workflow_dispatch: no PR diff to inspect.
             # For scheduled runs, skip entirely when no commits landed in the
             # last 24 hours — avoids burning runner minutes on idle days.
-            if [ "${{ github.event_name }}" = "schedule" ]; then
+            if [ "$event" = "schedule" ]; then
               recent=$(git log --oneline --after="24 hours ago" HEAD | wc -l)
               if [ "$recent" -eq 0 ]; then
                 echo "No commits in the last 24 hours -- skipping nightly run."

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -148,10 +148,6 @@ jobs:
 
   build-native-lib-centos-7:
     needs: detect-changes
-    if: >-
-      needs.detect-changes.outputs.cpp == 'true' ||
-      needs.detect-changes.outputs.java == 'true' ||
-      needs.detect-changes.outputs.tools_it == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -38,6 +38,17 @@ on:
       - 'cpp/**'
       - 'dev/**'
       - 'build/mvn'
+  # Nightly full run. PR runs trim the TPC matrices to representative JDKs and
+  # skip the OOM / random-kill chaos jobs unless native code changed (see
+  # detect-changes' `full_run` output); this scheduled run restores the full
+  # breadth once a day, so a combo dropped from the per-PR tier can stay broken
+  # for at most a day. It also gives the default branch a post-merge signal,
+  # which the per-PR-only trigger above never provided. 02:00 avoids the
+  # 00:00 velox_nightly.yml and 05:00 delta_spark_ut.yml slots.
+  schedule:
+    - cron: '0 2 * * *'
+  # On-demand full run (e.g. to re-check an extended combo before a release).
+  workflow_dispatch:
 
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
@@ -67,9 +78,19 @@ jobs:
   #   • gluten-core change  → java=true  → all spark-test jobs run  ✓
   #   • shims/spark35 only  → shims35=true → only spark35 jobs run  ✓
   #   • pure cpp change     → cpp=true   → only native/tpc jobs run ✓
+  #
+  # The `full_run` flag is true on schedule/workflow_dispatch runs: those have no
+  # PR diff to filter on, so every path flag is forced true AND the jobs below
+  # widen their matrices to the extended combos that PR runs skip (alternative
+  # JDKs, older Celeborn, chaos tests on java-only changes).
   detect-changes:
+    # Every job chains off this one, so the fork guard here skips the whole
+    # workflow: a fork with Actions enabled would otherwise burn ~1800 runner
+    # minutes nightly on a signal nobody reads.
+    if: github.event_name != 'schedule' || github.repository_owner == 'apache'
     runs-on: ubuntu-22.04
     outputs:
+      full_run: ${{ steps.filter.outputs.full_run }}
       cpp:      ${{ steps.filter.outputs.cpp }}
       java:     ${{ steps.filter.outputs.java }}
       shims33:  ${{ steps.filter.outputs.shims33 }}
@@ -85,6 +106,16 @@ jobs:
       - name: Detect changed paths
         id: filter
         run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # schedule / workflow_dispatch: no PR diff to inspect -- run
+            # everything, including the extended matrices PR runs skip.
+            for flag in cpp java shims33 shims34 shims35 shims40 shims41 tools_it; do
+              echo "$flag=true" >> $GITHUB_OUTPUT
+            done
+            echo "full_run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "full_run=false" >> $GITHUB_OUTPUT
           BASE=${{ github.event.pull_request.base.sha }}
           HEAD=${{ github.sha }}
           changed=$(git diff --name-only "$BASE" "$HEAD")
@@ -145,8 +176,18 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # Only the installed libs (libgluten.so / libvelox.so): every consumer
+          # in this workflow either packages ${cpp.releases.dir} into the
+          # backends-velox jar (backends-velox/pom.xml) or runs tests against
+          # that jar -- nothing reads the rest of cpp/build, which is gigabytes
+          # of CMake intermediates downloaded by ~40 jobs per run. (The udf
+          # example libs are not in this artifact either way: the static build
+          # runs with --build_examples=OFF, and UDFTest is tags-excluded in
+          # every spark-test job; cpp-test-udf-test builds its own natively.)
+          path: ./cpp/build/releases/
           if-no-files-found: error
+          # Pure inter-job hand-off; nothing needs it after the run ends.
+          retention-days: 1
 
   tpc-test-ubuntu:
     needs: [detect-changes, build-native-lib-centos-7]
@@ -159,7 +200,16 @@ jobs:
       matrix:
         os: [ "ubuntu:22.04" ]
         spark: [ "spark-3.3", "spark-3.4", "spark-3.5", "spark-4.0", "spark-4.1"  ]
-        java: [ "java-8", "java-11", "java-17", "java-21", "java-25" ]
+        # PR runs test the primary JDK per Spark line (8 for 3.x, 17 for 4.x --
+        # after the static excludes below that is 6 combos instead of 11). The
+        # alternative-JDK combos (11/21/25) validate build + TPC run under JDKs
+        # that Gluten changes rarely break in a JDK-specific way; the nightly
+        # full_run keeps covering them daily so a break surfaces within a day
+        # instead of costing ~75 runner-minutes on every PR.
+        java: >-
+          ${{ fromJSON(needs.detect-changes.outputs.full_run == 'true'
+          && '["java-8", "java-11", "java-17", "java-21", "java-25"]'
+          || '["java-8", "java-17"]') }}
         # Spark supports JDK17 since 3.3.
         exclude:
           - spark: spark-3.3
@@ -199,7 +249,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Setup tzdata
         run: |
           sed -i 's|http://archive|http://eu.archive|g' /etc/apt/sources.list
@@ -289,10 +340,21 @@ jobs:
       needs.detect-changes.outputs.tools_it == 'true'
     strategy:
       fail-fast: false
+      # This job's per-PR value is OS compatibility of the same native lib and
+      # TPC run that tpc-test-ubuntu already exercises combo-by-combo, so PRs
+      # test one representative combo per Spark line ({3.5, 4.1} x primary JDK
+      # = 2 jobs after the excludes below) and the nightly full_run restores
+      # the whole 7-combo fan-out.
       matrix:
         os: [ "centos:8" ]
-        spark: [ "spark-3.3", "spark-3.4", "spark-3.5", "spark-4.0", "spark-4.1" ]
-        java: [ "java-8", "java-11", "java-17" ]
+        spark: >-
+          ${{ fromJSON(needs.detect-changes.outputs.full_run == 'true'
+          && '["spark-3.3", "spark-3.4", "spark-3.5", "spark-4.0", "spark-4.1"]'
+          || '["spark-3.5", "spark-4.1"]') }}
+        java: >-
+          ${{ fromJSON(needs.detect-changes.outputs.full_run == 'true'
+          && '["java-8", "java-11", "java-17"]'
+          || '["java-8", "java-17"]') }}
         # Spark supports JDK17 since 3.3.
         exclude:
           - spark: spark-3.4
@@ -320,7 +382,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Update mirror list
         run: |
           if [ "${{ matrix.os }}" = "centos:7" ] || [ "${{ matrix.os }}" = "centos:8" ]; then
@@ -386,7 +449,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Build and run TPCH/DS tests
         run: |
           docker pull centos:7
@@ -417,10 +481,13 @@ jobs:
 
   tpc-test-ubuntu-oom:
     needs: [detect-changes, build-native-lib-centos-7]
+    # Chaos/stress tier: this job probes native memory-pressure behaviour, so
+    # per-PR it only runs when native code changed (cpp=true). For java-only
+    # changes its ~60 runner-minutes rarely produce PR-specific signal; the
+    # nightly full_run still exercises it daily.
     if: >-
-      needs.detect-changes.outputs.cpp == 'true' ||
-      needs.detect-changes.outputs.java == 'true' ||
-      needs.detect-changes.outputs.tools_it == 'true'
+      needs.detect-changes.outputs.full_run == 'true' ||
+      needs.detect-changes.outputs.cpp == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -444,7 +511,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Setup java
         run: |
           sudo apt-get update
@@ -531,10 +599,13 @@ jobs:
 
   tpc-test-ubuntu-randomkill:
     needs: [detect-changes, build-native-lib-centos-7]
+    # Chaos/stress tier (see tpc-test-ubuntu-oom): random task kills mainly
+    # probe native/JNI shutdown robustness, and at 3 shards this is the single
+    # most expensive TPC job (~190 runner-minutes). Per-PR only for native
+    # changes; nightly full_run covers the rest.
     if: >-
-      needs.detect-changes.outputs.cpp == 'true' ||
-      needs.detect-changes.outputs.java == 'true' ||
-      needs.detect-changes.outputs.tools_it == 'true'
+      needs.detect-changes.outputs.full_run == 'true' ||
+      needs.detect-changes.outputs.cpp == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -559,7 +630,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Setup java
         run: |
           sudo apt-get update
@@ -601,7 +673,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Install Uniffle ${{ matrix.uniffle }}
         run: |
           export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk
@@ -641,7 +714,14 @@ jobs:
       fail-fast: false
       matrix:
         spark: [ "spark-3.3" ]
-        celeborn: [ "celeborn-0.6.3", "celeborn-0.5.4"]
+        # Both shuffle writers stay per-PR (they exercise different Gluten
+        # writer code paths); the older Celeborn release is client-compat
+        # coverage that the nightly full_run re-checks daily instead of every
+        # PR paying for both versions.
+        celeborn: >-
+          ${{ fromJSON(needs.detect-changes.outputs.full_run == 'true'
+          && '["celeborn-0.6.3", "celeborn-0.5.4"]'
+          || '["celeborn-0.6.3"]') }}
         writer: ["sort", "hash"]
     runs-on: ubuntu-22.04
     container: centos:8
@@ -651,7 +731,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Update mirror list
         run: |
           sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* || true
@@ -724,7 +805,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Prepare
         run: |
           dnf module -y install python39 && \
@@ -781,7 +863,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
 
       - name: Build and Run unit test for Spark 3.3.1 (slow tests)
         run: |
@@ -830,7 +913,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Prepare spark.test.home for Spark 3.4.4 (other tests)
         run: |
           dnf module -y install python39 && \
@@ -901,7 +985,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 3.4.4 (slow tests, ${{ matrix.suite }})
         run: |
           cd $GITHUB_WORKSPACE/
@@ -955,7 +1040,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Prepare
         run: |
           dnf module -y install python39 && \
@@ -1027,7 +1113,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Prepare
         run: |
           dnf module -y install python39 && \
@@ -1093,7 +1180,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 3.5.5 (slow tests, ${{ matrix.suite }})
         run: |
           cd $GITHUB_WORKSPACE/
@@ -1331,7 +1419,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Prepare
         run: |
           dnf module -y install python39 && \
@@ -1397,7 +1486,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 4.0 (slow tests, ${{ matrix.suite }})
         run: |
           cd $GITHUB_WORKSPACE/
@@ -1454,7 +1544,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Prepare
         run: |
           dnf install -y python3.11 python3.11-pip python3.11-devel && \
@@ -1526,7 +1617,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: velox-native-lib-centos-7-${{github.sha}}
-          path: ./cpp/build/
+          # The artifact root is the releases/ dir (see the upload step).
+          path: ./cpp/build/releases/
       - name: Build and Run unit test for Spark 4.1 (slow tests, ${{ matrix.suite }})
         run: |
           cd $GITHUB_WORKSPACE/

--- a/.github/workflows/velox_backend_x86.yml
+++ b/.github/workflows/velox_backend_x86.yml
@@ -107,8 +107,21 @@ jobs:
         id: filter
         run: |
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            # schedule / workflow_dispatch: no PR diff to inspect -- run
-            # everything, including the extended matrices PR runs skip.
+            # schedule / workflow_dispatch: no PR diff to inspect.
+            # For scheduled runs, skip entirely when no commits landed in the
+            # last 24 hours — avoids burning runner minutes on idle days.
+            if [ "${{ github.event_name }}" = "schedule" ]; then
+              recent=$(git log --oneline --after="24 hours ago" HEAD | wc -l)
+              if [ "$recent" -eq 0 ]; then
+                echo "No commits in the last 24 hours -- skipping nightly run."
+                for flag in cpp java shims33 shims34 shims35 shims40 shims41 tools_it; do
+                  echo "$flag=false" >> $GITHUB_OUTPUT
+                done
+                echo "full_run=false" >> $GITHUB_OUTPUT
+                exit 0
+              fi
+            fi
+            # Run everything, including the extended matrices PR runs skip.
             for flag in cpp java shims33 shims34 shims35 shims40 shims41 tools_it; do
               echo "$flag=true" >> $GITHUB_OUTPUT
             done
@@ -134,6 +147,10 @@ jobs:
 
   build-native-lib-centos-7:
     needs: detect-changes
+    if: >-
+      needs.detect-changes.outputs.cpp == 'true' ||
+      needs.detect-changes.outputs.java == 'true' ||
+      needs.detect-changes.outputs.tools_it == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?
Move more jobs to nightly tests to save the GHA resource. This patch trim the TPC matrices to representative JDKs and move the OOM / random-kill chaos jobs to nighlty unless native code

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

## How was this patch tested?
pass GHA
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?
IBM Bob
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->


Related issue: #12288