### PR TITLE
[VL] Support LTO in builds

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -63,7 +63,7 @@ option(ENABLE_ORC "Enable ORC" OFF)
 option(ENABLE_ABFS "Enable ABFS" OFF)
 option(ENABLE_GPU "Enable GPU" OFF)
 option(ENABLE_ENHANCED_FEATURES "Enable enhanced features" OFF)
-option(ENABLE_LTO "Enable IPO/LTO for release builds" OFF)
+option(ENABLE_LTO "Enable IPO/LTO" OFF)
 
 set(root_directory ${PROJECT_BINARY_DIR})
 get_filename_component(GLUTEN_HOME ${CMAKE_SOURCE_DIR} DIRECTORY)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -25,6 +25,10 @@ if(POLICY CMP0126)
   cmake_policy(SET CMP0126 NEW)
 endif()
 
+if(POLICY CMP0069)
+  cmake_policy(SET CMP0069 NEW)
+endif()
+
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
   cmake_policy(SET CMP0135 NEW)
 endif()
@@ -42,6 +46,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
 
 project(gluten)
 
+include(CheckIPOSupported)
+
 option(BUILD_VELOX_BACKEND "Build Velox backend" ON)
 option(BUILD_TESTS "Build Tests" OFF)
 option(BUILD_EXAMPLES "Build Examples" OFF)
@@ -57,6 +63,7 @@ option(ENABLE_ORC "Enable ORC" OFF)
 option(ENABLE_ABFS "Enable ABFS" OFF)
 option(ENABLE_GPU "Enable GPU" OFF)
 option(ENABLE_ENHANCED_FEATURES "Enable enhanced features" OFF)
+option(ENABLE_LTO "Enable IPO/LTO for release builds" OFF)
 
 set(root_directory ${PROJECT_BINARY_DIR})
 get_filename_component(GLUTEN_HOME ${CMAKE_SOURCE_DIR} DIRECTORY)
@@ -178,6 +185,23 @@ if(COMMAND_STATUS EQUAL "1")
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SCRIPT_CXX_FLAGS}")
+
+if(ENABLE_LTO)
+  check_ipo_supported(
+    RESULT GLUTEN_IPO_SUPPORTED
+    OUTPUT GLUTEN_IPO_ERROR
+    LANGUAGES CXX)
+  if(NOT GLUTEN_IPO_SUPPORTED)
+    message(
+      FATAL_ERROR
+        "ENABLE_LTO requested, but IPO/LTO is not supported: ${GLUTEN_IPO_ERROR}"
+    )
+  endif()
+
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+
+  message(STATUS "ENABLE_LTO enabled for ${CMAKE_BUILD_TYPE} builds")
+endif()
 
 #
 # Dependencies

--- a/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
+++ b/cpp/velox/operators/serializer/VeloxRowToColumnarConverter.cc
@@ -110,8 +110,8 @@ VectorPtr createFlatVector<TypeKind::HUGEINT>(
       memcpy(bytesValue.data(), memoryAddress + offsets[pos] + wordoffset, length);
       uint8_t bytesValue2[16]{};
       GLUTEN_CHECK(length <= 16, "array out of bounds exception");
-      for (int k = length - 1; k >= 0; k--) {
-        bytesValue2[length - 1 - k] = bytesValue[k];
+      if (length > 0) {
+        std::reverse_copy(bytesValue.begin(), bytesValue.begin() + length, bytesValue2);
       }
       if (static_cast<int8_t>(bytesValue[0]) < 0) {
         memset(bytesValue2 + length, 255, 16 - length);

--- a/dev/builddeps-veloxbe.sh
+++ b/dev/builddeps-veloxbe.sh
@@ -39,6 +39,7 @@ ENABLE_ABFS=OFF
 ENABLE_VCPKG=OFF
 ENABLE_GPU=OFF
 ENABLE_ENHANCED_FEATURES=OFF
+ENABLE_LTO=OFF
 RUN_SETUP_SCRIPT=ON
 VELOX_REPO=""
 VELOX_BRANCH=""
@@ -113,6 +114,10 @@ do
         ;;
         --enable_enhanced_features=*)
         ENABLE_ENHANCED_FEATURES=("${arg#*=}")
+        shift # Remove argument name from processing
+        ;;
+        --enable_lto=*)
+        ENABLE_LTO=("${arg#*=}")
         shift # Remove argument name from processing
         ;;
         --run_setup_script=*)
@@ -244,7 +249,7 @@ function build_velox {
   ./build-velox.sh --enable_s3=$ENABLE_S3 --enable_gcs=$ENABLE_GCS --build_type=$BUILD_TYPE --enable_hdfs=$ENABLE_HDFS \
                    --enable_abfs=$ENABLE_ABFS --enable_gpu=$ENABLE_GPU --build_test_utils=$BUILD_TESTS \
                    --build_tests=$BUILD_VELOX_TESTS --build_benchmarks=$BUILD_VELOX_BENCHMARKS --num_threads=$NUM_THREADS \
-                   --velox_home=$VELOX_HOME
+                   --velox_home=$VELOX_HOME --enable_lto=$ENABLE_LTO
 }
 
 function build_gluten_cpp {
@@ -270,6 +275,7 @@ function build_gluten_cpp {
     "-DENABLE_GPU=$ENABLE_GPU"
     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
     "-DENABLE_ENHANCED_FEATURES=$ENABLE_ENHANCED_FEATURES"
+    "-DENABLE_LTO=$ENABLE_LTO"
   )
 
   if [ -n "${INSTALL_PREFIX:-}" ]; then

--- a/ep/build-velox/src/build-velox.sh
+++ b/ep/build-velox/src/build-velox.sh
@@ -28,6 +28,8 @@ ENABLE_HDFS=OFF
 ENABLE_ABFS=OFF
 # Enable GPU support
 ENABLE_GPU=OFF
+# Enable LTO/IPO support.
+ENABLE_LTO=OFF
 # CMake build type for Velox.
 BUILD_TYPE=release
 # May be deprecated in Gluten build.
@@ -68,6 +70,10 @@ for arg in "$@"; do
     ;;
   --enable_gpu=*)
     ENABLE_GPU=("${arg#*=}")
+    shift # Remove argument name from processing
+    ;;
+  --enable_lto=*)
+    ENABLE_LTO=("${arg#*=}")
     shift # Remove argument name from processing
     ;;
   --build_type=*)
@@ -138,6 +144,9 @@ function compile {
     # at /opt/homebrew/lib/cmake/fmt/ wins the AUTO find_package probe ahead of
     # INSTALL_PREFIX, producing a version mismatch. BUNDLED skips find_package.
     COMPILE_OPTION="$COMPILE_OPTION -Dfmt_SOURCE=BUNDLED"
+  fi
+  if [ $ENABLE_LTO == "ON" ]; then
+    COMPILE_OPTION="$COMPILE_OPTION -DVELOX_ENABLE_LTO=ON"
   fi
   if [ $BUILD_TEST_UTILS == "ON" ]; then
     COMPILE_OPTION="$COMPILE_OPTION -DVELOX_BUILD_TEST_UTILS=ON"
@@ -246,6 +255,7 @@ echo "ENABLE_GCS=${ENABLE_GCS}"
 echo "ENABLE_HDFS=${ENABLE_HDFS}"
 echo "ENABLE_ABFS=${ENABLE_ABFS}"
 echo "ENABLE_GPU=${ENABLE_GPU}"
+echo "ENABLE_LTO=${ENABLE_LTO}"
 echo "BUILD_TYPE=${BUILD_TYPE}"
 
 cd ${VELOX_HOME}


### PR DESCRIPTION
Adds option `ENABLE_LTO` in build to enable link-time optimization using CMake defaults. 

Fixes a bug in code for LTO build.