### PR TITLE
[VL] Re-enable window and sort UTs for Spark 4.0/4.1

### DIFF
--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -47,8 +47,7 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
     Row(95337, 12, decimal(915.61))
   )
 
-  // TODO: fix in Spark-4.0
-  ignore("Literal in window partition by and sort") {
+  testGluten("Literal in window partition by and sort") {
     withTable("customer") {
       val rdd = spark.sparkContext.parallelize(customerData)
       val customerDF = spark.createDataFrame(rdd, customerSchema)
@@ -94,8 +93,7 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
     }
   }
 
-  // TODO: fix in Spark-4.0
-  ignore("Filter on row number") {
+  testGluten("Filter on row number") {
     withTable("customer") {
       val rdd = spark.sparkContext.parallelize(customerData)
       val customerDF = spark.createDataFrame(rdd, customerSchema)
@@ -230,8 +228,7 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
     }
   }
 
-  // TODO: fix in Spark-4.0
-  ignore("Expression in WindowExpression") {
+  testGluten("Expression in WindowExpression") {
     withTable("customer") {
       val rdd = spark.sparkContext.parallelize(customerData)
       val customerDF = spark.createDataFrame(rdd, customerSchema)

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/GlutenSortSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/execution/GlutenSortSuite.scala
@@ -47,8 +47,7 @@ class GlutenSortSuite extends SortSuite with GlutenSQLTestsBaseTrait with Adapti
     }
   }
 
-  // TODO: fix in Spark-4.0
-  ignore("post-project outputOrdering check") {
+  testGluten("post-project outputOrdering check") {
     val input = Seq(
       ("Hello", 4, 2.0),
       ("Hello Bob", 10, 1.0),

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/GlutenSQLWindowFunctionSuite.scala
@@ -47,8 +47,7 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
     Row(95337, 12, decimal(915.61))
   )
 
-  // TODO: fix in Spark-4.0
-  ignore("Literal in window partition by and sort") {
+  testGluten("Literal in window partition by and sort") {
     withTable("customer") {
       val rdd = spark.sparkContext.parallelize(customerData)
       val customerDF = spark.createDataFrame(rdd, customerSchema)
@@ -94,8 +93,7 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
     }
   }
 
-  // TODO: fix in Spark-4.0
-  ignore("Filter on row number") {
+  testGluten("Filter on row number") {
     withTable("customer") {
       val rdd = spark.sparkContext.parallelize(customerData)
       val customerDF = spark.createDataFrame(rdd, customerSchema)
@@ -230,8 +228,7 @@ class GlutenSQLWindowFunctionSuite extends SQLWindowFunctionSuite with GlutenSQL
     }
   }
 
-  // TODO: fix in Spark-4.0
-  ignore("Expression in WindowExpression") {
+  testGluten("Expression in WindowExpression") {
     withTable("customer") {
       val rdd = spark.sparkContext.parallelize(customerData)
       val customerDF = spark.createDataFrame(rdd, customerSchema)

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/GlutenSortSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/execution/GlutenSortSuite.scala
@@ -47,8 +47,7 @@ class GlutenSortSuite extends SortSuite with GlutenSQLTestsBaseTrait with Adapti
     }
   }
 
-  // TODO: fix in Spark-4.0
-  ignore("post-project outputOrdering check") {
+  testGluten("post-project outputOrdering check") {
     val input = Seq(
       ("Hello", 4, 2.0),
       ("Hello Bob", 10, 1.0),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Re-enable four stale `ignore`d unit tests in the spark40 / spark41 modules:

- `GlutenSQLWindowFunctionSuite`: `Literal in window partition by and sort`, `Filter on row number`, `Expression in WindowExpression`
- `GlutenSortSuite`: `post-project outputOrdering check`

They were batch-`ignore`d with a generic `// TODO: fix in Spark-4.0` during initial spark40/spark41 framework bring-up, not because of a real Gluten failure.

## Why are the changes needed?
Re-enable UTs.

## How was this patch tested?

Re-enabled existing `gluten-ut` spark40/spark41 tests, they run in CI.

## Was this patch authored or co-authored using generative AI tooling?
Yes