### PR TITLE
[GLUTEN-12863][VL][TEST] Re-enable six GlutenTryCastSuite cases excluded on Spark 3.4+

### DIFF
--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -108,12 +108,6 @@ class VeloxTestSettings extends BackendTestSettings {
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
     )
     .exclude("cast from timestamp II") // Rewrite test for Gluten not supported with ANSI mode
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to byte type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to short type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to int type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
-    .exclude("cast from invalid string to numeric should throw NumberFormatException")
-    .exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
     // Set timezone through config.
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -112,12 +112,6 @@ class VeloxTestSettings extends BackendTestSettings {
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
     )
     .exclude("cast from timestamp II") // Rewrite test for Gluten not supported with ANSI mode
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to byte type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to short type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to int type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
-    .exclude("cast from invalid string to numeric should throw NumberFormatException")
-    .exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
     // Set timezone through config.
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -122,12 +122,6 @@ class VeloxTestSettings extends BackendTestSettings {
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
     )
     .exclude("cast from timestamp II") // Rewrite test for Gluten not supported with ANSI mode
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to byte type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to short type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to int type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
-    .exclude("cast from invalid string to numeric should throw NumberFormatException")
-    .exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
     // Set timezone through config.
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -125,12 +125,6 @@ class VeloxTestSettings extends BackendTestSettings {
       "Process Infinity, -Infinity, NaN in case insensitive manner" // +inf not supported in folly.
     )
     .exclude("cast from timestamp II") // Rewrite test for Gluten not supported with ANSI mode
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to byte type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to short type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to int type")
-    .exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
-    .exclude("cast from invalid string to numeric should throw NumberFormatException")
-    .exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
     // Set timezone through config.
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.


### PR DESCRIPTION
`VeloxTestSettings` excludes six cases from `GlutenTryCastSuite` on Spark 3.4, 3.5, 4.0 and 4.1. This removes those exclusions. All six pass.

```scala
.exclude("ANSI mode: Throw exception on casting out-of-range value to byte type")
.exclude("ANSI mode: Throw exception on casting out-of-range value to short type")
.exclude("ANSI mode: Throw exception on casting out-of-range value to int type")
.exclude("ANSI mode: Throw exception on casting out-of-range value to long type")
.exclude("cast from invalid string to numeric should throw NumberFormatException")
.exclude("SPARK-26218: Fix the corner case of codegen when casting float to Integer")
```

The diff is 24 deleted lines and nothing else. `gluten-ut/spark33` never excluded these six, so the gap is specific to 3.4+, and unlike the neighbouring entries in that block, none of the six carries a comment saying what failed.

### Evidence

CI on this PR ran the suite on all four versions. I pulled the surefire XML out of the run instead of reading the job summaries, so the six could be checked by name:

| job | tests | failures | errors | the six |
|-|-|-|-|-|
| spark34 | 83 | 0 | 0 | all present, passed |
| spark35 | 83 | 0 | 0 | all present, passed |
| spark35-scala213 | 83 | 0 | 0 | all present, passed |
| spark40 | 88 | 0 | 0 | all present, passed |
| spark41 | 104 | 0 | 0 | all present, passed |

`velox_backend_ansi.yml` does not run on PR events and was not triggered here. For this suite it makes no difference. `FallbackOnANSIMode` only consults `spark.gluten.sql.ansiFallback.enabled` when session ANSI is on, and `TryCastSuite` on 3.4+ never turns it on: neither `CastWithAnsiOnSuite` nor `CastSuiteBase` contains a `setConf(ANSI_ENABLED, true)`, and the "AnsiOn" in the name refers to the expression-level `evalMode`, which `TryCastSuite` overrides to `EvalMode.TRY`. The `enableSuite[GlutenTryCastSuite]` block also sits outside the `if (ansiNoFallback)` guard in the 4.0 and 4.1 settings.

### Why they were probably there

On Spark 3.3 `TryCastSuite` builds `TryCast(...)`, a separate expression class that Spark 3.4 removed. Gluten's expression mapping is keyed by class, `Sig(expClass: Class[_], name: String)`, and there is no `Sig[TryCast]`. `TryCast` also extends `CastBase` as a sibling of `Cast`, so it does not reach the `case c: Cast` dispatch in `ExpressionConverter` either. A plan containing it cannot be offloaded, so on 3.3 these cases run on vanilla Spark. Spark 3.4 folded try-cast into `Cast(child, dataType, timeZoneId, EvalMode.TRY)`, which Gluten does offload (`Spark34Shims.withTryEvalMode`, then `CastTransformer` in `UnaryExpressionTransformer.scala`). So 3.4 is where these cases first started reaching Velox. What failed at that point is not recorded and I have not tried to reconstruct it. They pass now on all four versions.

### Context

Found while inventorying which vanilla cases still run on `gluten-ut/spark33` but are excluded on every later version, a prerequisite for removing that module under #12807 and tracked in #12863. These six are the only candidates from that inventory that pass once enabled. The rest either fail for the reasons already written beside them, or are ClickHouse-only and need a ClickHouse build to check.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-5
