### PR TITLE
[GLUTEN-12711][VL] Support overriding S3 TLS CA bundle path via hive.s3.ssl.ca-file / SSL_CERT_FILE

### DIFF
--- a/cpp/velox/utils/ConfigExtractor.cc
+++ b/cpp/velox/utils/ConfigExtractor.cc
@@ -82,6 +82,7 @@ void getS3HiveConfig(
       {S3Config::Keys::kIamRoleSessionName, std::make_pair("iam.role.session.name", "gluten-session")},
       {S3Config::Keys::kEndpointRegion, std::make_pair("endpoint.region", std::nullopt)},
       {S3Config::Keys::kIMDSEnabled, std::make_pair("aws.imds.enabled", "true")},
+      {S3Config::Keys::kSSLCAFile, std::make_pair("ssl.ca-file", std::nullopt)},
   };
 
   // get Velox S3 config key from Spark Suffix.
@@ -144,6 +145,11 @@ void getS3HiveConfig(
   setConfigIfPresent(S3Config::Keys::kConnectTimeout);
   setConfigIfPresent(S3Config::Keys::kEndpointRegion);
   setConfigIfPresent(S3Config::Keys::kIMDSEnabled);
+  // See apache/gluten#12711: allows overriding the TLS CA bundle used to
+  // verify S3 endpoints via `spark.hadoop.fs.s3a.ssl.ca-file`, in addition
+  // to the SSL_CERT_FILE environment variable fallback handled directly in
+  // Velox's S3FileSystem.
+  setConfigIfPresent(S3Config::Keys::kSSLCAFile);
 
   hiveConfMap[S3Config::kS3LogLevel] = conf->get<std::string>(kVeloxAwsSdkLogLevel, kVeloxAwsSdkLogLevelDefault);
   hiveConfMap[S3Config::baseConfigKey(S3Config::Keys::kUseProxyFromEnv)] =

--- a/docs/get-started/VeloxS3.md
+++ b/docs/get-started/VeloxS3.md
@@ -88,6 +88,43 @@ Error: PermanentRedirect — The bucket you are attempting to access must be add
 spark.hadoop.fs.s3a.endpoint=s3.us-west-2.amazonaws.com
 ```
 
+# Known Issue: Native S3 Access Hangs on Non-RHEL-Family Runtime Images (Hardcoded CA Bundle Path)
+
+With `spark.gluten.sql.columnar.batchscan=true` (native scan enabled), a query reading from an S3-compatible
+object store may hang indefinitely with no error or exception in the driver or executor logs. Disabling Gluten
+(`spark.gluten.enabled=false`), or falling back to the JVM S3A path (`batchscan=false`), makes the exact same
+query complete normally. See [#10670](https://github.com/apache/gluten/issues/10670) and
+[#12711](https://github.com/apache/gluten/issues/12711) for the original reports.
+
+**Root cause:** Gluten's official/nightly native library (`libvelox.so`) is built on a RHEL-family OS
+(CentOS/Rocky Linux) with statically-linked HTTP client libraries (libcurl/OpenSSL, e.g. via vcpkg). These bake
+in a compile-time default CA bundle path, the RHEL-family location `/etc/pki/tls/certs/ca-bundle.crt`. On a
+different runtime distribution (e.g. Debian/Ubuntu, where the CA bundle lives at
+`/etc/ssl/certs/ca-certificates.crt`), that path does not exist, the native TLS handshake fails (`curlCode:
+77`), and an internal retry loop kicks in — which looks exactly like a silent hang from Spark's point of view.
+Plain `SSL_CERT_FILE`/`CURL_CA_BUNDLE` environment variables do **not** help on their own, since they are not
+read automatically by the native curl call inside the AWS SDK C++ layer.
+
+**Fix 1 (no rebuild required):** symlink the RHEL-family path to your runtime image's actual CA bundle at image
+build time, e.g. in your Dockerfile:
+
+```dockerfile
+RUN mkdir -p /etc/pki/tls/certs && \
+    ln -sf /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
+```
+
+**Fix 2 (config-driven, no symlink needed):** set the CA bundle path explicitly via the
+`spark.hadoop.fs.s3a.ssl.ca-file` config, or via the `SSL_CERT_FILE` environment variable on the executor/driver
+if you'd rather not add a Spark config:
+
+```properties
+spark.hadoop.fs.s3a.ssl.ca-file=/etc/ssl/certs/ca-certificates.crt
+```
+
+Either setting is passed through to `Aws::Client::ClientConfiguration::caFile`, the AWS SDK C++'s documented
+mechanism for overriding the TLS CA bundle (it flows through to libcurl's `CURLOPT_CAINFO`). If neither is set,
+Velox falls back to the HTTP client's compiled-in default path, preserving existing behavior.
+
 # Local Caching support
 
 Velox supports a local cache when reading data from S3 but not strictly tested and there are several limitations. Please refer [Velox Local Cache](VeloxLocalCache.md) part for more detailed configurations.
@@ -188,6 +225,7 @@ Gluten new parameters:
 | iam.role.session.name | gluten-session |
 | endpoint.region | (none) |
 | aws.imds.enabled | true |
+| ssl.ca-file | (none) |
 
 Gluten configures:
 | Name | Default Value | 

--- a/ep/build-velox/src/get-velox.sh
+++ b/ep/build-velox/src/get-velox.sh
@@ -162,6 +162,23 @@ function apply_compilation_fixes {
   git add ${VELOX_HOME}/CMake/resolve_dependency_modules/arrow/modify_arrow.patch # to avoid the file from being deleted by git clean -dffx :/
 }
 
+# Adds an 'hive.s3.ssl.ca-file' config (falling back to the SSL_CERT_FILE env
+# var) so the S3 client's TLS CA bundle path can be overridden at runtime
+# instead of relying solely on the HTTP client's compiled-in default path.
+# See apache/gluten#12711 for the underlying problem this addresses: a
+# statically-built libcurl/OpenSSL (e.g. via vcpkg on Rocky/CentOS) bakes in
+# a compile-time default CA bundle path that may not exist on a different
+# runtime OS.
+function apply_s3_ssl_ca_override_patch {
+  pushd $VELOX_HOME
+  (git apply --check ${CURRENT_DIR}/s3-ssl-ca-override.patch && \
+   git apply ${CURRENT_DIR}/s3-ssl-ca-override.patch) || {
+    echo "Failed to apply s3-ssl-ca-override.patch"
+    exit 1
+  }
+  popd
+}
+
 function setup_linux {
   local LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})
   local LINUX_VERSION_ID=$(. /etc/os-release && echo ${VERSION_ID})
@@ -242,6 +259,8 @@ if [[ "$RUN_SETUP_SCRIPT" == "ON" ]]; then
 fi
 
 apply_provided_velox_patch
+
+apply_s3_ssl_ca_override_patch
 
 apply_compilation_fixes
 

--- a/ep/build-velox/src/s3-ssl-ca-override.patch
+++ b/ep/build-velox/src/s3-ssl-ca-override.patch
@@ -1,0 +1,70 @@
+--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
++++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+@@ -78,6 +78,7 @@
+     kCredentialsProvider,
+     kIMDSEnabled,
+     kMultipartMinPartSize,
++    kSSLCAFile,
+     kEnd
+   };
+ 
+@@ -119,6 +120,7 @@
+             {Keys::kIMDSEnabled, std::make_pair("aws-imds-enabled", "true")},
+             {Keys::kMultipartMinPartSize,
+              std::make_pair("min-part-size", "10MB")},
++            {Keys::kSSLCAFile, std::make_pair("ssl.ca-file", std::nullopt)},
+         };
+     return config;
+   }
+@@ -254,6 +256,15 @@
+     return folly::to<bool>(value);
+   }
+ 
++  /// Custom CA bundle file path used to verify the S3 endpoint's TLS
++  /// certificate, overriding the HTTP client's compiled-in default trust
++  /// store location. If not set, S3FileSystem falls back to the
++  /// SSL_CERT_FILE environment variable before using the compiled-in
++  /// default.
++  std::optional<std::string> sslCAFile() const {
++    return config_.find(Keys::kSSLCAFile)->second;
++  }
++
+   size_t minPartSize() const;
+ 
+  private:
+--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
++++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+@@ -27,6 +27,7 @@
+ 
+ #include <fmt/format.h>
+ #include <glog/logging.h>
++#include <cstdlib>
+ #include <memory>
+ #include <stdexcept>
+ 
+@@ -239,6 +240,25 @@
+         Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
+     clientConfig.checksumConfig.responseChecksumValidation =
+         Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
++
++    // Allow overriding the TLS CA bundle used to verify S3 endpoints.
++    // HTTP client libraries built via static toolchains (e.g. vcpkg) bake
++    // in a compile-time default CA bundle path (for example the RHEL-family
++    // path when built on Rocky/CentOS), which may not exist on a different
++    // runtime OS (e.g. a Debian/Ubuntu container), causing TLS handshake
++    // failures despite the system otherwise having a valid, working CA
++    // bundle elsewhere. Prefer an explicit 'hive.s3.ssl.ca-file' config;
++    // otherwise fall back to the widely-used SSL_CERT_FILE environment
++    // variable convention (also respected by OpenSSL, the curl CLI,
++    // Python, Node.js, etc.), so a runtime image only needs to set one
++    // environment variable to point at its actual CA bundle location,
++    // without requiring a Velox/Spark config change.
++    if (s3Config_->sslCAFile().has_value()) {
++      clientConfig.caFile = awsString(s3Config_->sslCAFile().value());
++    } else if (const char* envCAFile = std::getenv("SSL_CERT_FILE")) {
++      clientConfig.caFile = envCAFile;
++    }
++
+     if (s3Config_->endpoint().has_value()) {
+       clientConfig.endpointOverride = s3Config_->endpoint().value();
+     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Gluten's official/nightly `libvelox.so` is built on a RHEL-family OS (CentOS/Rocky Linux) with statically-linked HTTP client libraries (libcurl/OpenSSL via vcpkg), which bake in a compile-time default TLS CA bundle path (`/etc/pki/tls/certs/ca-bundle.crt`). On a non-RHEL-family runtime image (e.g. Debian/Ubuntu, where the CA bundle instead lives at `/etc/ssl/certs/ca-certificates.crt`), that path does not exist. As a result, the native S3 client's TLS handshake fails silently (`curlCode: 77`), and an internal retry loop makes the query look like an indefinite hang with no JVM-visible exception. See #10670 for the original report and #12711 for further diagnosis.

A Dockerfile symlink workaround already exists and requires no source change, but this PR instead makes the CA bundle path configurable at runtime, so no image changes are needed either.

Since Velox itself lives in a separate repository (`IBM/velox`, fetched during `get-velox.sh`) rather than in this repository, the fix is carried as a source patch applied to the fetched Velox tree, following the same pattern already used for `modify_arrow.patch`:

- `ep/build-velox/src/s3-ssl-ca-override.patch`: adds a new Hive connector config, `hive.s3.ssl.ca-file`, with a matching `S3Config::sslCAFile()` getter. At the single `S3Client` construction point shared by both the read and write paths, it sets `Aws::Client::ClientConfiguration::caFile` — the documented AWS SDK C++ mechanism for overriding the TLS CA bundle, which flows through to libcurl's `CURLOPT_CAINFO` — from `hive.s3.ssl.ca-file` if set, otherwise falling back to the `SSL_CERT_FILE` environment variable (a convention also respected by OpenSSL, curl, Python, Node.js, etc.), before finally falling back to the HTTP client's compiled-in default. There is no behavior change if neither is set.
- `ep/build-velox/src/get-velox.sh`: applies the new patch during Velox source preparation.
- `cpp/velox/utils/ConfigExtractor.cc`: passes `hive.s3.ssl.ca-file` through from the new `spark.hadoop.fs.s3a.ssl.ca-file` Spark config, so it can be set without relying solely on the `SSL_CERT_FILE` environment variable fallback.
- `docs/get-started/VeloxS3.md`: documents the symptom, root cause, and both the image-level symlink workaround and this config-driven fix.

Addresses #12711.

## How was this patch tested?

Verified on a base image with no CA-bundle symlink applied, running a native Iceberg-on-S3 `GROUP BY` query (single partition, ~27k Parquet files) against S3-compatible object storage:

- With neither `hive.s3.ssl.ca-file` nor `SSL_CERT_FILE` set, the query reliably hung for 240+ seconds with no error, reproducing the symptom in #10670 and #12711.
- With the identical build, query, and native execution plan (confirmed via `numFallbackNodes == 0`), but the CA bundle path set via `SSL_CERT_FILE`, the same query consistently completed in ~43-44 seconds across repeated runs, returning identical, correct results.

No existing tests were affected, since `clientConfig.caFile` is only set when `hive.s3.ssl.ca-file` or `SSL_CERT_FILE` is present; otherwise the compiled-in default path is used exactly as before.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenCode claude-sonnet-5