### PR TITLE
[GLUTEN-12597][CORE] Remodel Kafka read onto ReadRel.ExtensionTable (Substrait 0.98)

### DIFF
--- a/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/clickhouse/ExtensionTableNode.java
+++ b/backends-clickhouse/src/main/java/org/apache/spark/sql/execution/datasources/clickhouse/ExtensionTableNode.java
@@ -16,8 +16,8 @@
  */
 package org.apache.spark.sql.execution.datasources.clickhouse;
 
-import org.apache.gluten.backendsapi.BackendsApiManager;
 import org.apache.gluten.substrait.rel.SplitInfo;
+import org.apache.gluten.utils.SubstraitUtil;
 
 import com.google.protobuf.StringValue;
 import io.substrait.proto.ReadRel;
@@ -59,10 +59,6 @@ public class ExtensionTableNode implements SplitInfo {
   }
 
   public static ReadRel.ExtensionTable toProtobuf(String result) {
-    ReadRel.ExtensionTable.Builder extensionTableBuilder = ReadRel.ExtensionTable.newBuilder();
-    StringValue extensionTable = StringValue.newBuilder().setValue(result).build();
-    extensionTableBuilder.setDetail(
-        BackendsApiManager.getTransformerApiInstance().packPBMessage(extensionTable));
-    return extensionTableBuilder.build();
+    return SubstraitUtil.packExtensionTable(StringValue.newBuilder().setValue(result).build());
   }
 }

--- a/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/ReadRelParser.cpp
@@ -35,6 +35,7 @@
 #include <Storages/SubstraitSource/SubstraitFileSourceStep.h>
 #include <google/protobuf/wrappers.pb.h>
 #include <rapidjson/document.h>
+#include <kafka.pb.h>
 #include <Common/BlockTypeUtils.h>
 #include <Common/DebugUtils.h>
 
@@ -122,7 +123,8 @@ bool ReadRelParser::isReadRelFromLocalFile(const substrait::ReadRel & rel)
     if (rel.has_local_files())
         return !isReadRelFromJavaIter(rel);
     else
-        return !rel.has_extension_table() && !isReadRelFromMergeTree(rel) && !isReadRelFromRange(rel) && !isReadFromStreamKafka(rel);
+        /// Kafka reads are identified by an extension table, so !has_extension_table() already excludes them.
+        return !rel.has_extension_table() && !isReadRelFromMergeTree(rel) && !isReadRelFromRange(rel);
 }
 
 bool ReadRelParser::isReadRelFromMergeTree(const substrait::ReadRel & rel)
@@ -161,7 +163,7 @@ bool ReadRelParser::isReadRelFromRange(const substrait::ReadRel & rel)
 
 bool ReadRelParser::isReadFromStreamKafka(const substrait::ReadRel & rel)
 {
-    return rel.has_stream_kafka() && rel.stream_kafka();
+    return rel.has_extension_table() && rel.extension_table().detail().Is<gluten::StreamKafka>();
 }
 
 DB::QueryPlanStepPtr ReadRelParser::parseReadRelWithJavaIter(const substrait::ReadRel & rel)

--- a/cpp-ch/local-engine/Parser/RelParsers/StreamKafkaRelParser.cpp
+++ b/cpp-ch/local-engine/Parser/RelParsers/StreamKafkaRelParser.cpp
@@ -20,7 +20,9 @@
 #include <Parser/SubstraitParserUtils.h>
 #include <Parser/TypeParser.h>
 #include <Storages/Kafka/ReadFromGlutenStorageKafka.h>
+#include <kafka.pb.h>
 #include <Common/BlockTypeUtils.h>
+#include <Common/DebugUtils.h>
 #include <Common/logger_useful.h>
 
 namespace DB
@@ -30,6 +32,7 @@ namespace ErrorCodes
 {
 extern const int NO_SUCH_DATA_PART;
 extern const int LOGICAL_ERROR;
+extern const int CANNOT_PARSE_PROTOBUF_SCHEMA;
 extern const int UNKNOWN_FUNCTION;
 extern const int UNKNOWN_TYPE;
 }
@@ -50,10 +53,19 @@ StreamKafkaRelParser::parse(DB::QueryPlanPtr query_plan, const substrait::Rel & 
 
 DB::QueryPlanPtr StreamKafkaRelParser::parseRelImpl(DB::QueryPlanPtr query_plan, const substrait::ReadRel & read_rel)
 {
-    if (!read_rel.has_stream_kafka())
-        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Can't not parse kafka rel, because of read rel don't contained stream kafka");
+    if (split_info.empty())
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Can't parse kafka rel, because no split info was supplied for it");
 
-    auto kafka_task = BinaryToMessage<substrait::ReadRel::StreamKafka>(split_info);
+    auto extension_table = BinaryToMessage<substrait::ReadRel::ExtensionTable>(split_info);
+    debug::dumpMessage(extension_table, "extension_table");
+
+    gluten::StreamKafka kafka_task;
+    if (!extension_table.detail().UnpackTo(&kafka_task))
+        throw DB::Exception(
+            DB::ErrorCodes::CANNOT_PARSE_PROTOBUF_SCHEMA,
+            "Can't parse kafka rel, expected an extension table detail of type gluten.StreamKafka but got '{}'",
+            extension_table.detail().type_url());
+
     auto topic = kafka_task.topic_partition().topic();
     auto partition = kafka_task.topic_partition().partition();
     auto start_offset = kafka_task.start_offset();

--- a/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
+++ b/cpp-ch/local-engine/Parser/SerializedPlanParser.cpp
@@ -270,6 +270,12 @@ QueryPlanPtr SerializedPlanParser::parseOp(const substrait::Rel & rel, std::list
         }
         else if (read_rel_parser->isReadFromStreamKafka(read))
         {
+            /// Unlike MergeTree/Range above, a Kafka read is *identified* by an in-plan extension_table
+            /// (its detail's type_url is gluten.StreamKafka), so has_extension_table() is always true here
+            /// yet the real per-partition payload still rides split-info -- we must consume a split
+            /// unconditionally. Do NOT add a `!read.has_extension_table()` guard like the siblings have:
+            /// that would stop split_info_index from advancing and hand later leaves the wrong split.
+            chassert(read.has_extension_table());
             read_rel_parser->setSplitInfo(nextSplitInfo());
         }
     }

--- a/cpp-ch/local-engine/proto/CMakeLists.txt
+++ b/cpp-ch/local-engine/proto/CMakeLists.txt
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-file(GLOB protobuf_files ./*.proto substrait/*.proto
+file(GLOB protobuf_files CONFIGURE_DEPENDS ./*.proto substrait/*.proto
      substrait/extensions/*.proto)
 
 foreach(FIL ${protobuf_files})

--- a/cpp-ch/local-engine/proto/kafka.proto
+++ b/cpp-ch/local-engine/proto/kafka.proto
@@ -1,0 +1,1 @@
+../../../gluten-core/src/main/resources/org/apache/gluten/proto/kafka.proto

--- a/docs/developers/SubstraitModifications.md
+++ b/docs/developers/SubstraitModifications.md
@@ -35,7 +35,6 @@ changed `Unbounded` in `WindowFunction` into `Unbounded_Preceding` and `Unbounde
 * Added `TopNRel` ([#5409](https://github.com/apache/gluten/pull/5409)).
 * Added `ref` field in window bound `Preceding` and `Following` ([#5626](https://github.com/apache/gluten/pull/5626)).
 * Added `BucketSpec` field in `WriteRel`([#8386](https://github.com/apache/gluten/pull/8386))
-* Added `StreamKafka` in `ReadRel`([#8321](https://github.com/apache/gluten/pull/8321))
 * Rebased the `WriteRel` body onto upstream `v0.98.0`: field 7 is now `common`, with `create_mode` (8) and
 `advanced_extension` (9) added, and the `OutputMode` value `OUTPUT_MODE_MODIFIED_TUPLES` renamed to
 `OUTPUT_MODE_MODIFIED_RECORDS`. Gluten's `BucketSpec` field moved off field 7 to 1000. The enclosing

--- a/gluten-core/src/main/resources/org/apache/gluten/proto/kafka.proto
+++ b/gluten-core/src/main/resources/org/apache/gluten/proto/kafka.proto
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+syntax = "proto3";
+
+package gluten;
+
+option java_package = "org.apache.gluten.proto";
+option java_multiple_files = true;
+
+// Kafka streaming-source payloads for Gluten's ClickHouse backend. A payload is
+// packed into a `google.protobuf.Any` and carried in the official
+// `substrait.ReadRel.ExtensionTable.detail` field; the native consumer
+// discriminates a Kafka read by the `Any`'s type_url (`gluten.StreamKafka`).
+
+// Streaming Kafka source, used for KafkaBatch / KafkaContinuous reads.
+// Produced per-partition as the detail of a ReadRel.ExtensionTable.
+message StreamKafka {
+  message TopicPartition {
+    string topic = 1;
+    int32 partition = 2;
+  }
+
+  TopicPartition topic_partition = 1;
+  int64 start_offset = 2;
+  int64 end_offset = 3;
+  map<string, string> params = 4;
+  int64 poll_timeout_ms = 5;
+  bool fail_on_data_loss = 6;
+  bool include_headers = 7;
+}

--- a/gluten-kafka/pom.xml
+++ b/gluten-kafka/pom.xml
@@ -52,6 +52,12 @@
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- For test -->
     <dependency>
@@ -86,12 +92,6 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/gluten-kafka/src/main/scala/org/apache/gluten/execution/MicroBatchScanExecTransformer.scala
+++ b/gluten-kafka/src/main/scala/org/apache/gluten/execution/MicroBatchScanExecTransformer.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.gluten.execution
 
+import org.apache.gluten.backendsapi.BackendsApiManager
+import org.apache.gluten.proto.StreamKafka
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.rel.{ReadRelNode, SplitInfo}
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
@@ -105,7 +107,13 @@ case class MicroBatchScanExecTransformer(
 
   override protected def doTransform(context: SubstraitContext): TransformContext = {
     val ctx = super.doTransform(context)
-    ctx.root.asInstanceOf[ReadRelNode].setStreamKafka(true)
+    // Mark this read as a Kafka stream by stamping an empty gluten.StreamKafka into the in-plan
+    // ReadRel.ExtensionTable. The native consumer discriminates on the detail's type_url; the real
+    // per-partition offsets/params still ride the split-info payload (see StreamKafkaSourceNode).
+    ctx.root
+      .asInstanceOf[ReadRelNode]
+      .setExtensionTableDetail(
+        BackendsApiManager.getTransformerApiInstance.packPBMessage(StreamKafka.getDefaultInstance))
     ctx
   }
 }

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/ReadRelNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/ReadRelNode.java
@@ -44,7 +44,7 @@ public class ReadRelNode implements RelNode, Serializable {
   private final List<ColumnTypeNode> columnTypeNodes = new ArrayList<>();
   private final ExpressionNode filterNode;
   private final AdvancedExtensionNode extensionNode;
-  private boolean streamKafka = false;
+  private Any extensionTableDetail;
 
   private BigInt rowCount;
   private InputStats inputStats;
@@ -78,8 +78,9 @@ public class ReadRelNode implements RelNode, Serializable {
     this.inputStats = inputStats;
   }
 
-  public void setStreamKafka(boolean streamKafka) {
-    this.streamKafka = streamKafka;
+  /** Sets the detail of the {@code read_type} oneof's {@code extension_table} member. */
+  public void setExtensionTableDetail(Any extensionTableDetail) {
+    this.extensionTableDetail = extensionTableDetail;
   }
 
   @Override
@@ -93,7 +94,11 @@ public class ReadRelNode implements RelNode, Serializable {
     ReadRel.Builder readBuilder = ReadRel.newBuilder();
     readBuilder.setCommon(relCommonBuilder.build());
     readBuilder.setBaseSchema(nStructBuilder.build());
-    readBuilder.setStreamKafka(streamKafka);
+
+    if (extensionTableDetail != null) {
+      readBuilder.setExtensionTable(
+          ReadRel.ExtensionTable.newBuilder().setDetail(extensionTableDetail).build());
+    }
 
     if (filterNode != null) {
       readBuilder.setFilter(filterNode.toProtobuf());

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/StreamKafkaSourceNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/StreamKafkaSourceNode.java
@@ -16,6 +16,9 @@
  */
 package org.apache.gluten.substrait.rel;
 
+import org.apache.gluten.proto.StreamKafka;
+import org.apache.gluten.utils.SubstraitUtil;
+
 import io.substrait.proto.ReadRel;
 
 import java.util.Collections;
@@ -59,11 +62,10 @@ public class StreamKafkaSourceNode implements SplitInfo {
   }
 
   @Override
-  public ReadRel.StreamKafka toProtobuf() {
-    ReadRel.StreamKafka.Builder builder = ReadRel.StreamKafka.newBuilder();
+  public ReadRel.ExtensionTable toProtobuf() {
+    StreamKafka.Builder builder = StreamKafka.newBuilder();
 
-    ReadRel.StreamKafka.TopicPartition.Builder topicPartition =
-        ReadRel.StreamKafka.TopicPartition.newBuilder();
+    StreamKafka.TopicPartition.Builder topicPartition = StreamKafka.TopicPartition.newBuilder();
     topicPartition.setTopic(topic);
     topicPartition.setPartition(partition);
 
@@ -75,6 +77,6 @@ public class StreamKafkaSourceNode implements SplitInfo {
     builder.setIncludeHeaders(includeHeaders);
     kafkaParams.forEach((k, v) -> builder.putParams(k, v.toString()));
 
-    return builder.build();
+    return SubstraitUtil.packExtensionTable(builder.build());
   }
 }

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -70,10 +70,6 @@ message ReadRel {
     NamedTable named_table = 7;
     ExtensionTable extension_table = 8;
     IcebergTable iceberg_table = 9;
-    // Gluten addition: streaming Kafka source. Relocated from field 9 to
-    // field 1000 so the official Substrait iceberg_table can occupy its
-    // 0.98 slot.
-    bool stream_kafka = 1000;
   }
 
   // A base table. The list of string is used to represent namespacing (e.g., mydb.mytable).
@@ -118,22 +114,6 @@ message ReadRel {
   // the specification.
   message ExtensionTable {
     google.protobuf.Any detail = 1;
-  }
-
-  // Used to KafkaBatch or KafkaContinuous source
-  message StreamKafka {
-    message TopicPartition {
-      string topic = 1;
-      int32 partition = 2;
-    }
-
-    TopicPartition topic_partition = 1;
-    int64 start_offset = 2;
-    int64 end_offset = 3;
-    map<string, string> params = 4;
-    int64 poll_timeout_ms = 5;
-    bool  fail_on_data_loss = 6;
-    bool include_headers = 7;
   }
 
   // Represents a list of files in input of a scan operation

--- a/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
+++ b/gluten-substrait/src/main/resources/substrait/proto/substrait/algebra.proto
@@ -69,7 +69,11 @@ message ReadRel {
     LocalFiles local_files = 6;
     NamedTable named_table = 7;
     ExtensionTable extension_table = 8;
-    bool stream_kafka = 9;
+    IcebergTable iceberg_table = 9;
+    // Gluten addition: streaming Kafka source. Relocated from field 9 to
+    // field 1000 so the official Substrait iceberg_table can occupy its
+    // 0.98 slot.
+    bool stream_kafka = 1000;
   }
 
   // A base table. The list of string is used to represent namespacing (e.g., mydb.mytable).
@@ -77,6 +81,29 @@ message ReadRel {
   message NamedTable {
     repeated string names = 1;
     substrait.extensions.AdvancedExtension advanced_extension = 10;
+  }
+
+  // Read an Iceberg Table
+  message IcebergTable {
+    oneof table_type {
+      MetadataFileRead direct = 1;
+      // future: add catalog table types (e.g. rest api, latest metadata in path, etc)
+    }
+
+    // Read an Iceberg table using a metadata file. Implicit assumption: required credentials are already known by plan consumer.
+    message MetadataFileRead {
+      // the specific uri of a metadata file (e.g. s3://mybucket/mytable/<ver>-<uuid>.metadata.json)
+      string metadata_uri = 1;
+
+      // snapshot options. if none set, uses the current snapshot listed in the metadata file
+      oneof snapshot {
+        // the snapshot id to read.
+        string snapshot_id = 2;
+
+        // the timestamp that should be used to select the snapshot (Time passed in microseconds since 1970-01-01 00:00:00.000000 in UTC)
+        int64 snapshot_timestamp = 3;
+      }
+    }
   }
 
   // A table composed of expressions.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/SubstraitPlanPrinterUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/SubstraitPlanPrinterUtil.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.gluten.utils
 
+import org.apache.gluten.proto.Kafka
+
 import org.apache.spark.internal.Logging
 
 import com.google.protobuf.WrappersProto
@@ -31,6 +33,9 @@ object SubstraitPlanPrinterUtil extends Logging {
       .newBuilder()
       .add(d)
       .add(defaultRegistry)
+      // Gluten's own payloads (e.g. StreamKafka) ride in Any fields of the Substrait plan, and
+      // nothing imports kafka.proto, so its messages are not reachable from the plan descriptor.
+      .add(Kafka.getDescriptor.getMessageTypes)
       .build()
   }
   private def MessageToJson(message: com.google.protobuf.Message): String = {

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/SubstraitUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/SubstraitUtil.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, FullOuter, InnerLike, JoinType, LeftAnti, LeftOuter, LeftSemi, RightOuter}
 
 import com.google.protobuf.{Any, DoubleValue, Int32Value, Int64Value, Message, StringValue}
-import io.substrait.proto.{JoinRel, NamedStruct, NestedLoopJoinRel, Type}
+import io.substrait.proto.{JoinRel, NamedStruct, NestedLoopJoinRel, ReadRel, Type}
 
 import java.lang.{Double => JDouble, Long => JLong}
 import java.util.{Collections, List => JList}
@@ -78,6 +78,14 @@ object SubstraitUtil {
     // so that it can be correctly parsed into JSON string on the cpp side.
     BackendsApiManager.getTransformerApiInstance.packPBMessage(
       TypeBuilder.makeStruct(false, inputTypeNodes.asJava).toProtobuf)
+  }
+
+  /** Wrap a Gluten payload as the detail of a Substrait `ReadRel.ExtensionTable`. */
+  def packExtensionTable(detail: Message): ReadRel.ExtensionTable = {
+    ReadRel.ExtensionTable
+      .newBuilder()
+      .setDetail(BackendsApiManager.getTransformerApiInstance.packPBMessage(detail))
+      .build()
   }
 
   def toSubstraitExpression(

--- a/gluten-substrait/src/test/scala/org/apache/gluten/substrait/rel/ReadRelProtoSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/substrait/rel/ReadRelProtoSuite.scala
@@ -21,12 +21,11 @@ import io.substrait.proto.ReadRel
 import org.scalatest.funsuite.AnyFunSuite
 
 /**
- * Pins the wire tags of the vendored `ReadRel.read_type` oneof after rebasing it onto upstream
- * Substrait v0.98.0: adding the official `iceberg_table = 9` and relocating Gluten's `stream_kafka`
- * graft off the field-9 collision into the 1000+ range. Producer and consumer share one schema, so
- * a renumber round-trips cleanly through the generated classes and cannot be caught by exercising
- * them; these assert on the descriptors instead. See docs/developers/SubstraitModifications.md for
- * the numbering convention.
+ * Pins the wire tags of the vendored `ReadRel.read_type` oneof to upstream Substrait v0.98.0,
+ * including the official `iceberg_table = 9`.
+ *
+ * Producer and consumer share one schema, so a renumber round-trips cleanly through the generated
+ * classes and cannot be caught by exercising them; these assert on the descriptors instead.
  */
 class ReadRelProtoSuite extends AnyFunSuite {
 
@@ -38,18 +37,15 @@ class ReadRelProtoSuite extends AnyFunSuite {
         assert(field.getNumber === number, s"${descriptor.getName} field $name changed its number")
     }
 
-  test("ReadRel.read_type field numbers match upstream v0.98.0 plus the relocated graft") {
+  test("ReadRel.read_type field numbers match upstream v0.98.0 verbatim") {
     assertFieldNumbers(
       ReadRel.getDescriptor,
       "virtual_table" -> 5,
       "local_files" -> 6,
       "named_table" -> 7,
       "extension_table" -> 8,
-      // Official Substrait 0.98 addition; must own field 9.
-      "iceberg_table" -> 9,
-      // Gluten-local graft, relocated off upstream's field 9 to the 1000+ range so that
-      // iceberg_table can take its 0.98 slot.
-      "stream_kafka" -> 1000
+      // Official Substrait 0.98 addition.
+      "iceberg_table" -> 9
     )
   }
 

--- a/gluten-substrait/src/test/scala/org/apache/gluten/substrait/rel/ReadRelProtoSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/gluten/substrait/rel/ReadRelProtoSuite.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.substrait.rel
+
+import com.google.protobuf.Descriptors.Descriptor
+import io.substrait.proto.ReadRel
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Pins the wire tags of the vendored `ReadRel.read_type` oneof after rebasing it onto upstream
+ * Substrait v0.98.0: adding the official `iceberg_table = 9` and relocating Gluten's `stream_kafka`
+ * graft off the field-9 collision into the 1000+ range. Producer and consumer share one schema, so
+ * a renumber round-trips cleanly through the generated classes and cannot be caught by exercising
+ * them; these assert on the descriptors instead. See docs/developers/SubstraitModifications.md for
+ * the numbering convention.
+ */
+class ReadRelProtoSuite extends AnyFunSuite {
+
+  private def assertFieldNumbers(descriptor: Descriptor, expected: (String, Int)*): Unit =
+    expected.foreach {
+      case (name, number) =>
+        val field = descriptor.findFieldByName(name)
+        assert(field != null, s"${descriptor.getName} has no field named $name")
+        assert(field.getNumber === number, s"${descriptor.getName} field $name changed its number")
+    }
+
+  test("ReadRel.read_type field numbers match upstream v0.98.0 plus the relocated graft") {
+    assertFieldNumbers(
+      ReadRel.getDescriptor,
+      "virtual_table" -> 5,
+      "local_files" -> 6,
+      "named_table" -> 7,
+      "extension_table" -> 8,
+      // Official Substrait 0.98 addition; must own field 9.
+      "iceberg_table" -> 9,
+      // Gluten-local graft, relocated off upstream's field 9 to the 1000+ range so that
+      // iceberg_table can take its 0.98 slot.
+      "stream_kafka" -> 1000
+    )
+  }
+
+  test("ReadRel.IcebergTable structure matches the vendored upstream layout") {
+    assertFieldNumbers(ReadRel.IcebergTable.getDescriptor, "direct" -> 1)
+    assertFieldNumbers(
+      ReadRel.IcebergTable.MetadataFileRead.getDescriptor,
+      "metadata_uri" -> 1,
+      "snapshot_id" -> 2,
+      "snapshot_timestamp" -> 3)
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Part of #12597.

This makes `ReadRel.read_type` verbatim upstream Substrait 0.98 by removing Gluten's last graft on it -- the `bool stream_kafka = 1000` discriminator and the nested `ReadRel.StreamKafka` message -- and remodels Gluten's ClickHouse Kafka streaming read onto the official `extension_table = 8` path, the same mechanism MergeTree and Range already use. `read_type` now matches upstream exactly, which never allocated field 1000, so the retired tag is not reserved.

The `StreamKafka` payload moves out of `algebra.proto` into a new Gluten-owned `kafka.proto` (`package gluten`, `org.apache.gluten.proto`), packed into a `google.protobuf.Any` and carried in `ReadRel.ExtensionTable.detail`. The native consumer discriminates a Kafka read by the detail's type_url via `detail().Is<gluten::StreamKafka>()` -- mirroring the already-merged Velox Iceberg idiom `enhancement().Is<gluten::IcebergReadExtension>()`. This `Any`-in-an-official-extension-field pattern is the preferred way to carry Gluten payloads going forward, rather than grafting new fields onto the vendored Substrait messages; `WriteRel.bucket_spec` (field 1000) remains the one legacy graft.

Compatibility: this is a JVM-producer + ClickHouse-consumer change with no wire-compatibility constraint -- Gluten plans are transient, and the JAR and native library are generated from one proto source and ship together. Two side effects are worth calling out. The Kafka split-info payload changes from a bare `StreamKafka` to a `ReadRel.ExtensionTable` wrapping it; and `read_type`, which the unconditional `stream_kafka` flag used to set on every `ReadRel`, is now left unset for non-Kafka scans (no native code reads `read_type_case`). A JAR and native library must therefore be rebuilt together. This path is ClickHouse-only -- Kafka has no Velox path.

Stacked on #12832 (the `iceberg_table` half of the `ReadRel.read_type` migration), whose commit appears in this diff until it merges; review this PR's second commit (`Remodel Kafka read onto ReadRel.ExtensionTable`) in isolation. It will be rebased onto `main` once #12832 lands.

## How was this patch tested?

Locally: standalone `protoc` confirms the post-delete `read_type` oneof is well-formed and that the relocated `gluten.StreamKafka` generates cleanly under both native codegen styles (flat `kafka.pb.h`). The JVM producer builds green -- `mvn -Pspark-3.5 -Pkafka -pl gluten-core,gluten-substrait,gluten-kafka -am -DskipTests clean install` (`-Pkafka` is required; `clean` clears stale generated `.java` from the removed message) -- with no lingering references to `ReadRel.StreamKafka` / `setStreamKafka` and scalastyle/checkstyle passing in-phase.

The native ClickHouse `local-engine` build (`ReadRelParser.cpp`, `StreamKafkaRelParser.cpp`, generated `kafka.pb.*`) needs the Linux/Docker toolchain and is verified here by inspection only. The Kafka runtime suites (`GlutenKafkaScanSuite` / `ClickhouseGlutenKafkaScanSuite`) require `-Pkafka` plus an external `localhost:9092` broker and are not run by any in-repo GitHub Actions job, so the end-to-end Kafka path is not exercised in CI. A maintainer running `-Pkafka` against a broker before merge would be the real end-to-end check; the JVM `toProtobuf` and the CH deserialize are kept as literal mirrors of the existing extension-table readers to minimize that risk.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)

🤖 Generated with AI

