### PR TITLE
[GLUTEN-12701][CORE][VL] Support Iceberg REST-catalog vended credentials in native scans

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -573,6 +573,8 @@ object VeloxBackendSettings extends BackendSettingsApi {
 
   override def supportIcebergInitialDefaultRead(): Boolean = true
 
+  override def supportIcebergVendedCredentialsRead(): Boolean = true
+
   override def reorderColumnsForPartitionWrite(): Boolean = true
 
   override def enableEnhancedFeatures(): Boolean = VeloxConfig.get.enableEnhancedFeatures()

--- a/cpp/velox/CMakeLists.txt
+++ b/cpp/velox/CMakeLists.txt
@@ -214,7 +214,8 @@ set(VELOX_SRCS
     utils/VeloxWriterUtils.cc)
 
 if(ENABLE_S3)
-  list(APPEND VELOX_SRCS filesystem/GlutenS3FileSystem.cc)
+  list(APPEND VELOX_SRCS filesystem/GlutenS3FileSystem.cc
+       utils/GlutenS3TokenProvider.cc)
   find_package(ZLIB)
 endif()
 

--- a/cpp/velox/compute/VeloxPlanConverter.cc
+++ b/cpp/velox/compute/VeloxPlanConverter.cc
@@ -149,6 +149,9 @@ std::shared_ptr<SplitInfo> parseScanSplitInfo(
   splitInfo->partitionColumns.reserve(fileList.size());
   splitInfo->properties.reserve(fileList.size());
   splitInfo->metadataColumns.reserve(fileList.size());
+  for (const auto& readProperty : localFiles.read_properties()) {
+    splitInfo->readProperties[readProperty.first] = readProperty.second;
+  }
   for (const auto& file : fileList) {
     // Expect all Partitions share the same index.
     splitInfo->partitionIndex = file.partition_index();

--- a/cpp/velox/compute/WholeStageResultIterator.cc
+++ b/cpp/velox/compute/WholeStageResultIterator.cc
@@ -28,6 +28,9 @@
 #include "compute/delta/DeltaSplitInfo.h"
 #include "config/VeloxConfig.h"
 #include "utils/ConfigExtractor.h"
+#ifdef ENABLE_S3
+#include "utils/GlutenS3TokenProvider.h"
+#endif
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -277,8 +280,22 @@ std::shared_ptr<velox::core::QueryCtx> WholeStageResultIterator::createNewVeloxQ
           "Gluten_Stage_{}_TID_{}_VTID_{}",
           std::to_string(taskInfo_.stageId),
           std::to_string(taskInfo_.taskId),
-          std::to_string(taskInfo_.vId)));
+          std::to_string(taskInfo_.vId)),
+      createFsTokenProvider());
   return ctx;
+}
+
+std::shared_ptr<velox::filesystems::TokenProvider> WholeStageResultIterator::createFsTokenProvider() const {
+#ifdef ENABLE_S3
+  std::vector<std::unordered_map<std::string, std::string>> readProperties;
+  readProperties.reserve(scanInfos_.size());
+  for (const auto& scanInfo : scanInfos_) {
+    readProperties.push_back(scanInfo->readProperties);
+  }
+  return GlutenS3TokenProvider::create(readProperties);
+#else
+  return nullptr;
+#endif
 }
 
 std::shared_ptr<ColumnarBatch> WholeStageResultIterator::next() {

--- a/cpp/velox/compute/WholeStageResultIterator.h
+++ b/cpp/velox/compute/WholeStageResultIterator.h
@@ -26,6 +26,7 @@
 #include "substrait/plan.pb.h"
 #include "utils/Metrics.h"
 #include "velox/common/config/Config.h"
+#include "velox/common/file/TokenProvider.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Cursor.h"
@@ -109,6 +110,11 @@ class WholeStageResultIterator : public SplitAwareColumnarBatchIterator {
 
   /// Create QueryCtx.
   std::shared_ptr<facebook::velox::core::QueryCtx> createNewVeloxQueryCtx();
+
+  /// The file system token provider built from the scans' table-scoped read
+  /// properties, e.g. the per-table S3 credentials an Iceberg REST catalog
+  /// vended. Null when no scan carries credentials, or when built without S3.
+  std::shared_ptr<facebook::velox::filesystems::TokenProvider> createFsTokenProvider() const;
 
   /// Get all the children plan node ids with postorder traversal.
   void getOrderedNodeIds(

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.h
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.h
@@ -65,6 +65,11 @@ struct SplitInfo {
   /// The file sizes and modification times of the files to be scanned.
   std::vector<std::optional<facebook::velox::FileProperties>> properties;
 
+  /// Table-scoped storage properties from LocalFiles.read_properties, e.g. the
+  /// S3 credentials an Iceberg REST catalog vended for this table plus the table
+  /// location. Empty for tables whose files the process credentials can read.
+  std::unordered_map<std::string, std::string> readProperties;
+
   /// The schema of the table being scanned.
   RowTypePtr tableSchema;
 

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -139,6 +139,8 @@ add_velox_test(velox_memory_test SOURCES MemoryManagerTest.cc)
 add_velox_test(buffer_outputstream_test SOURCES BufferOutputStreamTest.cc)
 if(ENABLE_S3)
   add_velox_test(gluten_s3_file_system_test SOURCES GlutenS3FileSystemTest.cc)
+  add_velox_test(gluten_s3_token_provider_test SOURCES
+                 GlutenS3TokenProviderTest.cc)
 endif()
 add_velox_test(scoped_timer_test SOURCES ScopedTimerTest.cc)
 add_velox_test(row_based_checksum_test SOURCES RowBasedChecksumTest.cc)

--- a/cpp/velox/tests/GlutenS3TokenProviderTest.cc
+++ b/cpp/velox/tests/GlutenS3TokenProviderTest.cc
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utils/GlutenS3TokenProvider.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/file/PlainUserNameTokenProvider.h"
+
+namespace gluten {
+namespace {
+
+using namespace facebook::velox::filesystems;
+
+std::unordered_map<std::string, std::string> readProperties(
+    const std::string& location,
+    const std::string& accessKeyId,
+    const std::string& secretAccessKey,
+    const std::string& sessionToken = "") {
+  std::unordered_map<std::string, std::string> properties{
+      {kReadPropertiesLocation, location},
+      {kReadPropertiesAccessKeyId, accessKeyId},
+      {kReadPropertiesSecretAccessKey, secretAccessKey}};
+  if (!sessionToken.empty()) {
+    properties[kReadPropertiesSessionToken] = sessionToken;
+  }
+  return properties;
+}
+
+std::shared_ptr<S3AccessToken> tokenFor(const TokenProvider& provider, const std::string& path) {
+  return std::dynamic_pointer_cast<S3AccessToken>(provider.getToken(S3AccessTokenKey{path}));
+}
+
+// A key belonging to some other file system.
+class OtherAccessTokenKey : public AccessTokenKey {};
+
+} // namespace
+
+TEST(GlutenS3TokenProviderTest, noProviderWithoutCredentials) {
+  ASSERT_EQ(GlutenS3TokenProvider::create({}), nullptr);
+  // A scan of a table the process credentials can read carries nothing.
+  ASSERT_EQ(GlutenS3TokenProvider::create({{}}), nullptr);
+  // An incomplete credential set is not usable and must not be installed.
+  ASSERT_EQ(
+      GlutenS3TokenProvider::create(
+          {{{kReadPropertiesLocation, "s3://bucket/db/t"}, {kReadPropertiesAccessKeyId, "ASIA"}}}),
+      nullptr);
+}
+
+TEST(GlutenS3TokenProviderTest, resolvesCredentialsOfTheTableOwningThePath) {
+  const auto provider = GlutenS3TokenProvider::create(
+      {readProperties("s3://bucket/db/first", "ASIAFIRST", "first-secret", "first-token"),
+       readProperties("s3a://bucket/db/second", "ASIASECOND", "second-secret")});
+  ASSERT_NE(provider, nullptr);
+
+  const auto first = tokenFor(*provider, "bucket/db/first/data/00000-0-a.parquet");
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(first->accessKeyId(), "ASIAFIRST");
+  EXPECT_EQ(first->secretAccessKey(), "first-secret");
+  EXPECT_EQ(first->sessionToken(), "first-token");
+
+  // Same bucket, different table: the other credential set, and no session
+  // token because the catalog vended none.
+  const auto second = tokenFor(*provider, "bucket/db/second/data/00000-0-b.parquet");
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(second->accessKeyId(), "ASIASECOND");
+  EXPECT_EQ(second->secretAccessKey(), "second-secret");
+  EXPECT_EQ(second->sessionToken(), "");
+
+  // A path no scan covers gets no token, which leaves the file system on its
+  // configured credentials.
+  EXPECT_EQ(tokenFor(*provider, "bucket/db/third/data/00000-0-c.parquet"), nullptr);
+  // A table name the prefix is a string prefix of is a different table.
+  EXPECT_EQ(tokenFor(*provider, "bucket/db/firstborn/data/00000-0-d.parquet"), nullptr);
+}
+
+TEST(GlutenS3TokenProviderTest, theLongestMatchingPrefixWins) {
+  // A table whose location is nested inside another table's location must get
+  // its own credentials, not the enclosing one's.
+  const auto provider = GlutenS3TokenProvider::create(
+      {readProperties("s3://bucket/db", "ASIAOUTER", "outer-secret"),
+       readProperties("s3://bucket/db/nested", "ASIAINNER", "inner-secret")});
+  ASSERT_NE(provider, nullptr);
+
+  EXPECT_EQ(tokenFor(*provider, "bucket/db/nested/data/f.parquet")->accessKeyId(), "ASIAINNER");
+  EXPECT_EQ(tokenFor(*provider, "bucket/db/other/data/f.parquet")->accessKeyId(), "ASIAOUTER");
+}
+
+TEST(GlutenS3TokenProviderTest, identityCoversAllCredentials) {
+  const auto provider = GlutenS3TokenProvider::create({readProperties("s3://bucket/db/t", "ASIA", "secret", "token")});
+  const auto same = GlutenS3TokenProvider::create({readProperties("s3://bucket/db/t", "ASIA", "secret", "token")});
+  // A re-vended credential set for the same table is a different identity, so
+  // velox's file handle cache cannot serve handles opened with the old one.
+  const auto rotated =
+      GlutenS3TokenProvider::create({readProperties("s3://bucket/db/t", "ASIA2", "secret2", "token2")});
+
+  EXPECT_TRUE(provider->equals(*same));
+  EXPECT_EQ(provider->hash(), same->hash());
+  EXPECT_FALSE(provider->equals(*rotated));
+  EXPECT_NE(provider->hash(), rotated->hash());
+
+  // Providers of another kind are never equal.
+  PlainUserNameTokenProvider other{"user"};
+  EXPECT_FALSE(provider->equals(other));
+  // A key belonging to another file system resolves nothing.
+  EXPECT_EQ(provider->getToken(OtherAccessTokenKey{}), nullptr);
+}
+
+TEST(GlutenS3TokenProviderTest, normalizesS3Schemes) {
+  EXPECT_EQ(GlutenS3TokenProvider::normalizeS3Path("s3://bucket/db/t"), "bucket/db/t");
+  EXPECT_EQ(GlutenS3TokenProvider::normalizeS3Path("s3a://bucket/db/t"), "bucket/db/t");
+  EXPECT_EQ(GlutenS3TokenProvider::normalizeS3Path("s3n://bucket/db/t"), "bucket/db/t");
+  EXPECT_EQ(GlutenS3TokenProvider::normalizeS3Path("bucket/db/t"), "bucket/db/t");
+}
+
+} // namespace gluten

--- a/cpp/velox/utils/GlutenS3TokenProvider.cc
+++ b/cpp/velox/utils/GlutenS3TokenProvider.cc
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "utils/GlutenS3TokenProvider.h"
+
+#include <cstring>
+#include <functional>
+
+#include "velox/common/base/BitUtil.h"
+
+namespace gluten {
+namespace {
+
+// Segment-boundary-safe prefix match: "bucket/tableA" must not claim
+// "bucket/tableAB/part.parquet".
+bool prefixMatches(const std::string& path, const std::string& prefix) {
+  if (prefix.empty() || path.size() < prefix.size() || path.compare(0, prefix.size(), prefix) != 0) {
+    return false;
+  }
+  return path.size() == prefix.size() || prefix.back() == '/' || path[prefix.size()] == '/';
+}
+
+std::string findOrEmpty(const std::unordered_map<std::string, std::string>& properties, const char* key) {
+  const auto it = properties.find(key);
+  return it == properties.end() ? "" : it->second;
+}
+
+} // namespace
+
+GlutenS3TokenProvider::GlutenS3TokenProvider(std::map<std::string, S3TableCredentials> credentialsByPrefix)
+    : credentialsByPrefix_(std::move(credentialsByPrefix)) {
+  const std::hash<std::string> hasher;
+  size_t hash = 0;
+  // std::map iteration order is deterministic, so equal contents hash equally.
+  for (const auto& [prefix, credentials] : credentialsByPrefix_) {
+    hash = facebook::velox::bits::hashMix(hash, hasher(prefix));
+    hash = facebook::velox::bits::hashMix(hash, hasher(credentials.accessKeyId));
+    hash = facebook::velox::bits::hashMix(hash, hasher(credentials.secretAccessKey));
+    hash = facebook::velox::bits::hashMix(hash, hasher(credentials.sessionToken));
+  }
+  hash_ = hash;
+}
+
+std::shared_ptr<GlutenS3TokenProvider> GlutenS3TokenProvider::create(
+    const std::vector<std::unordered_map<std::string, std::string>>& readProperties) {
+  std::map<std::string, S3TableCredentials> credentialsByPrefix;
+  for (const auto& properties : readProperties) {
+    const auto location = findOrEmpty(properties, kReadPropertiesLocation);
+    const auto accessKeyId = findOrEmpty(properties, kReadPropertiesAccessKeyId);
+    const auto secretAccessKey = findOrEmpty(properties, kReadPropertiesSecretAccessKey);
+    if (location.empty() || accessKeyId.empty() || secretAccessKey.empty()) {
+      continue;
+    }
+    credentialsByPrefix[normalizeS3Path(location)] =
+        S3TableCredentials{accessKeyId, secretAccessKey, findOrEmpty(properties, kReadPropertiesSessionToken)};
+  }
+  if (credentialsByPrefix.empty()) {
+    return nullptr;
+  }
+  return std::make_shared<GlutenS3TokenProvider>(std::move(credentialsByPrefix));
+}
+
+bool GlutenS3TokenProvider::equals(const facebook::velox::filesystems::TokenProvider& other) const {
+  const auto* typedOther = dynamic_cast<const GlutenS3TokenProvider*>(&other);
+  return typedOther != nullptr && credentialsByPrefix_ == typedOther->credentialsByPrefix_;
+}
+
+size_t GlutenS3TokenProvider::hash() const {
+  return hash_;
+}
+
+std::shared_ptr<facebook::velox::filesystems::AccessToken> GlutenS3TokenProvider::getToken(
+    const facebook::velox::filesystems::AccessTokenKey& key) const {
+  const auto* s3Key = dynamic_cast<const facebook::velox::filesystems::S3AccessTokenKey*>(&key);
+  if (s3Key == nullptr) {
+    return nullptr;
+  }
+  const auto& path = s3Key->path();
+  const S3TableCredentials* longestMatch = nullptr;
+  size_t longestMatchSize = 0;
+  for (const auto& [prefix, credentials] : credentialsByPrefix_) {
+    if (prefix.size() >= longestMatchSize && prefixMatches(path, prefix)) {
+      longestMatch = &credentials;
+      longestMatchSize = prefix.size();
+    }
+  }
+  if (longestMatch == nullptr) {
+    return nullptr;
+  }
+  return std::make_shared<facebook::velox::filesystems::S3AccessToken>(
+      longestMatch->accessKeyId, longestMatch->secretAccessKey, longestMatch->sessionToken);
+}
+
+std::string GlutenS3TokenProvider::normalizeS3Path(const std::string& path) {
+  for (const char* scheme : {"s3://", "s3a://", "s3n://"}) {
+    if (path.rfind(scheme, 0) == 0) {
+      return path.substr(std::strlen(scheme));
+    }
+  }
+  return path;
+}
+
+} // namespace gluten

--- a/cpp/velox/utils/GlutenS3TokenProvider.h
+++ b/cpp/velox/utils/GlutenS3TokenProvider.h
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "velox/common/file/TokenProvider.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3AccessToken.h"
+
+namespace gluten {
+
+// Keys of the LocalFiles.read_properties map. Contract with the JVM side
+// (GlutenIcebergSourceUtil.vendedReadProperties): the Iceberg FileIO property
+// names of the credentials, plus the table location under kReadPropertiesLocation.
+constexpr const char* kReadPropertiesLocation = "location";
+constexpr const char* kReadPropertiesAccessKeyId = "s3.access-key-id";
+constexpr const char* kReadPropertiesSecretAccessKey = "s3.secret-access-key";
+constexpr const char* kReadPropertiesSessionToken = "s3.session-token";
+
+struct S3TableCredentials {
+  std::string accessKeyId;
+  std::string secretAccessKey;
+  // Empty when the credentials are not temporary.
+  std::string sessionToken;
+
+  bool operator==(const S3TableCredentials& other) const {
+    return accessKeyId == other.accessKeyId && secretAccessKey == other.secretAccessKey &&
+        sessionToken == other.sessionToken;
+  }
+};
+
+/// Resolves the per-table S3 credentials for native reads of tables whose
+/// credentials an Iceberg REST catalog vends. Holds the credentials of all the
+/// task's scans keyed by normalized table-location prefix; getToken()
+/// longest-prefix-matches the file path, so a query joining two tables that
+/// live in one bucket but carry different credentials cannot mix them up.
+///
+/// equals()/hash() cover the full contents because they key velox's file handle
+/// cache: a rotated credential set can never be served a handle that was opened
+/// with the credentials it replaced.
+class GlutenS3TokenProvider final : public facebook::velox::filesystems::TokenProvider {
+ public:
+  explicit GlutenS3TokenProvider(std::map<std::string, S3TableCredentials> credentialsByPrefix);
+
+  /// Builds a provider from the read properties of a task's scans, or nullptr
+  /// when none of them carries credentials.
+  static std::shared_ptr<GlutenS3TokenProvider> create(
+      const std::vector<std::unordered_map<std::string, std::string>>& readProperties);
+
+  bool equals(const facebook::velox::filesystems::TokenProvider& other) const override;
+
+  size_t hash() const override;
+
+  std::shared_ptr<facebook::velox::filesystems::AccessToken> getToken(
+      const facebook::velox::filesystems::AccessTokenKey& key) const override;
+
+  /// "s3://bucket/path" (also s3a/s3n) -> "bucket/path", matching the
+  /// scheme-stripped paths the S3 file system puts in S3AccessTokenKey.
+  static std::string normalizeS3Path(const std::string& path);
+
+ private:
+  const std::map<std::string, S3TableCredentials> credentialsByPrefix_;
+  size_t hash_;
+};
+
+} // namespace gluten

--- a/docs/get-started/VeloxIceberg.md
+++ b/docs/get-started/VeloxIceberg.md
@@ -103,8 +103,29 @@ the added column name is same to the deleted column, the scan will fall back.
 | --- | --- | --- |
 | spark.gluten.sql.columnar.iceberg.enableNativeRead | true | Enable offloading Iceberg scans to the native backend. When disabled, Iceberg scans fall back to vanilla Spark while scans of other formats stay offloaded. |
 | spark.gluten.sql.columnar.iceberg.enableNativeWrite | true | Enable offloading Iceberg writes to the native backend. When disabled, Iceberg writes fall back to vanilla Spark. Note the Velox backend additionally requires `spark.gluten.sql.enable.enhancedFeatures` to be enabled. |
+| spark.gluten.sql.columnar.iceberg.enableVendedCredentials | true | Pass the per-table S3 credentials an Iceberg REST catalog vends from the table's FileIO to the native backend, so that such tables can be scanned natively. When disabled, scans of tables read with vended credentials fall back to vanilla Spark. Tables whose files are readable with the process credentials are unaffected either way. |
 
-Both options are runtime modifiable, so they can be flipped per session with `SET`.
+All three options are runtime modifiable, so they can be flipped per session with `SET`.
+
+### Credential vending
+
+REST catalogs can be configured to vend credentials rather than let the compute
+use its own identity, for example Apache Polaris with
+
+```
+spark.sql.catalog.<catalog>.header.X-Iceberg-Access-Delegation=vended-credentials
+```
+
+In that case `loadTable` returns credentials scoped to one table, and only the
+JVM `FileIO` sees them. Gluten reads them from the scan table's `FileIO` at split
+planning time and passes them to the native reader with the split, which resolves
+them per table by matching the file path against the table locations. A query may
+therefore join tables that live in the same bucket but carry different
+credentials.
+
+The credentials are read once on the driver, so a scan has to start within the
+lifetime of the credentials the catalog vended; executors cannot ask the catalog
+for new ones.
 
 ### Catalogs
 All the catalog configurations are transparent to Gluten

--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -25,7 +25,9 @@ RUN_SETUP_SCRIPT=ON
 ENABLE_ENHANCED_FEATURES=OFF
 
 # Developer use only for testing Velox PR.
-UPSTREAM_VELOX_PR_ID=""
+# TODO: reset to "" once facebookincubator/velox#18570 (per-path S3 credentials
+# from the query TokenProvider) is merged and the Velox pin above includes it.
+UPSTREAM_VELOX_PR_ID="18570"
 
 OS=`uname -s`
 

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/config/GlutenIcebergConfig.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/config/GlutenIcebergConfig.scala
@@ -24,6 +24,8 @@ class GlutenIcebergConfig(conf: SQLConf) extends GlutenCoreConfig(conf) {
   def enableNativeRead: Boolean = getConf(ENABLE_NATIVE_READ)
 
   def enableNativeWrite: Boolean = getConf(ENABLE_NATIVE_WRITE)
+
+  def enableVendedCredentials: Boolean = getConf(ENABLE_VENDED_CREDENTIALS)
 }
 
 object GlutenIcebergConfig extends ConfigRegistry {
@@ -36,6 +38,17 @@ object GlutenIcebergConfig extends ConfigRegistry {
     buildConf("spark.gluten.sql.columnar.iceberg.enableNativeRead")
       .doc("Enable offloading Iceberg scans to the native backend. When disabled, Iceberg scans" +
         " fall back to vanilla Spark while scans of other formats stay offloaded.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val ENABLE_VENDED_CREDENTIALS: ConfigEntry[Boolean] =
+    buildConf("spark.gluten.sql.columnar.iceberg.enableVendedCredentials")
+      .doc("Pass the per-table S3 credentials an Iceberg REST catalog vends (e.g. Apache" +
+        " Polaris with 'X-Iceberg-Access-Delegation: vended-credentials') from the table's" +
+        " FileIO to the native backend, so that such tables can be scanned natively. When" +
+        " disabled, scans of tables read with vended credentials fall back to vanilla Spark," +
+        " which reads them through the JVM FileIO. Tables whose files are readable with the" +
+        " process credentials are unaffected either way.")
       .booleanConf
       .createWithDefault(true)
 

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -17,6 +17,7 @@
 package org.apache.gluten.execution
 
 import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.config.GlutenIcebergConfig
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.IcebergScanTransformer.{containsMetadataColumn, containsUuidOrFixedType}
 import org.apache.gluten.sql.shims.SparkShimLoader
@@ -76,6 +77,9 @@ case class IcebergScanTransformer(
       GlutenIcebergSourceUtil.getFieldIds(scan)
     }
 
+  private lazy val icebergVendedReadProperties =
+    GlutenIcebergSourceUtil.vendedReadProperties(scan)
+
   override def withNewPushdownFilters(filters: Seq[Expression]): BatchScanExecTransformerBase = {
     this.copy(pushDownFilters = Some(filters))
   }
@@ -88,6 +92,21 @@ case class IcebergScanTransformer(
     val validationResult = super.doValidateInternal()
     if (!validationResult.ok()) {
       return validationResult
+    }
+
+    // Files of a table read with catalog-vended credentials are not readable with
+    // the process credentials, so offloading such a scan without passing the vended
+    // credentials down would only produce access-denied errors.
+    if (!icebergVendedReadProperties.isEmpty) {
+      if (!GlutenIcebergConfig.get.enableVendedCredentials) {
+        return ValidationResult.failed(
+          "Table is read with catalog-vended credentials and " +
+            s"${GlutenIcebergConfig.ENABLE_VENDED_CREDENTIALS.key} is disabled")
+      }
+      if (!BackendsApiManager.getSettings.supportIcebergVendedCredentialsRead()) {
+        return ValidationResult.failed(
+          "Table is read with catalog-vended credentials, which this backend cannot use")
+      }
     }
 
     if (!BackendsApiManager.getSettings.supportIcebergEqualityDeleteRead()) {
@@ -230,7 +249,8 @@ case class IcebergScanTransformer(
           getPartitionSchema,
           metadataColumnNames,
           icebergFieldIds,
-          icebergInitialDefaults)
+          icebergInitialDefaults,
+          icebergVendedReadProperties)
       case _ => throw new GlutenNotSupportException()
     }
     numSplits.add(splitInfo.asInstanceOf[LocalFilesNode].getPaths.size())

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -32,7 +32,7 @@ import org.apache.iceberg._
 import org.apache.iceberg.spark.SparkSchemaUtil
 
 import java.lang.{Class, Long => JLong}
-import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
+import java.util.{ArrayList => JArrayList, Collections, HashMap => JHashMap, List => JList, Map => JMap}
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -41,6 +41,22 @@ object GlutenIcebergSourceUtil {
   private val InputFileNameCol = "input_file_name"
   private val InputFileBlockStartCol = "input_file_block_start"
   private val InputFileBlockLengthCol = "input_file_block_length"
+
+  // Contract with the native backend: the split's read_properties map carries the
+  // table location under LocationKey plus the vended S3 credentials under their
+  // Iceberg FileIO property names.
+  val LocationKey = "location"
+  private val S3AccessKeyId = "s3.access-key-id"
+  private val S3SecretAccessKey = "s3.secret-access-key"
+  // Carried verbatim when the catalog vends them alongside the key pair.
+  private val OptionalCredentialKeys = Seq(
+    "s3.session-token",
+    "s3.session-token-expires-at-ms",
+    "s3.endpoint",
+    "s3.path-style-access",
+    "s3.region",
+    "client.region"
+  )
 
   def getClassOfSparkBatchQueryScan(): Class[SparkBatchQueryScan] = {
     classOf[SparkBatchQueryScan]
@@ -55,12 +71,64 @@ object GlutenIcebergSourceUtil {
     }
   }
 
+  /**
+   * The per-table S3 credentials the catalog vended for this scan's table, empty when the table has
+   * none - which is the case whenever the files are readable with the process credentials.
+   *
+   * The credentials are read on the driver at planning time and travel with the split; executors
+   * cannot re-vend them, so a scan has to start within the vend TTL.
+   */
+  def vendedReadProperties(sparkScan: Scan): JMap[String, String] = sparkScan match {
+    case scan: SparkBatchQueryScan =>
+      val table = scan.table()
+      val ioProperties =
+        try {
+          table.io().properties()
+        } catch {
+          // FileIO.properties() is implemented by S3FileIO and ResolvingFileIO but
+          // defaults to throwing on FileIOs that do not expose their configuration.
+          // Such a FileIO cannot be carrying vended credentials.
+          case _: UnsupportedOperationException => Collections.emptyMap[String, String]()
+        }
+      extractVendedReadProperties(
+        ioProperties,
+        BackendsApiManager.getTransformerApiInstance.encodeFilePathIfNeed(table.location()))
+    case _ => Collections.emptyMap()
+  }
+
+  /**
+   * Keeps the vended credential set only when the access-key/secret pair is present, carrying the
+   * optional companions verbatim and the table location under [[LocationKey]].
+   */
+  private[source] def extractVendedReadProperties(
+      ioProperties: JMap[String, String],
+      encodedTableLocation: String): JMap[String, String] = {
+    val accessKeyId = ioProperties.get(S3AccessKeyId)
+    val secretAccessKey = ioProperties.get(S3SecretAccessKey)
+    if (accessKeyId == null || secretAccessKey == null) {
+      return Collections.emptyMap()
+    }
+    val readProperties = new JHashMap[String, String]()
+    readProperties.put(S3AccessKeyId, accessKeyId)
+    readProperties.put(S3SecretAccessKey, secretAccessKey)
+    OptionalCredentialKeys.foreach {
+      key =>
+        val value = ioProperties.get(key)
+        if (value != null) {
+          readProperties.put(key, value)
+        }
+    }
+    readProperties.put(LocationKey, encodedTableLocation)
+    readProperties
+  }
+
   def genSplitInfo(
       partition: SparkDataSourceRDDPartition,
       readPartitionSchema: StructType,
       metadataColumnNames: Seq[String],
       fieldIds: JMap[String, Integer],
-      initialDefaults: JMap[String, String]): SplitInfo = {
+      initialDefaults: JMap[String, String],
+      readProperties: JMap[String, String]): SplitInfo = {
     val paths = new JArrayList[String]()
     val starts = new JArrayList[JLong]()
     val lengths = new JArrayList[JLong]()
@@ -94,7 +162,7 @@ object GlutenIcebergSourceUtil {
       case o =>
         throw new GlutenNotSupportException(s"Unsupported input partition type: $o")
     }
-    IcebergLocalFilesBuilder.makeIcebergLocalFiles(
+    val localFiles = IcebergLocalFilesBuilder.makeIcebergLocalFiles(
       partition.index,
       paths,
       starts,
@@ -110,6 +178,10 @@ object GlutenIcebergSourceUtil {
       fieldIds,
       initialDefaults
     )
+    if (!readProperties.isEmpty) {
+      localFiles.setReadProperties(readProperties)
+    }
+    localFiles
   }
 
   def getFieldIds(sparkScan: Scan): JHashMap[String, Integer] = {

--- a/gluten-iceberg/src/test/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNodeReadPropertiesTest.java
+++ b/gluten-iceberg/src/test/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNodeReadPropertiesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.substrait.rel;
+
+import io.substrait.proto.ReadRel;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class IcebergLocalFilesNodeReadPropertiesTest {
+
+  private static IcebergLocalFilesNode newNode() {
+    return new IcebergLocalFilesNode(
+        0,
+        Collections.singletonList("s3a://warehouse/ns/db/table/data/00000-0-data.parquet"),
+        Collections.singletonList(0L),
+        Collections.singletonList(100L),
+        Collections.singletonList(Collections.emptyMap()),
+        LocalFilesNode.ReadFileFormat.ParquetReadFormat,
+        Collections.emptyList(),
+        Collections.singletonList(Collections.emptyList()),
+        Collections.singletonList(Collections.emptyMap()),
+        Collections.emptyMap(),
+        Collections.emptyMap());
+  }
+
+  @Test
+  public void serializesTableScopedReadProperties() {
+    Map<String, String> readProperties = new HashMap<>();
+    readProperties.put("location", "s3://warehouse/ns/db/table");
+    readProperties.put("s3.access-key-id", "ASIAVENDED");
+    readProperties.put("s3.secret-access-key", "secret");
+    readProperties.put("s3.session-token", "token");
+
+    IcebergLocalFilesNode node = newNode();
+    node.setReadProperties(readProperties);
+
+    ReadRel.LocalFiles localFiles = node.toProtobuf();
+
+    Assert.assertEquals(readProperties, localFiles.getReadPropertiesMap());
+  }
+
+  @Test
+  public void omitsReadPropertiesWhenTheTableHasNone() {
+    ReadRel.LocalFiles localFiles = newNode().toProtobuf();
+
+    Assert.assertEquals(Collections.emptyMap(), localFiles.getReadPropertiesMap());
+  }
+}

--- a/gluten-iceberg/src/test/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtilSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtilSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.spark.source
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.{HashMap => JHashMap}
+
+class GlutenIcebergSourceUtilSuite extends AnyFunSuite {
+
+  private val location = "s3://warehouse/ns/db/table"
+
+  test("the vended credential set is extracted with the location and its companions") {
+    val ioProperties = new JHashMap[String, String]()
+    ioProperties.put("s3.access-key-id", "ASIAVENDED")
+    ioProperties.put("s3.secret-access-key", "secret")
+    ioProperties.put("s3.session-token", "token")
+    ioProperties.put("s3.session-token-expires-at-ms", "1780000000000")
+    ioProperties.put("client.region", "us-west-2")
+    ioProperties.put("io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
+
+    val extracted = GlutenIcebergSourceUtil.extractVendedReadProperties(ioProperties, location)
+
+    val expected = new JHashMap[String, String]()
+    expected.put("s3.access-key-id", "ASIAVENDED")
+    expected.put("s3.secret-access-key", "secret")
+    expected.put("s3.session-token", "token")
+    expected.put("s3.session-token-expires-at-ms", "1780000000000")
+    expected.put("client.region", "us-west-2")
+    expected.put(GlutenIcebergSourceUtil.LocationKey, location)
+    // io-impl is not a credential, so it must not ride along.
+    assert(extracted == expected)
+  }
+
+  test("a table without vended credentials extracts nothing") {
+    val noCredentials = new JHashMap[String, String]()
+    noCredentials.put("io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
+    noCredentials.put("client.region", "us-west-2")
+    assert(
+      GlutenIcebergSourceUtil.extractVendedReadProperties(noCredentials, location).isEmpty,
+      "a region without an access-key/secret pair is not a vended credential set"
+    )
+
+    val secretOnly = new JHashMap[String, String]()
+    secretOnly.put("s3.secret-access-key", "secret")
+    assert(GlutenIcebergSourceUtil.extractVendedReadProperties(secretOnly, location).isEmpty)
+
+    val accessKeyOnly = new JHashMap[String, String]()
+    accessKeyOnly.put("s3.access-key-id", "ASIAVENDED")
+    assert(GlutenIcebergSourceUtil.extractVendedReadProperties(accessKeyOnly, location).isEmpty)
+  }
+
+  test("the session token is optional") {
+    val staticKeys = new JHashMap[String, String]()
+    staticKeys.put("s3.access-key-id", "AKIASTATIC")
+    staticKeys.put("s3.secret-access-key", "secret")
+
+    val expected = new JHashMap[String, String]()
+    expected.put("s3.access-key-id", "AKIASTATIC")
+    expected.put("s3.secret-access-key", "secret")
+    expected.put(GlutenIcebergSourceUtil.LocationKey, location)
+    assert(GlutenIcebergSourceUtil.extractVendedReadProperties(staticKeys, location) == expected)
+  }
+}

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/LocalFilesNode.java
@@ -59,6 +59,10 @@ public class LocalFilesNode implements SplitInfo {
   private Boolean iterAsInput = false;
   private StructType fileSchema;
   private Map<String, String> fileReadProperties;
+  // Table-scoped storage properties required to open this split's files
+  // natively, e.g. Iceberg catalog-vended S3 credentials. Serialized into
+  // ReadRel.LocalFiles.read_properties when non-empty.
+  private Map<String, String> readProperties;
 
   LocalFilesNode(
       Integer index,
@@ -112,6 +116,7 @@ public class LocalFilesNode implements SplitInfo {
     this.fileFormat = other.fileFormat;
     this.preferredLocations.addAll(other.preferredLocations);
     this.fileReadProperties = other.fileReadProperties;
+    this.readProperties = other.readProperties;
     this.iterAsInput = other.iterAsInput;
     this.fileSchema = other.fileSchema;
     this.otherMetadataColumns.addAll(otherMetadataColumns);
@@ -128,6 +133,10 @@ public class LocalFilesNode implements SplitInfo {
 
   public void setFileSchema(StructType schema) {
     this.fileSchema = schema;
+  }
+
+  public void setReadProperties(Map<String, String> readProperties) {
+    this.readProperties = readProperties;
   }
 
   private NamedStruct buildNamedStruct() {
@@ -283,6 +292,9 @@ public class LocalFilesNode implements SplitInfo {
       }
       processFileBuilder(fileBuilder, i);
       localFilesBuilder.addItems(fileBuilder.build());
+    }
+    if (readProperties != null && !readProperties.isEmpty()) {
+      localFilesBuilder.putAllReadProperties(readProperties);
     }
     return localFilesBuilder.build();
   }

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -111,6 +111,12 @@ message ReadRel {
     repeated FileOrFiles items = 1;
     substrait.extensions.AdvancedExtension advanced_extension = 10;
 
+    // Table-scoped storage properties the native reader needs to open the
+    // listed files, e.g. the S3 credentials an Iceberg REST catalog vends for
+    // one table. A LocalFiles is single-table by construction, so table
+    // granularity is split granularity. Emitted only when present.
+    map<string, string> read_properties = 11;
+
     // Many files consist of indivisible chunks (e.g. parquet row groups
     // or CSV rows).  If a slice partially selects an indivisible chunk
     // then the consumer should employ some rule to decide which slice to

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -154,6 +154,12 @@ trait BackendSettingsApi {
 
   def supportIcebergInitialDefaultRead(): Boolean = false
 
+  /**
+   * Whether the backend reads the files of an Iceberg table with the credentials the catalog vended
+   * for it, carried in LocalFiles.read_properties.
+   */
+  def supportIcebergVendedCredentialsRead(): Boolean = false
+
   def reorderColumnsForPartitionWrite(): Boolean = false
 
   def enableEnhancedFeatures(): Boolean = false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #12701: make native scans work for Iceberg tables read through a REST
catalog that vends credentials (`X-Iceberg-Access-Delegation: vended-credentials`,
e.g. Apache Polaris).

`loadTable` returns credentials scoped to one table and only the JVM `FileIO`
ever sees them. The native scan path receives file paths only, so Velox's S3
client falls back to the process credential chain — which by design has no
access to the warehouse — and every native `TableScan` of such a table dies with
S3 403 (`S3ReadFile.cpp preadInternal: Failed to get S3 object due to: 'Access
denied'`) while the same query reads fine on vanilla Spark.

**JVM side.** At split planning, read the scan table's `FileIO.properties()`;
when a vended access-key/secret pair is present, carry it (plus session
token/expiry/endpoint/region companions) together with the table location in a
new table-scoped `ReadRel.LocalFiles.read_properties` map. A `LocalFiles` is
single-table by construction, so table granularity is split granularity.
`FileIO.properties()` is implemented by `S3FileIO`/`ResolvingFileIO` and defaults
to throwing, which is treated as "no credentials". Tables whose files the process
credentials can read (e.g. Glue-catalog tables) attach nothing and are untouched.

**Native side.** `parseScanSplitInfo` copies the map onto `SplitInfo`, and
`WholeStageResultIterator` unions the task's scans into a `GlutenS3TokenProvider`
installed on the `QueryCtx` as the file system token provider. Resolution is a
segment-boundary-safe longest-prefix match of the file path against the
normalized table locations, so a query joining two vended-credential tables that
live in the same bucket cannot mix them up, and a table nested inside another
table's location still gets its own credentials. `equals()`/`hash()` cover all
credentials because they key Velox's file handle cache — a re-vended credential
set can never be served a handle opened with the set it replaced. When no scan
carries credentials the provider is `nullptr`, i.e. behaviour is unchanged.

Velox already threads `ConnectorQueryCtx::fsTokenProvider()` into every data-file
and delete-file open through `FileHandleKey` and `FileOptions`.

**New config.** `spark.gluten.sql.columnar.iceberg.enableVendedCredentials`
(default `true`). When disabled, scans of tables read with vended credentials
fail native validation and fall back to vanilla Spark, which reads them
correctly through the JVM `FileIO` — a working escape hatch rather than a
degraded one.

**Backend gate.** Consuming `read_properties` is a Velox-backend capability, so
validation also requires the new
`BackendSettingsApi.supportIcebergVendedCredentialsRead()` (default `false`,
`true` for Velox). Without it a ClickHouse-backend scan of a vended-credential
table would keep failing with access-denied errors; now it falls back to vanilla
Spark and reads correctly. Please shout if you would rather the ClickHouse
backend also implement this — the JVM half is backend-agnostic and already emits
the map.

### Dependency on a Velox PR

The native half needs the S3 file system to consume
`FileOptions::tokenProvider`, which no file system does today (only ABFS and GCS
have token-provider paths, and neither uses `FileOptions`). That is
[facebookincubator/velox#18570](https://github.com/facebookincubator/velox/pull/18570),
which adds `S3AccessTokenKey`/`S3AccessToken` and a per-credential client cache
in `S3FileSystem`.

The second commit here (`[MINOR]`) points `UPSTREAM_VELOX_PR_ID` at that PR so
CI can build this one, and **must be reverted before merge**, once the Velox
change is merged and the pin is advanced past it. Happy to split this PR into
the JVM half and the native half if you would rather land them separately.

### Notes for reviewers

- Credentials ride the substrait split payload to executors, i.e. the same trust
  plane as the broadcast Hadoop conf. Say the word if you would prefer the
  config to default to `false` (opt-in) instead.
- Credentials are snapshotted on the driver, so a scan has to start within the
  lifetime of the vended credentials; executors cannot re-vend. A 403 on expiry
  stays a retriable task failure. Refresh-on-open is a follow-up — this is the
  same staging `apache/datafusion-comet` used for the same problem
  (comet#3523 static extraction, then comet#4309 pluggable refresh).

## How was this patch tested?

New unit tests. The JVM ones pass locally on JDK 17 with
`-Pbackends-velox,spark-3.5,iceberg` and the scalastyle/spotless gates live
(`dev/format-scala-code.sh check` is clean):

- `GlutenIcebergSourceUtilSuite` (3 tests) — the credential set is extracted with
  its location and companions and nothing else; a table without a vended
  access-key/secret pair extracts nothing; the session token is optional.
- `IcebergLocalFilesNodeReadPropertiesTest` (2 tests) — the map round-trips into
  `ReadRel.LocalFiles.read_properties`, and a split without credentials emits no
  `read_properties`.
- `GlutenS3TokenProviderTest` (5 tests, `ENABLE_S3`, not run locally — no Velox
  build environment on hand, so these are on CI) — no provider without
  credentials or from an incomplete set; per-table resolution for two tables in
  one bucket; longest-prefix wins for nested locations; a string-prefix table
  name is not a match; identity covers all credentials; scheme normalization.

Also covered by the Velox PR's Minio-backed tests, which prove that
provider-supplied credentials are the ones used to open the file.

End to end, this patch set (backported to 1.6.0) has been running Iceberg reads
against Apache Polaris with STS credential vending on Spark 3.5.2 in production,
on both arm64 and x86_64: native `TableScan` of vended-credential tables reads
with the vended credentials instead of 403ing, and row-level parity against
vanilla Spark holds.
