### PR TITLE
[GLUTEN-12834][CH] Fix nullable filtering after Expand with constant columns

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.execution.GlutenPlan
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.{SparkConf, SparkEnv, SparkException}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, ConstantFolding, NullPropagation}
 import org.apache.spark.sql.execution.{ColumnarToRowExec, ReusedSubqueryExec, SubqueryExec}
@@ -876,6 +876,80 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         |order by l_shipdate, l_shipmode, cnt
         |""".stripMargin
     compareResultsAgainstVanillaSpark(sql, true, { _ => })
+  }
+
+  test("grouping sets preserves nullable columns across union") {
+    val sql =
+      """
+        |select msg_type, os, count(*) as cnt
+        |from (
+        |  select 'file' as msg_type, 'Android' as os, id from range(10)
+        |  union all
+        |  select 'file' as msg_type, 'iOS' as os, id from range(10)
+        |) t
+        |group by grouping sets ((msg_type), (os))
+        |having msg_type is not null
+        |order by msg_type, os, cnt
+        |""".stripMargin
+    withSparkEnvAndSQLConf(CHConfig.runtimeConfig("enable_lazy_aggregate_expand"), "false") {
+      compareResultsAgainstVanillaSpark(
+        sql,
+        true,
+        {
+          df =>
+            val expands = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case e: ExpandExecTransformer
+                  if !e.child.isInstanceOf[HashAggregateExecBaseTransformer] =>
+                e
+            }
+            assert(expands.size == 1)
+        }
+      )
+    }
+  }
+
+  test("lazy aggregate expand preserves nullable columns across union") {
+    val sql =
+      """
+        |select msg_type, os, count(*) as cnt
+        |from (
+        |  select 'file' as msg_type, 'Android' as os, id from range(10)
+        |  union all
+        |  select 'file' as msg_type, 'iOS' as os, id from range(10)
+        |) t
+        |group by grouping sets ((msg_type), (os))
+        |having msg_type is not null
+        |order by msg_type, os, cnt
+        |""".stripMargin
+    withSparkEnvAndSQLConf(CHConfig.runtimeConfig("enable_lazy_aggregate_expand"), "true") {
+      compareResultsAgainstVanillaSpark(
+        sql,
+        true,
+        {
+          df =>
+            val expands = collectWithSubqueries(df.queryExecution.executedPlan) {
+              case e: ExpandExecTransformer
+                  if e.child.isInstanceOf[HashAggregateExecBaseTransformer] =>
+                e
+            }
+            assert(expands.size == 1)
+        }
+      )
+    }
+  }
+
+  private def withSparkEnvAndSQLConf(key: String, value: String)(f: => Unit): Unit = {
+    val sparkConf = SparkEnv.get.conf
+    val previousValue = sparkConf.getOption(key)
+    sparkConf.set(key, value)
+    try {
+      withSQLConf(key -> value)(f)
+    } finally {
+      previousValue match {
+        case Some(previous) => sparkConf.set(key, previous)
+        case None => sparkConf.remove(key)
+      }
+    }
   }
 
   test("expand with nullable type not match") {

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/tpch/GlutenClickHouseTPCHSaltNullParquetSuite.scala
@@ -891,7 +891,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         |having msg_type is not null
         |order by msg_type, os, cnt
         |""".stripMargin
-    withSparkEnvAndSQLConf(CHConfig.runtimeConfig("enable_lazy_aggregate_expand"), "false") {
+    withSparkEnvConf(CHConfig.runtimeConfig("enable_lazy_aggregate_expand"), "false") {
       compareResultsAgainstVanillaSpark(
         sql,
         true,
@@ -921,7 +921,7 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
         |having msg_type is not null
         |order by msg_type, os, cnt
         |""".stripMargin
-    withSparkEnvAndSQLConf(CHConfig.runtimeConfig("enable_lazy_aggregate_expand"), "true") {
+    withSparkEnvConf(CHConfig.runtimeConfig("enable_lazy_aggregate_expand"), "true") {
       compareResultsAgainstVanillaSpark(
         sql,
         true,
@@ -938,12 +938,12 @@ class GlutenClickHouseTPCHSaltNullParquetSuite
     }
   }
 
-  private def withSparkEnvAndSQLConf(key: String, value: String)(f: => Unit): Unit = {
+  private def withSparkEnvConf(key: String, value: String)(f: => Unit): Unit = {
     val sparkConf = SparkEnv.get.conf
     val previousValue = sparkConf.getOption(key)
     sparkConf.set(key, value)
     try {
-      withSQLConf(key -> value)(f)
+      f
     } finally {
       previousValue match {
         case Some(previous) => sparkConf.set(key, previous)

--- a/cpp-ch/local-engine/Operator/AdvancedExpandStep.cpp
+++ b/cpp-ch/local-engine/Operator/AdvancedExpandStep.cpp
@@ -248,7 +248,7 @@ void AdvancedExpandTransform::expandInputChunk()
             input_arg.column = input_column;
             input_arg.type = input_header->getByPosition(index).type;
             /// input_column maybe non-Nullable
-            columns[col_i] = DB::castColumn(input_arg, type);
+            columns[col_i] = DB::castColumn(input_arg, type)->convertToFullColumnIfConst();
         }
         else if (kind == EXPAND_FIELD_KIND_LITERAL)
         {

--- a/cpp-ch/local-engine/Operator/ExpandTransform.cpp
+++ b/cpp-ch/local-engine/Operator/ExpandTransform.cpp
@@ -114,7 +114,7 @@ void ExpandTransform::work()
             input_arg.column = input_column;
             input_arg.type = input_header.getByPosition(index).type;
             /// input_column maybe non-Nullable
-            columns[col_i] = DB::castColumn(input_arg, type);
+            columns[col_i] = DB::castColumn(input_arg, type)->convertToFullColumnIfConst();
         }
         else if (kind == EXPAND_FIELD_KIND_LITERAL)
         {

--- a/cpp-ch/local-engine/Parser/RelParsers/ExpandRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/ExpandRelParser.cpp
@@ -20,6 +20,7 @@
 #include <Columns/ColumnAggregateFunction.h>
 #include <Core/Block.h>
 #include <Core/ColumnWithTypeAndName.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <Operator/AdvancedExpandStep.h>
 #include <Operator/ExpandStep.h>
 #include <Parser/RelParsers/RelParser.h>
@@ -113,6 +114,12 @@ ExpandField ExpandRelParser::buildExpandField(const DB::Block & header, const su
             else if (project_expr.has_literal())
             {
                 auto [type, field] = parseLiteral(project_expr.literal());
+                // A NULL literal is nullable even when the type carried by the
+                // Substrait literal does not explicitly encode nullability.
+                // Keep that information in the Expand output type so the
+                // generated column contains a real null map.
+                if (field.isNull() && type && !type->isNullable())
+                    type = std::make_shared<DB::DataTypeNullable>(type);
                 kinds.push_back(ExpandFieldKind::EXPAND_FIELD_KIND_LITERAL);
                 fields.push_back(field);
                 updateType(types[i], type);

--- a/cpp-ch/local-engine/Parser/RelParsers/ExpandRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/ExpandRelParser.cpp
@@ -119,7 +119,7 @@ ExpandField ExpandRelParser::buildExpandField(const DB::Block & header, const su
                 // Keep that information in the Expand output type so the
                 // generated column contains a real null map.
                 if (field.isNull() && type && !type->isNullable())
-                    type = std::make_shared<DB::DataTypeNullable>(type);
+                    type = DB::makeNullable(type);
                 kinds.push_back(ExpandFieldKind::EXPAND_FIELD_KIND_LITERAL);
                 fields.push_back(field);
                 updateType(types[i], type);


### PR DESCRIPTION

## What changes are proposed in this pull request?

This PR fixes incorrect nullable filtering after Expand in the ClickHouse backend.

The changes:

- Materialize constant selection columns in regular Expand.
- Apply the same behavior to AdvancedExpand.
- Preserve nullable types for NULL literals.
- Add regression tests for both regular and lazy aggregate Expand paths.

Expand emits each grouping-set projection as a separate chunk.

When a selected input column originates from a SQL literal, `castColumn` may preserve it as a `ColumnConst`. In the reproducing query, the first chunk contains a constant non-null `msg_type`, so `isNotNull(msg_type)` produces a constant true filter.

The ClickHouse `FilterTransform` version used by the backend preserves `ConstantFilterDescription` between chunks. It checks the previous `always_true` state before recalculating the filter for the current chunk.

As a result, the following chunk, whose `msg_type` is a real nullable NULL, can bypass filtering and produce extra grouping-set rows.

For example:

```sql
select msg_type, os, count(*) as cnt
from (
  select 'file' as msg_type, 'Android' as os, id from range(10)
  union all
  select 'file' as msg_type, 'iOS' as os, id from range(10)
) t
group by grouping sets ((msg_type), (os))
having msg_type is not null
order by msg_type, os, cnt
```

the incorrect result was:


```text
NULL  Android  10
NULL  iOS      10
file  NULL     20
```

The expected result is:
```text
file  NULL  20
```

Materialize constant selection columns in regular and advanced Expand to prevent stale constant filter state from leaking null rows. Preserve nullable types for null literals and add regression coverage for both Expand paths.

## How was this patch tested?

add ut

## Was this patch authored or co-authored using generative AI tooling?

Codex

close #12834 