### PR TITLE
[GLUTEN-12863][TEST] Document test exclusions and restore cast-from-timestamp coverage for Spark 3.4/3.5

### DIFF
--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -551,6 +551,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .exclude("cast from boolean")
     .exclude("data type casting")
     .excludeGlutenTest("data type casting")
+    // The Gluten rewrite of "cast from timestamp II" is not vetted on ClickHouse;
+    // the vanilla case is excluded separately in this block.
+    .excludeGlutenTest("cast from timestamp II")
     .exclude("cast between string and interval")
     .exclude("SPARK-27671: cast from nested null type in struct")
     .exclude("Process Infinity, -Infinity, NaN in case insensitive manner")

--- a/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -100,6 +100,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.
     .exclude("cast string to timestamp")
+    // Excluded in favour of the GlutenCastSuite rewrite, which drops the Long.MinValue
+    // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
     .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
@@ -629,6 +631,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenInsertSuite]
     // the native write staing dir is differnt with vanilla Spark for coustom partition paths
     .exclude("SPARK-35106: Throw exception when rename custom partition paths returns false")
+    // The case expects a SparkException; Gluten surfaces the raw
+    // FileAlreadyExistsException instead.
     .exclude("Stop task set if FileAlreadyExistsException was thrown")
     // Rewrite: Additional support for file scan with default values has been added in Spark-3.4.
     // It appends the default value in record if it is not present while scanning.

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -165,6 +165,18 @@ class GlutenCastSuite extends CastWithAnsiOffSuite with GlutenTestsTrait {
     checkEvaluation(cast(false, TimestampType), tsFalse)
   }
 
+  // Gluten's glutenCheckExpression uses collect(), which triggers
+  // toJavaTimestamp -> rebaseGregorianToJulianMicros. Long.MinValue micros (~292000 BC) overflows
+  // during rebase, so the vanilla case's Long.MinValue assertion is dropped here.
+  testGluten("cast from timestamp II") {
+    checkEvaluation(cast(Double.NaN, TimestampType), null)
+    checkEvaluation(cast(1.0 / 0.0, TimestampType), null)
+    checkEvaluation(cast(Float.NaN, TimestampType), null)
+    checkEvaluation(cast(1.0f / 0.0f, TimestampType), null)
+    checkEvaluation(cast(Literal(Long.MaxValue), TimestampType), Long.MaxValue)
+    // Long.MinValue is not asserted; see the comment above the test.
+  }
+
   testGluten("cast string to timestamp") {
     DebuggableThreadUtils.parmap(
       ALL_TIMEZONES

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/clickhouse/ClickHouseTestSettings.scala
@@ -374,6 +374,9 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .excludeCH("SPARK-33291: Cast struct with null elements to string")
     .excludeCH("SPARK-35111: Cast string to year-month interval")
     .excludeCH("Gluten - data type casting")
+    // The Gluten rewrite of "cast from timestamp II" is not vetted on ClickHouse;
+    // the vanilla case is excluded separately in this block.
+    .excludeGlutenTest("cast from timestamp II")
     .exclude("cast string to date #2")
     .exclude("casting to fixed-precision decimals")
     .exclude("SPARK-28470: Cast should honor nullOnOverflow property")
@@ -1180,6 +1183,8 @@ class ClickHouseTestSettings extends BackendTestSettings {
   enableSuite[GlutenMathExpressionsSuite]
     // Spark round UT for round(3.1415,3) is not correct.
     .exclude("round/bround/floor/ceil")
+    // TANH(-0.1) returns -0.0996695958408681 on ClickHouse; the case expects
+    // -0.09966799462495582.
     .excludeCH("tanh")
     .excludeCH("unhex")
     .excludeCH("atan2")
@@ -2195,8 +2200,14 @@ class ClickHouseTestSettings extends BackendTestSettings {
     .excludeCH("cast from timestamp II")
     .excludeCH("cast a timestamp before the epoch 1970-01-01 00:00:00Z II")
     .excludeCH("cast a timestamp before the epoch 1970-01-01 00:00:00Z")
+    // Casting the string array ("123", "true", "f") to array<boolean> should yield
+    // [null, true, false] under try_cast; ClickHouse throws instead.
     .excludeCH("cast from array II")
+    // TRY-mode overflow inside a complex type wraps instead of yielding null on
+    // ClickHouse: try_cast([2.147483648E9] as array<int>) returns [-2147483648].
     .excludeCH("cast from array III")
+    // Same as "cast from array III": try_cast([2.147483648E9] as struct<a:int>)
+    // returns [-2147483648] on ClickHouse.
     .excludeCH("cast from struct III")
     .excludeCH("ANSI mode: cast string to timestamp with parse error")
     .excludeCH("ANSI mode: cast string to date with parse error")

--- a/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -104,6 +104,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.
     .exclude("cast string to timestamp")
+    // Excluded in favour of the GlutenCastSuite rewrite, which drops the Long.MinValue
+    // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
     .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
@@ -589,6 +591,8 @@ class VeloxTestSettings extends BackendTestSettings {
   enableSuite[GlutenInsertSuite]
     // the native write staing dir is differnt with vanilla Spark for coustom partition paths
     .exclude("SPARK-35106: Throw exception when rename custom partition paths returns false")
+    // The case expects a SparkException; Gluten surfaces the raw
+    // FileAlreadyExistsException instead.
     .exclude("Stop task set if FileAlreadyExistsException was thrown")
     // Rewrite: Additional support for file scan with default values has been added in Spark-3.4.
     // It appends the default value in record if it is not present while scanning.

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastSuite.scala
@@ -168,6 +168,18 @@ class GlutenCastSuite extends CastWithAnsiOffSuite with GlutenTestsTrait {
     checkEvaluation(cast(false, TimestampType), tsFalse)
   }
 
+  // Gluten's glutenCheckExpression uses collect(), which triggers
+  // toJavaTimestamp -> rebaseGregorianToJulianMicros. Long.MinValue micros (~292000 BC) overflows
+  // during rebase, so the vanilla case's Long.MinValue assertion is dropped here.
+  testGluten("cast from timestamp II") {
+    checkEvaluation(cast(Double.NaN, TimestampType), null)
+    checkEvaluation(cast(1.0 / 0.0, TimestampType), null)
+    checkEvaluation(cast(Float.NaN, TimestampType), null)
+    checkEvaluation(cast(1.0f / 0.0f, TimestampType), null)
+    checkEvaluation(cast(Literal(Long.MaxValue), TimestampType), Long.MaxValue)
+    // Long.MinValue is not asserted; see the comment above the test.
+  }
+
   testGluten("cast string to timestamp") {
     DebuggableThreadUtils.parmap(
       ALL_TIMEZONES

--- a/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -114,6 +114,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.
     .exclude("cast string to timestamp")
+    // Excluded in favour of the GlutenCastWithAnsiOffSuite rewrite, which drops the Long.MinValue
+    // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
     .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
@@ -859,6 +861,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-24583 Wrong schema type in InsertIntoDataSourceCommand")
     // the native write staing dir is differnt with vanilla Spark for coustom partition paths
     .exclude("SPARK-35106: Throw exception when rename custom partition paths returns false")
+    // The case expects a SparkException; Gluten surfaces the raw
+    // FileAlreadyExistsException instead.
     .exclude("Stop task set if FileAlreadyExistsException was thrown")
     // Rewrite: Additional support for file scan with default values has been added in Spark-3.4.
     // It appends the default value in record if it is not present while scanning.

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastWithAnsiOffSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastWithAnsiOffSuite.scala
@@ -134,15 +134,14 @@ class GlutenCastWithAnsiOffSuite extends CastWithAnsiOffSuite with GlutenExpress
 
   // Gluten's glutenCheckExpression uses collect(), which triggers
   // toJavaTimestamp -> rebaseGregorianToJulianMicros. Long.MinValue micros (~292000 BC) overflows
-  // during rebase. Velox computes correctly; only the collect path fails. Skip Long.MinValue.
+  // during rebase, so the vanilla case's Long.MinValue assertion is dropped here.
   testGluten("cast from timestamp II") {
     checkEvaluation(cast(Double.NaN, TimestampType), null)
     checkEvaluation(cast(1.0 / 0.0, TimestampType), null)
     checkEvaluation(cast(Float.NaN, TimestampType), null)
     checkEvaluation(cast(1.0f / 0.0f, TimestampType), null)
     checkEvaluation(cast(Literal(Long.MaxValue), TimestampType), Long.MaxValue)
-    // Skip Long.MinValue: Velox result is correct but collect() path overflows in
-    // rebaseGregorianToJulianMicros when converting extreme timestamp to java.sql.Timestamp.
+    // Long.MinValue is not asserted; see the comment above the test.
   }
 
   // Sync session timezone with per-expression timezone and run single-threaded.

--- a/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/gluten/utils/velox/VeloxTestSettings.scala
@@ -117,6 +117,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("data type casting")
     // Revised by setting timezone through config and commented unsupported cases.
     .exclude("cast string to timestamp")
+    // Excluded in favour of the GlutenCastWithAnsiOffSuite rewrite, which drops the Long.MinValue
+    // assertion: collect() -> toJavaTimestamp -> rebaseGregorianToJulianMicros overflows.
     .exclude("cast from timestamp II")
     .exclude("SPARK-36286: invalid string cast to timestamp")
     .exclude("SPARK-39749: cast Decimal to string")
@@ -840,6 +842,8 @@ class VeloxTestSettings extends BackendTestSettings {
     .exclude("SPARK-24583 Wrong schema type in InsertIntoDataSourceCommand")
     // the native write staing dir is differnt with vanilla Spark for coustom partition paths
     .exclude("SPARK-35106: Throw exception when rename custom partition paths returns false")
+    // The case expects a SparkException; Gluten surfaces the raw
+    // FileAlreadyExistsException instead.
     .exclude("Stop task set if FileAlreadyExistsException was thrown")
     // Rewrite: Additional support for file scan with default values has been added in Spark-3.4.
     // It appends the default value in record if it is not present while scanning.

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastWithAnsiOffSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/catalyst/expressions/GlutenCastWithAnsiOffSuite.scala
@@ -132,15 +132,14 @@ class GlutenCastWithAnsiOffSuite
 
   // Gluten's glutenCheckExpression uses collect(), which triggers
   // toJavaTimestamp -> rebaseGregorianToJulianMicros. Long.MinValue micros (~292000 BC) overflows
-  // during rebase. Velox computes correctly; only the collect path fails. Skip Long.MinValue.
+  // during rebase, so the vanilla case's Long.MinValue assertion is dropped here.
   testGluten("cast from timestamp II") {
     checkEvaluation(cast(Double.NaN, TimestampType), null)
     checkEvaluation(cast(1.0 / 0.0, TimestampType), null)
     checkEvaluation(cast(Float.NaN, TimestampType), null)
     checkEvaluation(cast(1.0f / 0.0f, TimestampType), null)
     checkEvaluation(cast(Literal(Long.MaxValue), TimestampType), Long.MaxValue)
-    // Skip Long.MinValue: Velox result is correct but collect() path overflows in
-    // rebaseGregorianToJulianMicros when converting extreme timestamp to java.sql.Timestamp.
+    // Long.MinValue is not asserted; see the comment above the test.
   }
 
   // Sync session timezone with per-expression timezone and run single-threaded.


### PR DESCRIPTION
Six `.exclude(...)` entries across the Velox and ClickHouse test settings carried no comment saying what fails. This writes down all six reasons, and one of them turned out to be a real coverage gap on Spark 3.4 and 3.5. No production code.

| module | change |
|-|-|
| spark34, spark35 | a `testGluten("cast from timestamp II")` rewrite; comments in the Velox settings; a paired exclusion in the ClickHouse settings |
| spark35 | reasons for four ClickHouse exclusions, from a CI run |
| spark40, spark41 | comments in the Velox settings; two claims dropped from the rewrite they already had |

Spark 3.4.4 and 3.5.5 both assert six values in `cast from timestamp II`, the four NaN/Infinity ones plus `Long.MaxValue` and `Long.MinValue`. Spark 3.4.0 only had the four, which is why the exclusion predates the extra assertions. 4.0 and 4.1 carry a `testGluten("cast from timestamp II")` rewrite in `GlutenCastWithAnsiOffSuite` that keeps five of the six and says why the sixth is dropped: `glutenCheckExpression` uses `collect()`, which goes through `toJavaTimestamp` and `rebaseGregorianToJulianMicros`, and `Long.MinValue` microseconds overflows there.

3.4 and 3.5 have the bare exclusion and no rewrite, so on those two versions the other five assertions run nowhere. This ports the 4.0 rewrite to their `GlutenCastSuite`, which is safe because both wrappers extend the same parent, `CastWithAnsiOffSuite`. All four modules also get a comment above the vanilla exclusion so the pair is visible from the settings file.

Because the wrapper file is shared by both backends and `testGluten` registration is not backend-conditional, adding the rewrite would also have started running it under ClickHouse, which has never validated this case. The ClickHouse settings get the matching exclusion that the neighbouring `data type casting` entry already uses: `.excludeCH("Gluten - cast from timestamp II")` on spark35 and `.excludeGlutenTest("cast from timestamp II")` on spark34. Only the spark35 one has any effect, since `backends-clickhouse/pom.xml` has profiles for 3.3 and 3.5 only; the spark34 line is there to keep the two files the same shape.

The other Velox entry, `Stop task set if FileAlreadyExistsException was thrown`, is excluded in all four modules with nothing said about why; the comment on the line above it, `the native write staing dir is differnt with vanilla Spark for coustom partition paths`, belongs to the `SPARK-35106` entry between them. I removed the exclusion locally and ran `GlutenInsertSuite` against Spark 3.4.4 with Velox. 70 of 71 cases pass; this one fails:

```
- Stop task set if FileAlreadyExistsException was thrown *** FAILED ***
  Expected exception org.apache.spark.SparkException to be thrown,
  but org.apache.hadoop.fs.FileAlreadyExistsException was thrown (InsertSuite.scala:2035)
```

The case installs a `FileSystem` that throws `FileAlreadyExistsException` on create and expects Spark's write path to wrap it. Gluten surfaces the raw Hadoop exception instead, and the new comment records only that. Gluten's native write does have its own task-failure handling: `VeloxColumnarWriteFilesExec.scala` mirrors both branches of `FileFormatWriter`, so where the raw exception escapes is not something I established, and the comment does not guess at it.

The four ClickHouse entries came from #12889, now folded in here since it was the same activity on a file this PR already touches. `tanh`, `cast from array II`, `cast from array III` and `cast from struct III` are excluded on ClickHouse 3.5 with no reason recorded, and all four run on ClickHouse 3.3, so they would have lost their only run site when `gluten-ut/spark33` goes away under #12807. That made it worth removing all four and letting the ClickHouse CI answer whether the exclusions were stale. It failed all four:

```
- tanh *** FAILED ***
  Incorrect evaluation: TANH(-0.1), actual: -0.0996695958408681, expected: -0.09966799462495582
- cast from array II *** FAILED ***
  Exception evaluating try_cast([123,true,f] as array<boolean>)
- cast from array III *** FAILED ***
  Incorrect evaluation: try_cast([2.147483648E9] as array<int>),
  actual: ArraySeq(-2147483648), expected: [Lscala.runtime.Null$;@73684390
- cast from struct III *** FAILED ***
  Incorrect evaluation: try_cast([2.147483648E9] as struct<a:int>),
  actual: [-2147483648], expected: [null]
```

So those exclusions stay and only their reasons were missing. The two array/struct cases are one behaviour, TRY-mode overflow inside a complex type wrapping instead of yielding null; `tanh` differs at the sixth significant digit; `cast from array II` throws rather than returning null. Whether ClickHouse should be changed to match is out of scope here.

Two claims came out of the rewrite's own comments while addressing review, in all four modules rather than only the two this patch adds. `Velox computes correctly; only the collect path fails` is not something this repository can show, so the comment now stops at the mechanism it can. The same explanation also appeared twice, once above the test and once inside it; the inner one is now a pointer. And the exclude comment no longer names the version it was reproduced on, since the identical text sits in the 4.0 and 4.1 settings where no such run was done.

One adjacent thing left alone: the `GlutenTryCastSuite` block in all four modules excludes `cast from timestamp II` with `// Rewrite test for Gluten not supported with ANSI mode`, but no `testGluten("cast from timestamp II")` exists in that suite's wrapper, so that comment points at a rewrite that is not there. It predates this change, and its real reason is unverified, so replacing one unsupported sentence with another would not help. It needs the exclusion removed and the suite run on 3.4 to settle, which is a separate change.

`test-compile` and `spotless:check` pass on `-Pspark-3.4`, `-Pspark-3.5 -Pscala-2.13`, `-Pspark-4.0 -Pscala-2.13` and `-Pspark-4.1 -Pscala-2.13`. The five re-enabled assertions on 3.4/3.5 are for CI to confirm; the `GlutenInsertSuite` run above is on this machine, which is not authoritative for a pass but is enough to read a deterministic exception-type mismatch.

Found while auditing the excludes that have no stated reason, in preparation for removing `gluten-ut/spark33` under #12807. Related: #12863, #12886, #12889.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-5
