### PR TITLE
[MINOR][CI] Automate nightly Delta known-failures updates

### DIFF
--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -90,8 +90,8 @@ on:
   # Nightly full run against the latest default branch. Per-PR the `paths:` filter
   # above runs the suite only for Delta-relevant changes, to save GHA minutes;
   # this scheduled run keeps full coverage once a day so regressions from general
-  # Velox/core changes are still caught. It also publishes a deletion-only
-  # baseline artifact for external PR automation.
+  # Velox/core changes are still caught. It also opens or updates a pull request
+  # that removes tests confirmed to pass from the known-failures baseline.
   schedule:
     - cron: '0 5 * * *'
 
@@ -331,10 +331,10 @@ jobs:
         # (with defaults); the `pull_request` and nightly `schedule` events supply
         # NONE, so fall back to the same defaults here. The boolean inputs are
         # rendered as explicit 'true'/'false' strings (never empty) via the `&&/||`
-        # form so those runs resolve cleanly. Pull requests and comment runs use
-        # fail_on_fixed=true so contributors keep baseline changes with their
-        # fixes. Nightly uses false so it can publish a deletion-only artifact;
-        # regressions still fail the gate.
+        # form so those runs resolve cleanly: update_baseline=false (enforce) and
+        # Pull requests default fail_on_fixed=true so contributors keep baseline
+        # changes with their fixes. Nightly uses false because the final job
+        # proposes those removals automatically; regressions still fail the gate.
         env:
           DELTA_REF: ${{ inputs.delta_ref || 'v4.2.0' }}
           SPARK_VERSION: ${{ inputs.spark_version || '4.1' }}
@@ -342,7 +342,7 @@ jobs:
           UPDATE_BASELINE: ${{ github.event_name == 'workflow_dispatch' && (inputs.update_baseline && 'true' || 'false') || 'false' }}
           # `inputs` only exists on workflow_dispatch. Keep PR enforcement on,
           # honor the manual input, and let the scheduled run report (but not fail
-          # on) fixed tests so aggregation can publish the baseline update.
+          # on) fixed tests so its final job can publish the baseline update.
           FAIL_ON_FIXED: ${{ github.event_name == 'workflow_dispatch' && (inputs.fail_on_fixed && 'true' || 'false') || github.event_name == 'schedule' && 'false' || 'true' }}
         run: |
           set -euo pipefail
@@ -504,7 +504,7 @@ jobs:
   # known-failures.txt and reports global regressions / now-passing / stale
   # entries. Runs even when some shards went red so the refreshed baseline
   # artifact is available for manual bootstrap/refresh and the scheduled run can
-  # safely publish a deletion-only update (see util/delta-spark-ut/README.md).
+  # safely propose deletion-only updates (see util/delta-spark-ut/README.md).
   delta-spark-aggregate:
     needs: delta-spark-test
     # Runs even when shards go red -- a partially-failing run still produces a
@@ -558,3 +558,102 @@ jobs:
           name: delta-spark-ut-pruned-known-failures
           path: aggregated/pruned-known-failures.txt
           if-no-files-found: error
+
+  delta-spark-update-baseline:
+    needs:
+      - delta-spark-test
+      - delta-spark-aggregate
+    # A complete aggregate is necessary but not sufficient: aggregation is
+    # deliberately allowed to succeed after shard regressions so it can still
+    # publish diagnostics. Only propose a baseline update from a fully clean
+    # nightly test matrix; scheduled runs do not fail on now-passing tests.
+    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.delta-spark-test.result == 'success' && needs.delta-spark-aggregate.result == 'success' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download safe nightly baseline update
+        uses: actions/download-artifact@v4
+        with:
+          name: delta-spark-ut-pruned-known-failures
+          path: nightly-baseline
+      - name: Open or update baseline pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          UPDATE_BRANCH: ci/delta-known-failures-nightly
+          BASELINE_PATH: .github/workflows/util/delta-spark-ut/known-failures.txt
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$UPDATE_BRANCH"
+          cp nightly-baseline/pruned-known-failures.txt "$BASELINE_PATH"
+
+          pr_number=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$UPDATE_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if git diff --quiet -- "$BASELINE_PATH"; then
+            echo "No newly passing tests to remove from the Delta baseline."
+            if [ -n "$pr_number" ]; then
+              gh pr close "$pr_number" \
+                --repo "$GITHUB_REPOSITORY" \
+                --delete-branch \
+                --comment "Closing because the latest scheduled Delta Spark UT run found no baseline tests that now pass."
+            fi
+            exit 0
+          fi
+
+          git add -- "$BASELINE_PATH"
+          git commit -m "[MINOR][CI] Refresh Delta known-failures baseline"
+
+          remote_sha=""
+          if remote_ref=$(git ls-remote --exit-code --heads origin "$UPDATE_BRANCH"); then
+            remote_sha=$(printf '%s\n' "$remote_ref" | cut -f1)
+          fi
+          if [ -n "$remote_sha" ]; then
+            git push \
+              --force-with-lease="refs/heads/${UPDATE_BRANCH}:${remote_sha}" \
+              origin "HEAD:refs/heads/${UPDATE_BRANCH}"
+          else
+            git push origin "HEAD:refs/heads/${UPDATE_BRANCH}"
+          fi
+
+          body_file="$RUNNER_TEMP/delta-known-failures-pr.md"
+          {
+            echo "## What changes are proposed in this pull request?"
+            echo
+            echo "Remove Delta tests confirmed as passing by the scheduled Delta Spark UT run."
+            echo "New failures are not added automatically, and skipped or unseen baseline entries are preserved."
+            echo
+            echo "## How was this patch tested?"
+            echo
+            printf 'Generated from the [scheduled Delta Spark UT run](%s).\n' "$SOURCE_RUN_URL"
+            echo
+            echo "## Was this patch authored or co-authored using generative AI tooling?"
+            echo
+            echo "No"
+          } > "$body_file"
+
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "[MINOR][CI] Refresh Delta known-failures baseline" \
+              --body-file "$body_file"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "$BASE_BRANCH" \
+              --head "$UPDATE_BRANCH" \
+              --title "[MINOR][CI] Refresh Delta known-failures baseline" \
+              --body-file "$body_file"
+          fi

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -90,8 +90,8 @@ on:
   # Nightly full run against the latest default branch. Per-PR the `paths:` filter
   # above runs the suite only for Delta-relevant changes, to save GHA minutes;
   # this scheduled run keeps full coverage once a day so regressions from general
-  # Velox/core changes are still caught. It also opens or updates a pull request
-  # that removes tests confirmed to pass from the known-failures baseline.
+  # Velox/core changes are still caught. It also publishes a deletion-only
+  # baseline artifact for external PR automation.
   schedule:
     - cron: '0 5 * * *'
 
@@ -331,10 +331,10 @@ jobs:
         # (with defaults); the `pull_request` and nightly `schedule` events supply
         # NONE, so fall back to the same defaults here. The boolean inputs are
         # rendered as explicit 'true'/'false' strings (never empty) via the `&&/||`
-        # form so those runs resolve cleanly: update_baseline=false (enforce) and
-        # Pull requests default fail_on_fixed=true so contributors keep baseline
-        # changes with their fixes. Nightly uses false because the final job
-        # proposes those removals automatically; regressions still fail the gate.
+        # form so those runs resolve cleanly. Pull requests and comment runs use
+        # fail_on_fixed=true so contributors keep baseline changes with their
+        # fixes. Nightly uses false so it can publish a deletion-only artifact;
+        # regressions still fail the gate.
         env:
           DELTA_REF: ${{ inputs.delta_ref || 'v4.2.0' }}
           SPARK_VERSION: ${{ inputs.spark_version || '4.1' }}
@@ -342,7 +342,7 @@ jobs:
           UPDATE_BASELINE: ${{ github.event_name == 'workflow_dispatch' && (inputs.update_baseline && 'true' || 'false') || 'false' }}
           # `inputs` only exists on workflow_dispatch. Keep PR enforcement on,
           # honor the manual input, and let the scheduled run report (but not fail
-          # on) fixed tests so its final job can publish the baseline update.
+          # on) fixed tests so aggregation can publish the baseline update.
           FAIL_ON_FIXED: ${{ github.event_name == 'workflow_dispatch' && (inputs.fail_on_fixed && 'true' || 'false') || github.event_name == 'schedule' && 'false' || 'true' }}
         run: |
           set -euo pipefail
@@ -504,7 +504,7 @@ jobs:
   # known-failures.txt and reports global regressions / now-passing / stale
   # entries. Runs even when some shards went red so the refreshed baseline
   # artifact is available for manual bootstrap/refresh and the scheduled run can
-  # safely propose deletion-only updates (see util/delta-spark-ut/README.md).
+  # safely publish a deletion-only update (see util/delta-spark-ut/README.md).
   delta-spark-aggregate:
     needs: delta-spark-test
     # Runs even when shards go red -- a partially-failing run still produces a
@@ -558,102 +558,3 @@ jobs:
           name: delta-spark-ut-pruned-known-failures
           path: aggregated/pruned-known-failures.txt
           if-no-files-found: error
-
-  delta-spark-update-baseline:
-    needs:
-      - delta-spark-test
-      - delta-spark-aggregate
-    # A complete aggregate is necessary but not sufficient: aggregation is
-    # deliberately allowed to succeed after shard regressions so it can still
-    # publish diagnostics. Only propose a baseline update from a fully clean
-    # nightly test matrix; scheduled runs do not fail on now-passing tests.
-    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.delta-spark-test.result == 'success' && needs.delta-spark-aggregate.result == 'success' }}
-    runs-on: ubuntu-22.04
-    permissions:
-      actions: read
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download safe nightly baseline update
-        uses: actions/download-artifact@v4
-        with:
-          name: delta-spark-ut-pruned-known-failures
-          path: nightly-baseline
-      - name: Open or update baseline pull request
-        env:
-          GH_TOKEN: ${{ github.token }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
-          UPDATE_BRANCH: ci/delta-known-failures-nightly
-          BASELINE_PATH: .github/workflows/util/delta-spark-ut/known-failures.txt
-          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -C "$UPDATE_BRANCH"
-          cp nightly-baseline/pruned-known-failures.txt "$BASELINE_PATH"
-
-          pr_number=$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --head "$UPDATE_BRANCH" \
-            --base "$BASE_BRANCH" \
-            --state open \
-            --json number \
-            --jq '.[0].number // empty')
-          if git diff --quiet -- "$BASELINE_PATH"; then
-            echo "No newly passing tests to remove from the Delta baseline."
-            if [ -n "$pr_number" ]; then
-              gh pr close "$pr_number" \
-                --repo "$GITHUB_REPOSITORY" \
-                --delete-branch \
-                --comment "Closing because the latest scheduled Delta Spark UT run found no baseline tests that now pass."
-            fi
-            exit 0
-          fi
-
-          git add -- "$BASELINE_PATH"
-          git commit -m "[MINOR][CI] Refresh Delta known-failures baseline"
-
-          remote_sha=""
-          if remote_ref=$(git ls-remote --exit-code --heads origin "$UPDATE_BRANCH"); then
-            remote_sha=$(printf '%s\n' "$remote_ref" | cut -f1)
-          fi
-          if [ -n "$remote_sha" ]; then
-            git push \
-              --force-with-lease="refs/heads/${UPDATE_BRANCH}:${remote_sha}" \
-              origin "HEAD:refs/heads/${UPDATE_BRANCH}"
-          else
-            git push origin "HEAD:refs/heads/${UPDATE_BRANCH}"
-          fi
-
-          body_file="$RUNNER_TEMP/delta-known-failures-pr.md"
-          {
-            echo "## What changes are proposed in this pull request?"
-            echo
-            echo "Remove Delta tests confirmed as passing by the scheduled Delta Spark UT run."
-            echo "New failures are not added automatically, and skipped or unseen baseline entries are preserved."
-            echo
-            echo "## How was this patch tested?"
-            echo
-            printf 'Generated from the [scheduled Delta Spark UT run](%s).\n' "$SOURCE_RUN_URL"
-            echo
-            echo "## Was this patch authored or co-authored using generative AI tooling?"
-            echo
-            echo "No"
-          } > "$body_file"
-
-          if [ -n "$pr_number" ]; then
-            gh pr edit "$pr_number" \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "[MINOR][CI] Refresh Delta known-failures baseline" \
-              --body-file "$body_file"
-          else
-            gh pr create \
-              --repo "$GITHUB_REPOSITORY" \
-              --base "$BASE_BRANCH" \
-              --head "$UPDATE_BRANCH" \
-              --title "[MINOR][CI] Refresh Delta known-failures baseline" \
-              --body-file "$body_file"
-          fi

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -560,8 +560,14 @@ jobs:
           if-no-files-found: error
 
   delta-spark-update-baseline:
-    needs: delta-spark-aggregate
-    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.delta-spark-aggregate.result == 'success' }}
+    needs:
+      - delta-spark-test
+      - delta-spark-aggregate
+    # A complete aggregate is necessary but not sufficient: aggregation is
+    # deliberately allowed to succeed after shard regressions so it can still
+    # publish diagnostics. Only propose a baseline update from a fully clean
+    # nightly test matrix; scheduled runs do not fail on now-passing tests.
+    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.delta-spark-test.result == 'success' && needs.delta-spark-aggregate.result == 'success' }}
     runs-on: ubuntu-22.04
     permissions:
       actions: read

--- a/.github/workflows/delta_spark_ut.yml
+++ b/.github/workflows/delta_spark_ut.yml
@@ -90,8 +90,8 @@ on:
   # Nightly full run against the latest default branch. Per-PR the `paths:` filter
   # above runs the suite only for Delta-relevant changes, to save GHA minutes;
   # this scheduled run keeps full coverage once a day so regressions from general
-  # Velox/core changes are still caught, and it enforces `fail_on_fixed` so the
-  # baseline stays honest.
+  # Velox/core changes are still caught. It also opens or updates a pull request
+  # that removes tests confirmed to pass from the known-failures baseline.
   schedule:
     - cron: '0 5 * * *'
 
@@ -332,19 +332,18 @@ jobs:
         # NONE, so fall back to the same defaults here. The boolean inputs are
         # rendered as explicit 'true'/'false' strings (never empty) via the `&&/||`
         # form so those runs resolve cleanly: update_baseline=false (enforce) and
-        # fail_on_fixed=true (so a now-passing baseline test turns the nightly red
-        # -- our signal that the committed baseline needs refreshing).
+        # Pull requests default fail_on_fixed=true so contributors keep baseline
+        # changes with their fixes. Nightly uses false because the final job
+        # proposes those removals automatically; regressions still fail the gate.
         env:
           DELTA_REF: ${{ inputs.delta_ref || 'v4.2.0' }}
           SPARK_VERSION: ${{ inputs.spark_version || '4.1' }}
           TEST_PARALLELISM: ${{ inputs.test_parallelism || '4' }}
           UPDATE_BASELINE: ${{ github.event_name == 'workflow_dispatch' && (inputs.update_baseline && 'true' || 'false') || 'false' }}
-          # Defaults to true for pull_request and schedule: `inputs` only exists on
-          # workflow_dispatch, so a bare `inputs.fail_on_fixed` would silently
-          # resolve to false on those events and stop the now-passing check from
-          # being enforced -- the behaviour the removed workflow_call input used to
-          # provide via `default: true`.
-          FAIL_ON_FIXED: ${{ github.event_name == 'workflow_dispatch' && (inputs.fail_on_fixed && 'true' || 'false') || 'true' }}
+          # `inputs` only exists on workflow_dispatch. Keep PR enforcement on,
+          # honor the manual input, and let the scheduled run report (but not fail
+          # on) fixed tests so its final job can publish the baseline update.
+          FAIL_ON_FIXED: ${{ github.event_name == 'workflow_dispatch' && (inputs.fail_on_fixed && 'true' || 'false') || github.event_name == 'schedule' && 'false' || 'true' }}
         run: |
           set -euo pipefail
           {
@@ -503,9 +502,9 @@ jobs:
 
   # Merges every shard's failure/ran lists into a single, sorted, ready-to-commit
   # known-failures.txt and reports global regressions / now-passing / stale
-  # entries. Runs even when some shards went red (if: always()) so the refreshed
-  # baseline artifact is always available -- this is what you download and commit
-  # to bootstrap or refresh the baseline (see util/delta-spark-ut/README.md).
+  # entries. Runs even when some shards went red so the refreshed baseline
+  # artifact is available for manual bootstrap/refresh and the scheduled run can
+  # safely propose deletion-only updates (see util/delta-spark-ut/README.md).
   delta-spark-aggregate:
     needs: delta-spark-test
     # Runs even when shards go red -- a partially-failing run still produces a
@@ -522,6 +521,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.DELTA_CHECKOUT_REF }}
+      - name: Test result comparison helper
+        run: |
+          python3 -m unittest discover \
+            -s .github/workflows/util/delta-spark-ut \
+            -p 'test_*.py'
       - name: Download per-shard gate lists
         uses: actions/download-artifact@v4
         continue-on-error: true
@@ -538,7 +542,8 @@ jobs:
             --expected-shards "${{ env.DELTA_NUM_SHARDS }}" \
             --known-failures .github/workflows/util/delta-spark-ut/known-failures.txt \
             --flaky-tests .github/workflows/util/delta-spark-ut/flaky-tests.txt \
-            --baseline-out aggregated/known-failures.txt
+            --baseline-out aggregated/known-failures.txt \
+            --pruned-baseline-out aggregated/pruned-known-failures.txt
       - name: Upload refreshed baseline
         if: always()
         uses: actions/upload-artifact@v4
@@ -546,3 +551,103 @@ jobs:
           name: delta-spark-ut-known-failures
           path: aggregated/known-failures.txt
           if-no-files-found: warn
+      - name: Upload safe nightly baseline update
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: delta-spark-ut-pruned-known-failures
+          path: aggregated/pruned-known-failures.txt
+          if-no-files-found: error
+
+  delta-spark-update-baseline:
+    needs: delta-spark-aggregate
+    if: ${{ !cancelled() && github.event_name == 'schedule' && needs.delta-spark-aggregate.result == 'success' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download safe nightly baseline update
+        uses: actions/download-artifact@v4
+        with:
+          name: delta-spark-ut-pruned-known-failures
+          path: nightly-baseline
+      - name: Open or update baseline pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          UPDATE_BRANCH: ci/delta-known-failures-nightly
+          BASELINE_PATH: .github/workflows/util/delta-spark-ut/known-failures.txt
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$UPDATE_BRANCH"
+          cp nightly-baseline/pruned-known-failures.txt "$BASELINE_PATH"
+
+          pr_number=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$UPDATE_BRANCH" \
+            --base "$BASE_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if git diff --quiet -- "$BASELINE_PATH"; then
+            echo "No newly passing tests to remove from the Delta baseline."
+            if [ -n "$pr_number" ]; then
+              gh pr close "$pr_number" \
+                --repo "$GITHUB_REPOSITORY" \
+                --delete-branch \
+                --comment "Closing because the latest scheduled Delta Spark UT run found no baseline tests that now pass."
+            fi
+            exit 0
+          fi
+
+          git add -- "$BASELINE_PATH"
+          git commit -m "[MINOR][CI] Refresh Delta known-failures baseline"
+
+          remote_sha=""
+          if remote_ref=$(git ls-remote --exit-code --heads origin "$UPDATE_BRANCH"); then
+            remote_sha=$(printf '%s\n' "$remote_ref" | cut -f1)
+          fi
+          if [ -n "$remote_sha" ]; then
+            git push \
+              --force-with-lease="refs/heads/${UPDATE_BRANCH}:${remote_sha}" \
+              origin "HEAD:refs/heads/${UPDATE_BRANCH}"
+          else
+            git push origin "HEAD:refs/heads/${UPDATE_BRANCH}"
+          fi
+
+          body_file="$RUNNER_TEMP/delta-known-failures-pr.md"
+          {
+            echo "## What changes are proposed in this pull request?"
+            echo
+            echo "Remove Delta tests confirmed as passing by the scheduled Delta Spark UT run."
+            echo "New failures are not added automatically, and skipped or unseen baseline entries are preserved."
+            echo
+            echo "## How was this patch tested?"
+            echo
+            printf 'Generated from the [scheduled Delta Spark UT run](%s).\n' "$SOURCE_RUN_URL"
+            echo
+            echo "## Was this patch authored or co-authored using generative AI tooling?"
+            echo
+            echo "No"
+          } > "$body_file"
+
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "[MINOR][CI] Refresh Delta known-failures baseline" \
+              --body-file "$body_file"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "$BASE_BRANCH" \
+              --head "$UPDATE_BRANCH" \
+              --title "[MINOR][CI] Refresh Delta known-failures baseline" \
+              --body-file "$body_file"
+          fi

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -104,11 +104,10 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   the safety net.
 - **Nightly** — the **full** suite runs against the latest default branch on a
   `schedule` (05:00 UTC), so regressions from general Velox/core changes are
-  still caught daily. It reports now-passing tests without failing on them, then
-  opens or updates a `[MINOR][CI]` pull request that removes those entries from
-  `known-failures.txt`. The automated update is deliberately deletion-only:
-  regressions are still reported and fail the run, but are never added to the
-  baseline; skipped and unseen tests are left unchanged.
+  still caught daily. It reports now-passing tests without failing on them and
+  uploads a deletion-only baseline artifact for authorized external automation.
+  Regressions are still reported and fail the run, but are never added to the
+  artifact; skipped and unseen tests are left unchanged.
 - **On demand, from a PR** — anyone can comment **`/delta-test`** as the first
   token to run the default configuration against the PR merge ref. This covers
   PRs skipped by `paths:` without requiring label permissions. The workflow
@@ -138,7 +137,7 @@ From the next run onward the gate enforces the baseline.
   *now-passing*. Delete those lines from `known-failures.txt` in your PR. That
   is the whole point — the baseline only ever shrinks as coverage improves. If
   the fix reached the default branch without running Delta CI, the next nightly
-  run will propose the same removals automatically.
+  run will include the same removals in its deletion-only artifact.
 - **You intentionally added a new expected failure** (e.g. a test that asserts
   on a query plan that legitimately differs once Gluten offloads, or one that
   hits a tracked bug you are not fixing here). Add the exact `Suite#test`

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -39,7 +39,8 @@ starts failing** (a regression).
 | `known-failures.txt` | Committed baseline: the tests currently expected to fail. One `<suite>#<test>` per line. |
 | `flaky-tests.txt` | Quarantine list by test name: tests whose pass/fail is non-deterministic. Ignored by the gate whether they pass or fail. `<suite-glob>#<test>` per line. |
 | `flaky-error-patterns.txt` | Quarantine list by error signature: regex patterns matched against a failure's text, for bugs that surface on a different test each run (e.g. the native DV bitmap row-index error). |
-| `compare-test-results.py` | Parses the JUnit XML from `sbt spark/test` and gates / seeds / aggregates against the baseline. Standard-library only. |
+| `compare-test-results.py` | Parses the JUnit XML from `sbt spark/test` and gates / seeds / aggregates against the baseline. It can also produce a deletion-only baseline for nightly automation. Standard-library only. |
+| `test_compare_test_results.py` | Focused standard-library tests for comparison and baseline-update safety. |
 | `run-delta-tests.sh` | The shard step's body: runs `sbt spark/test` (tuned JVM/heap flags) under a hang watchdog, prints memory forensics, then gates the results against the baseline via `compare-test-results.py`. |
 | `java-test-args.sh` | Shared JVM flags (`--add-opens` + Netty property) needed to run the suite on JDK 17 with the Gluten bundle. Sourced by `run-delta-tests.sh` and by local runs. |
 | `setup-delta.sh` | Clones Delta, drops in the Gluten bundle, and patches `DeltaSQLCommandTest`. |
@@ -62,6 +63,9 @@ Each test shard:
 A final `aggregate` job merges every shard's results into a single, sorted,
 ready-to-commit `known-failures.txt` artifact and reports **stale** baseline
 entries (tests no longer present in any shard, e.g. after a Delta version bump).
+It also produces a safe, deletion-only variant that removes only baseline tests
+confirmed as passing. Unlike the full refresh artifact, that variant never adds
+new failures or removes tests that were skipped or not seen.
 
 Tests reported as `<skipped>` are tracked separately from tests that actually
 ran, so a baseline entry that was merely skipped this run is **not** mistaken
@@ -100,9 +104,11 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   the safety net.
 - **Nightly** — the **full** suite runs against the latest default branch on a
   `schedule` (05:00 UTC), so regressions from general Velox/core changes are
-  still caught daily. The nightly run enforces the baseline **and** fails on
-  now-passing tests (`fail_on_fixed=true`), so baseline drift surfaces as a red
-  nightly — the signal to refresh `known-failures.txt`.
+  still caught daily. It reports now-passing tests without failing on them, then
+  opens or updates a `[MINOR][CI]` pull request that removes those entries from
+  `known-failures.txt`. The automated update is deliberately deletion-only:
+  regressions are still reported and fail the run, but are never added to the
+  baseline; skipped and unseen tests are left unchanged.
 - **On demand, from a PR** — anyone can comment **`/delta-test`** as the first
   token to run the default configuration against the PR merge ref. This covers
   PRs skipped by `paths:` without requiring label permissions. The workflow
@@ -130,7 +136,9 @@ From the next run onward the gate enforces the baseline.
 
 - **You fixed Gluten and some Delta tests now pass.** CI will flag them as
   *now-passing*. Delete those lines from `known-failures.txt` in your PR. That
-  is the whole point — the baseline only ever shrinks as coverage improves.
+  is the whole point — the baseline only ever shrinks as coverage improves. If
+  the fix reached the default branch without running Delta CI, the next nightly
+  run will propose the same removals automatically.
 - **You intentionally added a new expected failure** (e.g. a test that asserts
   on a query plan that legitimately differs once Gluten offloads, or one that
   hits a tracked bug you are not fixing here). Add the exact `Suite#test`

--- a/.github/workflows/util/delta-spark-ut/README.md
+++ b/.github/workflows/util/delta-spark-ut/README.md
@@ -104,10 +104,11 @@ longer shared between them, those PRs pay for the centos-7 native build twice
   the safety net.
 - **Nightly** — the **full** suite runs against the latest default branch on a
   `schedule` (05:00 UTC), so regressions from general Velox/core changes are
-  still caught daily. It reports now-passing tests without failing on them and
-  uploads a deletion-only baseline artifact for authorized external automation.
-  Regressions are still reported and fail the run, but are never added to the
-  artifact; skipped and unseen tests are left unchanged.
+  still caught daily. It reports now-passing tests without failing on them, then
+  opens or updates a `[MINOR][CI]` pull request that removes those entries from
+  `known-failures.txt`. The automated update is deliberately deletion-only:
+  regressions are still reported and fail the run, but are never added to the
+  baseline; skipped and unseen tests are left unchanged.
 - **On demand, from a PR** — anyone can comment **`/delta-test`** as the first
   token to run the default configuration against the PR merge ref. This covers
   PRs skipped by `paths:` without requiring label permissions. The workflow
@@ -137,7 +138,7 @@ From the next run onward the gate enforces the baseline.
   *now-passing*. Delete those lines from `known-failures.txt` in your PR. That
   is the whole point — the baseline only ever shrinks as coverage improves. If
   the fix reached the default branch without running Delta CI, the next nightly
-  run will include the same removals in its deletion-only artifact.
+  run will propose the same removals automatically.
 - **You intentionally added a new expected failure** (e.g. a test that asserts
   on a query plan that legitimately differs once Gluten offloads, or one that
   hits a tracked bug you are not fixing here). Add the exact `Suite#test`

--- a/.github/workflows/util/delta-spark-ut/compare-test-results.py
+++ b/.github/workflows/util/delta-spark-ut/compare-test-results.py
@@ -54,6 +54,10 @@ This script has three modes:
     a skipped test is not evidence of a fix. Pass ``--expected-shards N``
     to fail when fewer than ``N`` shards contributed gate lists (a shard that
     died before writing them), so an incomplete baseline is never produced.
+    ``--pruned-baseline-out`` writes a second, automation-safe baseline that
+    removes only tests proven to pass. It preserves comments, stale/skipped
+    entries, and never adds new failures, so a nightly job can propose fixes
+    without silently accepting regressions.
 
 Flaky quarantine (``--flaky-tests``)
     Some Delta-on-Gluten failures are non-deterministic (e.g. a native bug that
@@ -267,6 +271,19 @@ def write_entries(path, entries, header=None):
             # Defensive: collapse any stray newlines so each entry stays on one line.
             safe_test = test.replace("\r", " ").replace("\n", " ")
             fh.write(format_entry(suite, safe_test) + "\n")
+
+
+def write_pruned_baseline(source_path, output_path, removed):
+    """Copy a baseline verbatim except for entries in ``removed``."""
+    with open(source_path, "r", encoding="utf-8") as source:
+        lines = source.readlines()
+
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)) or ".", exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as output:
+        for line in lines:
+            entry = parse_entry(line)
+            if entry is None or entry not in removed:
+                output.write(line)
 
 
 # --------------------------------------------------------------------------- #
@@ -601,6 +618,15 @@ def _shard_ids(files, prefix):
 
 
 def run_aggregate(args):
+    if args.pruned_baseline_out and (
+        not args.known_failures or not os.path.exists(args.known_failures)
+    ):
+        eprint(
+            "ERROR: --pruned-baseline-out requires an existing "
+            "--known-failures file."
+        )
+        return 2
+
     failure_files = sorted(
         glob.glob(os.path.join(args.inputs_dir, "**", "failures-*.txt"), recursive=True)
     )
@@ -681,6 +707,7 @@ def run_aggregate(args):
     # (otherwise it would trip the now-passing gate on the next run where it
     # passes). Flaky failures are tracked in flaky-tests.txt, not the baseline.
     baseline_body = {e for e in (union_failed | carried_skipped) if not flaky_is(e)}
+    fixed = {e for e in (prev_baseline & (union_ran - union_failed)) if not flaky_is(e)}
 
     header = (
         "# Known Delta-on-Gluten unit test failures.\n"
@@ -694,6 +721,10 @@ def run_aggregate(args):
     )
     if args.baseline_out:
         write_entries(args.baseline_out, baseline_body, header=header)
+    if args.pruned_baseline_out:
+        write_pruned_baseline(
+            args.known_failures, args.pruned_baseline_out, removed=fixed
+        )
 
     write, handle = _summary_sink()
     try:
@@ -711,11 +742,6 @@ def run_aggregate(args):
             if baseline:
                 regressions = {e for e in (union_failed - baseline) if not flaky_is(e)}
                 quarantined = {e for e in (union_failed - baseline) if flaky_is(e)}
-                fixed = {
-                    e
-                    for e in (baseline & (union_ran - union_failed))
-                    if not flaky_is(e)
-                }
                 stale = baseline - union_ran - union_skipped
                 skipped_baseline = baseline & union_skipped
                 write("| Baseline entries | {} |".format(len(baseline)))
@@ -821,6 +847,12 @@ def main(argv=None):
     )
     parser.add_argument(
         "--baseline-out", help="Write the merged baseline here (aggregate)."
+    )
+    parser.add_argument(
+        "--pruned-baseline-out",
+        help="Write a copy of --known-failures with only confirmed now-passing "
+        "entries removed (aggregate). Comments, skipped/stale entries, and all "
+        "other baseline entries are preserved; new failures are never added.",
     )
     parser.add_argument(
         "--fail-on-regression",

--- a/.github/workflows/util/delta-spark-ut/test_compare_test_results.py
+++ b/.github/workflows/util/delta-spark-ut/test_compare_test_results.py
@@ -15,11 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPT = Path(__file__).with_name("compare-test-results.py")
 
@@ -64,31 +66,41 @@ class AggregatePrunedBaselineTest(unittest.TestCase):
 
             refreshed = root / "refreshed.txt"
             pruned = root / "pruned.txt"
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    str(SCRIPT),
-                    "--mode",
-                    "aggregate",
-                    "--inputs-dir",
-                    str(inputs),
-                    "--expected-shards",
-                    "1",
-                    "--known-failures",
-                    str(baseline),
-                    "--flaky-tests",
-                    str(flaky),
-                    "--baseline-out",
-                    str(refreshed),
-                    "--pruned-baseline-out",
-                    str(pruned),
-                ],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            job_summary = root / "job-summary.md"
+            job_summary.write_text("Existing job summary.\n", encoding="utf-8")
+            with mock.patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": str(job_summary)}):
+                subprocess_env = os.environ.copy()
+                subprocess_env.pop("GITHUB_STEP_SUMMARY", None)
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(SCRIPT),
+                        "--mode",
+                        "aggregate",
+                        "--inputs-dir",
+                        str(inputs),
+                        "--expected-shards",
+                        "1",
+                        "--known-failures",
+                        str(baseline),
+                        "--flaky-tests",
+                        str(flaky),
+                        "--baseline-out",
+                        str(refreshed),
+                        "--pruned-baseline-out",
+                        str(pruned),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    env=subprocess_env,
+                )
 
             self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(
+                "Existing job summary.\n",
+                job_summary.read_text(encoding="utf-8"),
+            )
             self.assertEqual(
                 "# Keep this header verbatim.\n"
                 "suite.Expected#still fails\n"

--- a/.github/workflows/util/delta-spark-ut/test_compare_test_results.py
+++ b/.github/workflows/util/delta-spark-ut/test_compare_test_results.py
@@ -21,7 +21,6 @@ import tempfile
 import unittest
 from pathlib import Path
 
-
 SCRIPT = Path(__file__).with_name("compare-test-results.py")
 
 

--- a/.github/workflows/util/delta-spark-ut/test_compare_test_results.py
+++ b/.github/workflows/util/delta-spark-ut/test_compare_test_results.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("compare-test-results.py")
+
+
+class AggregatePrunedBaselineTest(unittest.TestCase):
+    def test_pruned_baseline_removes_only_confirmed_passing_tests(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            inputs = root / "inputs"
+            inputs.mkdir()
+
+            baseline = root / "known-failures.txt"
+            baseline.write_text(
+                "# Keep this header verbatim.\n"
+                "suite.Fixed#now passes\n"
+                "suite.Expected#still fails\n"
+                "suite.Skipped#not executed\n"
+                "suite.Stale#not seen\n"
+                "suite.Flaky#sometimes passes\n",
+                encoding="utf-8",
+            )
+            flaky = root / "flaky-tests.txt"
+            flaky.write_text(
+                "suite.Flaky#sometimes passes\n",
+                encoding="utf-8",
+            )
+            (inputs / "failures-shard-0.txt").write_text(
+                "suite.Expected#still fails\n" "suite.Regression#new failure\n",
+                encoding="utf-8",
+            )
+            (inputs / "ran-shard-0.txt").write_text(
+                "suite.Fixed#now passes\n"
+                "suite.Expected#still fails\n"
+                "suite.Flaky#sometimes passes\n"
+                "suite.Regression#new failure\n",
+                encoding="utf-8",
+            )
+            (inputs / "skipped-shard-0.txt").write_text(
+                "suite.Skipped#not executed\n",
+                encoding="utf-8",
+            )
+
+            refreshed = root / "refreshed.txt"
+            pruned = root / "pruned.txt"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--mode",
+                    "aggregate",
+                    "--inputs-dir",
+                    str(inputs),
+                    "--expected-shards",
+                    "1",
+                    "--known-failures",
+                    str(baseline),
+                    "--flaky-tests",
+                    str(flaky),
+                    "--baseline-out",
+                    str(refreshed),
+                    "--pruned-baseline-out",
+                    str(pruned),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(
+                "# Keep this header verbatim.\n"
+                "suite.Expected#still fails\n"
+                "suite.Skipped#not executed\n"
+                "suite.Stale#not seen\n"
+                "suite.Flaky#sometimes passes\n",
+                pruned.read_text(encoding="utf-8"),
+            )
+            refreshed_text = refreshed.read_text(encoding="utf-8")
+            self.assertIn("suite.Regression#new failure\n", refreshed_text)
+            self.assertNotIn(
+                "suite.Regression#new failure\n",
+                pruned.read_text(encoding="utf-8"),
+            )
+            self.assertNotIn("suite.Stale#not seen\n", refreshed_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changes are proposed in this pull request?

Automate maintenance of the Delta Spark UT `known-failures.txt` baseline from the scheduled daily run.

We recently had to remove now-passing tests manually in two separate PRs:

- [#12815](https://github.com/apache/gluten/pull/12815) removed four tests fixed by cast-mode preservation.
- [#12851](https://github.com/apache/gluten/pull/12851) removed two type-widening tests fixed by a Velox update.

Those fixes reached core libraries without triggering Delta CI when merged. The daily run eventually detected the now-passing tests, but updating the baseline still required a manual PR.

This change makes the scheduled workflow open or update a `[MINOR][CI]` PR containing those removals. The generated update is deliberately deletion-only: it removes tests confirmed as passing, never adds new failures, and preserves skipped, unseen, and flaky entries as well as existing comments. Regressions continue to fail the Delta gate and cannot be accepted automatically.

A focused unit test covers the pruning behavior, including preservation of regressions, skipped tests, stale entries, flaky tests, and baseline comments.

Related to #12743.

## How was this patch tested?

- Ran the `compare-test-results.py` unit test.
- Checked both Python files with Black.
- Validated `delta_spark_ut.yml` with actionlint.
- Validated the embedded PR-update shell script.
- Ran `git diff --check`.

Validated the complete scheduled flow end to end in
[`felipepessoto/gluten`](https://github.com/felipepessoto/gluten):

- [Scheduled run #32615561149](https://github.com/felipepessoto/gluten/actions/runs/32615561149)
  completed every build, test, aggregate, and update job successfully. The
  aggregate reported zero regressions and two now-passing tests, with no
  synthetic unit-test fixtures leaking into the job summary.
- The run opened [fork PR #3](https://github.com/felipepessoto/gluten/pull/3)
  as `github-actions[bot]`, containing exactly the two expected baseline
  deletions and no additions.
- The fork retained its repository-wide read-only workflow default, confirming
  that the job's explicit write permissions are sufficient when the repository
  setting allowing Actions to create pull requests is enabled.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI 1.0.80
