### PR TITLE
[GLUTEN-12377][CI] Stop quarantining the Delta DV row-index failures

### DIFF
--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -182,10 +182,10 @@ and blank lines allowed:
 ### Quarantine by error signature
 
 Some bugs surface on a **different test each run** — for example the native Delta
-DV bitmap row-index error (the aggregator gets a garbage row index during a MERGE
-that writes deletion vectors and aborts, e.g. `Delta RoaringBitmapArray row index
+DV bitmap row-index error (the aggregator got a garbage row index during a MERGE
+that writes deletion vectors and aborted, e.g. `Delta RoaringBitmapArray row index
 ... exceeds max representable value` or `Delta bitmap row index cannot be
-negative: ...`) lands on a different `*DVs*Suite` MERGE test every time. Chasing
+negative: ...`) landed on a different `*DVs*Suite` MERGE test every time. Chasing
 those by name is whack-a-mole, so quarantine them by **root cause** in
 **`flaky-error-patterns.txt`** instead: each line is a regex matched against a
 failed test's `<failure>`/`<error>` text. Any failure that matches is treated as
@@ -198,6 +198,11 @@ list so it can't leak into the baseline):
 Delta RoaringBitmapArray row index \d+ exceeds max representable value
 Delta bitmap row index cannot be negative: -?\d+
 ```
+
+That example is historical: the root cause was a Velox scan bug
+([velox#18535](https://github.com/facebookincubator/velox/issues/18535)), fixed
+upstream, so both patterns have since been removed and the suite is enforced
+again. It is kept here because it shows the shape of the mechanism.
 
 This is more precise than a name glob: a *different* real failure in the same
 suite is still caught, because only failures carrying the signature are ignored.

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -193,18 +193,20 @@ flaky regardless of which test it hit (and is dropped from the shard's failures
 list so it can't leak into the baseline):
 
 ```
+# HISTORICAL EXAMPLE -- no longer active; flaky-error-patterns.txt has no
+# entries. Do not copy these back in: the bug they matched is fixed.
 # regex matched against the failure message + stack (enforce mode).
 # one explicit pattern per known error, deliberately specific.
 Delta RoaringBitmapArray row index \d+ exceeds max representable value
 Delta bitmap row index cannot be negative: -\d+
 ```
 
-That example is historical: the root cause was a Velox scan bug
+The root cause was a Velox scan bug
 ([velox#18535](https://github.com/facebookincubator/velox/issues/18535)), fixed
 by [velox#18536](https://github.com/facebookincubator/velox/pull/18536) and
 picked up by the `dft-2026_08_21` Velox pin, so both patterns were removed and
-the suite is enforced again. It is kept here because it shows the shape of the
-mechanism.
+the suite is enforced again. The example is kept because it shows the shape of
+the mechanism.
 
 This is more precise than a name glob: a *different* real failure in the same
 suite is still caught, because only failures carrying the signature are ignored.

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -196,13 +196,15 @@ list so it can't leak into the baseline):
 # regex matched against the failure message + stack (enforce mode).
 # one explicit pattern per known error, deliberately specific.
 Delta RoaringBitmapArray row index \d+ exceeds max representable value
-Delta bitmap row index cannot be negative: -?\d+
+Delta bitmap row index cannot be negative: -\d+
 ```
 
 That example is historical: the root cause was a Velox scan bug
 ([velox#18535](https://github.com/facebookincubator/velox/issues/18535)), fixed
-upstream, so both patterns have since been removed and the suite is enforced
-again. It is kept here because it shows the shape of the mechanism.
+by [velox#18536](https://github.com/facebookincubator/velox/pull/18536) and
+picked up by the `dft-2026_08_21` Velox pin, so both patterns were removed and
+the suite is enforced again. It is kept here because it shows the shape of the
+mechanism.
 
 This is more precise than a name glob: a *different* real failure in the same
 suite is still caught, because only failures carrying the signature are ignored.

--- a/.github/workflows/util/delta-spark-ut/flaky-error-patterns.txt
+++ b/.github/workflows/util/delta-spark-ut/flaky-error-patterns.txt
@@ -10,37 +10,5 @@
 # surfaces on a different test each run, so matching by test name is
 # whack-a-mole. Prefer fixing the underlying bug and REMOVING the entry.
 #
-# ---------------------------------------------------------------------------
-# Native Delta bitmap aggregator receives an INVALID row index during a MERGE
-# that writes deletion vectors, and aborts. The garbage row index trips one of
-# two bounds checks, so the same root cause shows up with two messages:
-#
-#   too large (Long.MAX_VALUE):
-#     VeloxRuntimeError INVALID_STATE
-#     Reason: Delta RoaringBitmapArray row index 9223372036854775807 exceeds max
-#             representable value 9223372030412324864
-#     Expression: value <= kMaxRepresentableValue
-#     Function: addSafe  File: .../velox/compute/delta/RoaringBitmapArray.cpp:92
-#
-#   negative (garbage):
-#     VeloxRuntimeError INVALID_STATE
-#     Reason: Delta bitmap row index cannot be negative: -6254810385378525259
-#     Expression: value >= 0
-#     Function: addRowIndex  File: .../operators/functions/delta/DeltaBitmapAggregator.cc:44
-#
-# Both are the same root cause (garbage row index into the DV bitmap aggregator)
-# but distinct native errors, so each has its own explicit pattern below --
-# deliberately specific (bound to the exact error string) rather than a broad
-# "Delta bitmap row index" match, to avoid masking an unrelated failure. Add a
-# new line if a further bounds-check variant appears. Intermittent (depends on
-# the runtime plan/scan/scheduling), so it hits a different *DVs*Suite MERGE test
-# on each run. Remove these once the row-index materialization is fixed in the
-# native backend. Tracked upstream (DV bitmap invalid row index).
-# ---------------------------------------------------------------------------
-# too-large (Long.MAX_VALUE) -- RoaringBitmapArray.cpp addSafe, value <= kMaxRepresentableValue
-Delta RoaringBitmapArray row index \d+ exceeds max representable value
-# negative garbage -- DeltaBitmapAggregator.cc addRowIndex, value >= 0
-# The check is `value >= 0`, so the reported index is always negative: match the
-# sign explicitly rather than `-?` so this can't quarantine an unrelated failure
-# if the message format ever changes.
-Delta bitmap row index cannot be negative: -\d+
+# There are currently no quarantined error signatures. Add one below when a
+# nondeterministic bug starts landing on a different test each run.

--- a/.github/workflows/util/delta-spark-ut/flaky-tests.txt
+++ b/.github/workflows/util/delta-spark-ut/flaky-tests.txt
@@ -18,7 +18,5 @@
 #
 # NOTE: when a bug surfaces on a DIFFERENT test each run (so matching by name is
 # whack-a-mole), quarantine it by ERROR SIGNATURE in flaky-error-patterns.txt
-# instead. The native Delta DV bitmap row-index bug (RoaringBitmapArray
-# Long.MAX_VALUE) is handled there, which is why no `*DVs*Suite` MERGE entries
-# are listed below.
+# instead.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The Delta Spark UT gate quarantines two native error signatures:

```
Delta RoaringBitmapArray row index \d+ exceeds max representable value
Delta bitmap row index cannot be negative: -\d+
```

Both come from the native Delta bitmap aggregator receiving a garbage row index during a `MERGE` that writes deletion vectors. Because the abort landed on a different `*DVs*Suite` test each run, matching by test name was whack-a-mole, so it was quarantined by error signature instead.

The root cause was not in the aggregator, and not in Gluten. It was a Velox scan defect: in `SelectiveStructColumnReaderBase::next()`, the no-child-readers branch sized the result vector to `numValues` but sized the synthesized fields from `outputRows()`, which is empty when the scan has a filter and no deletion. The row-index child therefore came back with zero rows inside a `RowVector` reporting N. `BaseVector::wrapInDictionary()` does not bounds-check indexes against the base, so downstream reads ran off the end of a zero-length buffer and returned whatever heap memory followed -- hence row indexes like `9223372036854775807`, `-1` and pointer-shaped values such as `0xe43315c000007f00`. Most were silently accepted; occasionally one failed the aggregator's bounds check and aborted the query.

Fixed upstream in facebookincubator/velox#18536 (facebookincubator/velox#18535), merged as `1f971d3`. The aggregator now receives real row indexes, so the suite can be enforced again.

This PR removes both patterns, plus the two cross-references that named them:

| file | change |
|---|---|
| `flaky-error-patterns.txt` | both patterns and their rationale block removed; the generic header is kept so the mechanism stays documented |
| `flaky-tests.txt` | drops the note claiming the DV bug "is handled there, which is why no `*DVs*Suite` MERGE entries are listed below" -- no longer true |
| `README.md` | keeps the worked example, marked historical and linked to the upstream issue, since it documents how signature quarantine works |

**Merge dependency -- satisfied.** This needed the Velox pin to contain `1f971d3`. Gluten now pins `dft-2026_08_21`, which does, and this branch is rebased onto that bump, so the PR is ready to merge.

Fixes #12377

## How was this patch tested?

The Delta Spark UT runs on this PR: `.github/workflows/util/delta-spark-ut/**` is in the workflow's `paths:` filter. With the patterns removed, a DV abort is now counted as a regression instead of being dropped.

**A green run here is weak evidence on its own.** The abort is intermittent -- that is precisely why it was quarantined by signature rather than by test name -- so the suite can pass on a given run whether or not the Velox fix is present. Red would be informative (the bug still fires); green would not prove much. The dependable check is simply whether the pinned Velox tag contains `1f971d3`; `dft-2026_08_21` does.

This PR demonstrated that caveat by accident. Its first run, before the rebase, went **8 of 8 green while building `dft-2026_08_17`** -- a tag that does *not* contain the fix. So a fully green Delta suite says nothing about whether the bug is present. The current run is against the fixed pin.

The fix itself was therefore validated separately, by making the failure deterministic instead of relying on chance. Two throwaway PRs enabled Velox's `debug.validate_output_from_operators` across the Delta suite, which turns the malformed vector into an immediate, reproducible error:

* #12783 -- validation on, stock Velox: **6 of 8 shards failed**, `Child vector has size 0 less than parent and parent has no nulls`.
* #12808 -- identical, plus `UPSTREAM_VELOX_PR_ID=18536`: **8 of 8 shards green**.

That A/B, not this PR's own run, is the evidence that the row indexes were corrupt and that velox#18536 fixes them.

Upstream, the fix carries two regression tests in `TableScanTest`, covering both ways the branch is reached: `rowIndexWithFilterOnPartitionKeyOnly` (static subfield filter) and `rowIndexWithDynamicFilterOnPartitionKey` (no filter in the plan; a join on the partition key supplies a dynamic filter at runtime). Both fail before the fix and pass after it.

Locally, `compare-test-results.py` was exercised against the edited file: `load_patterns()` returns `[]`, and the signature matcher returns `False` for the old DV error -- i.e. such a failure is now enforced rather than ignored.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI (Claude Opus 5)