### PR TITLE
[MINOR][CI] Trigger Delta Spark UT on Velox revision updates

### DIFF
--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -54,6 +54,8 @@ on:
     paths:
       - '.github/workflows/delta_spark_ut.yml'
       - '.github/workflows/util/delta-spark-ut/**'
+      # Velox revision updates can change Delta offload behavior.
+      - 'ep/build-velox/src/get-velox.sh'
       - 'gluten-delta/**'
       # Covers src-delta, src-delta33, src-delta40 and any future variant.
       - 'backends-velox/src-delta*/**'


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `ep/build-velox/src/get-velox.sh` to the Delta Spark UT pull request path filters.

Changes to this file update the pinned Velox revision and can affect Delta offload behavior, so they should trigger the Delta test suite instead of waiting for the nightly run.

## How was this patch tested?

Ran `git diff --check`. This is a workflow path-filter-only change.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI 1.0.80
