### PR TITLE
[VL][Iceberg] Add read evolved Iceberg schemas using recursive field identity support

### DIFF
--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergFieldIdSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergFieldIdSuite.scala
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.gluten.config.GlutenConfig
+
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.iceberg.types.Types
+
+class VeloxIcebergFieldIdSuite extends IcebergSuite {
+  testWithMinSparkVersion(
+    "field IDs: flat mixed files, case folding, type promotion, and name reuse",
+    "3.4") {
+    withTable("field_id_verify_flat") {
+      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+        spark.sql("""
+                    |CREATE TABLE field_id_verify_flat (
+                    |  id INT,
+                    |  LegacyName STRING,
+                    |  recycled BIGINT,
+                    |  widened INT,
+                    |  stable STRING
+                    |) USING iceberg
+                    |""".stripMargin)
+        spark.sql("""
+                    |INSERT INTO field_id_verify_flat
+                    |VALUES
+                    |  (1, 'old-a', 101L, 10, 's1'),
+                    |  (2, 'old-b', NULL, 20, 's2')
+                    |""".stripMargin)
+
+        val table = loadIcebergTable("field_id_verify_flat")
+        table
+          .updateSchema()
+          .renameColumn("LegacyName", "DisplayName")
+          .deleteColumn("recycled")
+          .updateColumn("widened", Types.LongType.get())
+          .moveFirst("DisplayName")
+          .commit()
+        table.updateSchema().addColumn("recycled", Types.BooleanType.get()).commit()
+        spark.catalog.refreshTable("field_id_verify_flat")
+
+        spark.sql("""
+                    |INSERT INTO field_id_verify_flat
+                    |VALUES
+                    |  ('new-c', 3, 30000000000L, 's3', true),
+                    |  ('new-d', 4, 40L, 's4', false)
+                    |""".stripMargin)
+      }
+
+      verifyNative("""
+                     |SELECT displayname, id, recycled, widened, stable
+                     |FROM field_id_verify_flat
+                     |ORDER BY id
+                     |""".stripMargin)
+      verifyNative("""
+                     |SELECT id, displayname
+                     |FROM field_id_verify_flat
+                     |WHERE displayname = 'old-a'
+                     |""".stripMargin)
+      verifyNative("""
+                     |SELECT id, recycled
+                     |FROM field_id_verify_flat
+                     |WHERE recycled = true
+                     |""".stripMargin)
+      verifyNative("SELECT count(*), sum(widened) FROM field_id_verify_flat")
+    }
+  }
+
+  testWithMinSparkVersion(
+    "field IDs: deeply nested struct rename, reorder, and name reuse",
+    "3.4") {
+    withTable("field_id_verify_struct") {
+      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+        spark.sql("""
+                    |CREATE TABLE field_id_verify_struct (
+                    |  id INT,
+                    |  profile STRUCT<
+                    |    legacy_name: STRING,
+                    |    address: STRUCT<old_city: STRING, zip: INT>,
+                    |    obsolete: BIGINT,
+                    |    score: INT
+                    |  >
+                    |) USING iceberg
+                    |""".stripMargin)
+        spark.sql("""
+                    |INSERT INTO field_id_verify_struct
+                    |VALUES
+                    |  (1, named_struct(
+                    |    'legacy_name', 'old-a',
+                    |    'address', named_struct('old_city', 'old-city', 'zip', 111),
+                    |    'obsolete', 100L,
+                    |    'score', 10)),
+                    |  (2, NULL)
+                    |""".stripMargin)
+
+        val table = loadIcebergTable("field_id_verify_struct")
+        table
+          .updateSchema()
+          .renameColumn("profile.legacy_name", "name")
+          .renameColumn("profile.address.old_city", "city")
+          .deleteColumn("profile.obsolete")
+          .moveFirst("profile.score")
+          .moveFirst("profile.address.zip")
+          .commit()
+        table
+          .updateSchema()
+          .addColumn("profile", "obsolete", Types.BooleanType.get())
+          .commit()
+        spark.catalog.refreshTable("field_id_verify_struct")
+
+        spark.sql("""
+                    |INSERT INTO field_id_verify_struct
+                    |VALUES
+                    |  (3, named_struct(
+                    |    'score', 30,
+                    |    'name', 'new-c',
+                    |    'address', named_struct('zip', 333, 'city', 'new-city'),
+                    |    'obsolete', true))
+                    |""".stripMargin)
+      }
+
+      verifyNative("SELECT id, profile FROM field_id_verify_struct ORDER BY id")
+      verifyNative("""
+                     |SELECT
+                     |  id,
+                     |  profile.name,
+                     |  profile.address.city,
+                     |  profile.address.zip,
+                     |  profile.obsolete,
+                     |  profile.score
+                     |FROM field_id_verify_struct
+                     |ORDER BY id
+                     |""".stripMargin)
+      verifyNative("""
+                     |SELECT id
+                     |FROM field_id_verify_struct
+                     |WHERE profile.address.city = 'old-city'
+                     |""".stripMargin)
+    }
+  }
+
+  testWithMinSparkVersion(
+    "field IDs: array element struct evolution with nulls and mixed files",
+    "3.4") {
+    withTable("field_id_verify_array") {
+      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+        spark.sql("""
+                    |CREATE TABLE field_id_verify_array (
+                    |  id INT,
+                    |  items ARRAY<STRUCT<legacy: STRING, obsolete: BIGINT, amount: INT>>
+                    |) USING iceberg
+                    |""".stripMargin)
+        spark.sql("""
+                    |INSERT INTO field_id_verify_array
+                    |VALUES
+                    |  (1, array(
+                    |    named_struct('legacy', 'old-item', 'obsolete', 99L, 'amount', 10),
+                    |    CAST(NULL AS STRUCT<legacy: STRING, obsolete: BIGINT, amount: INT>))),
+                    |  (2, NULL)
+                    |""".stripMargin)
+
+        val table = loadIcebergTable("field_id_verify_array")
+        table
+          .updateSchema()
+          .renameColumn("items.element.legacy", "label")
+          .deleteColumn("items.element.obsolete")
+          .moveFirst("items.element.amount")
+          .commit()
+        table
+          .updateSchema()
+          .addColumn("items.element", "obsolete", Types.BooleanType.get())
+          .commit()
+        spark.catalog.refreshTable("field_id_verify_array")
+
+        spark.sql("""
+                    |INSERT INTO field_id_verify_array
+                    |VALUES
+                    |  (3, array(
+                    |    named_struct('amount', 30, 'label', 'new-item', 'obsolete', true),
+                    |    CAST(NULL AS STRUCT<amount: INT, label: STRING, obsolete: BOOLEAN>)))
+                    |""".stripMargin)
+      }
+
+      verifyNative("SELECT id, items FROM field_id_verify_array ORDER BY id")
+      verifyNative("""
+                     |SELECT id, items[0].label, items[0].amount, items[0].obsolete
+                     |FROM field_id_verify_array
+                     |ORDER BY id
+                     |""".stripMargin)
+    }
+  }
+
+  testWithMinSparkVersion(
+    "field IDs: map value struct evolution with nulls and mixed files",
+    "3.4") {
+    withTable("field_id_verify_map") {
+      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+        spark.sql("""
+                    |CREATE TABLE field_id_verify_map (
+                    |  id INT,
+                    |  attrs MAP<
+                    |    STRING,
+                    |    STRUCT<legacy: STRING, obsolete: BIGINT, rank: INT>
+                    |  >
+                    |) USING iceberg
+                    |""".stripMargin)
+        spark.sql("""
+                    |INSERT INTO field_id_verify_map
+                    |VALUES
+                    |  (1, map(
+                    |    'a', named_struct('legacy', 'old-value', 'obsolete', 88L, 'rank', 1),
+                    |    'null-value',
+                    |      CAST(NULL AS STRUCT<legacy: STRING, obsolete: BIGINT, rank: INT>))),
+                    |  (2, NULL)
+                    |""".stripMargin)
+
+        val table = loadIcebergTable("field_id_verify_map")
+        table
+          .updateSchema()
+          .renameColumn("attrs.value.legacy", "label")
+          .deleteColumn("attrs.value.obsolete")
+          .moveFirst("attrs.value.rank")
+          .commit()
+        table
+          .updateSchema()
+          .addColumn("attrs.value", "obsolete", Types.BooleanType.get())
+          .commit()
+        spark.catalog.refreshTable("field_id_verify_map")
+
+        spark.sql("""
+                    |INSERT INTO field_id_verify_map
+                    |VALUES
+                    |  (3, map(
+                    |    'a', named_struct('rank', 3, 'label', 'new-value', 'obsolete', true),
+                    |    'null-value',
+                    |      CAST(NULL AS STRUCT<rank: INT, label: STRING, obsolete: BOOLEAN>)))
+                    |""".stripMargin)
+      }
+
+      verifyNative("SELECT id, attrs FROM field_id_verify_map ORDER BY id")
+      verifyNative("""
+                     |SELECT id, attrs['a'].label, attrs['a'].rank, attrs['a'].obsolete
+                     |FROM field_id_verify_map
+                     |ORDER BY id
+                     |""".stripMargin)
+    }
+  }
+
+  testWithMinSparkVersion(
+    "field IDs: renamed identity-partition column across mixed files",
+    "3.4") {
+    withTable("field_id_verify_partition") {
+      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+        spark.sql("""
+                    |CREATE TABLE field_id_verify_partition (
+                    |  id INT,
+                    |  category STRING,
+                    |  payload STRING
+                    |) USING iceberg
+                    |PARTITIONED BY (category)
+                    |""".stripMargin)
+        spark.sql("""
+                    |INSERT INTO field_id_verify_partition
+                    |VALUES (1, 'old-a', 'p1'), (2, 'old-b', 'p2')
+                    |""".stripMargin)
+
+        val table = loadIcebergTable("field_id_verify_partition")
+        table.updateSchema().renameColumn("category", "group_name").commit()
+        spark.catalog.refreshTable("field_id_verify_partition")
+
+        spark.sql("""
+                    |INSERT INTO field_id_verify_partition
+                    |VALUES (3, 'new-c', 'p3')
+                    |""".stripMargin)
+      }
+
+      verifyNative("""
+                     |SELECT id, group_name, payload
+                     |FROM field_id_verify_partition
+                     |ORDER BY id
+                     |""".stripMargin)
+      verifyNative("""
+                     |SELECT id
+                     |FROM field_id_verify_partition
+                     |WHERE group_name = 'old-a'
+                     |""".stripMargin)
+    }
+  }
+
+  testWithMinSparkVersion(
+    "field IDs: time travel uses the snapshot schema after name reuse",
+    "3.4") {
+    withTable("field_id_time_travel") {
+      var oldSnapshotId = 0L
+      withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
+        spark.sql("""
+                    |CREATE TABLE field_id_time_travel (
+                    |  id INT,
+                    |  recycled STRING
+                    |) USING iceberg
+                    |""".stripMargin)
+        spark.sql("INSERT INTO field_id_time_travel VALUES (1, 'old-value')")
+
+        val table = loadIcebergTable("field_id_time_travel")
+        oldSnapshotId = table.currentSnapshot().snapshotId()
+        table.updateSchema().deleteColumn("recycled").commit()
+        table
+          .updateSchema()
+          .addColumn("recycled", Types.BooleanType.get())
+          .commit()
+        spark.catalog.refreshTable("field_id_time_travel")
+
+        spark.sql("INSERT INTO field_id_time_travel VALUES (2, true)")
+      }
+
+      verifyNative(
+        s"""
+           |SELECT id, recycled
+           |FROM field_id_time_travel VERSION AS OF $oldSnapshotId
+           |ORDER BY id
+           |""".stripMargin)
+    }
+  }
+
+  private def verifyNative(sqlText: String): Unit = {
+    runQueryAndCompare(sqlText) {
+      df => checkGlutenPlan[IcebergScanTransformer](df)
+    }
+  }
+
+  private def loadIcebergTable(name: String) = {
+    spark.sessionState.catalogManager
+      .catalog("spark_catalog")
+      .asInstanceOf[TableCatalog]
+      .loadTable(Identifier.of(Array("default"), name))
+      .asInstanceOf[SparkTable]
+      .table()
+  }
+}

--- a/backends-velox/src/main/resources/org/apache/gluten/proto/IcebergReadExtension.proto
+++ b/backends-velox/src/main/resources/org/apache/gluten/proto/IcebergReadExtension.proto
@@ -11,6 +11,7 @@ message IcebergReadExtension {
   message ColumnFieldId {
     string name = 1;
     int32 field_id = 2;
+    repeated ColumnFieldId children = 3;
   }
 
   message ColumnDefault {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -573,6 +573,8 @@ object VeloxBackendSettings extends BackendSettingsApi {
 
   override def supportIcebergInitialDefaultRead(): Boolean = true
 
+  override def supportIcebergFieldIdRead(): Boolean = true
+
   override def reorderColumnsForPartitionWrite(): Boolean = true
 
   override def enableEnhancedFeatures(): Boolean = VeloxConfig.get.enableEnhancedFeatures()

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxTransformerApi.scala
@@ -25,6 +25,7 @@ import org.apache.gluten.proto.{ConfigMap, IcebergReadExtension}
 import org.apache.gluten.runtime.Runtimes
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.expression.{ExpressionBuilder, ExpressionNode}
+import org.apache.gluten.substrait.rel.IcebergFieldId
 import org.apache.gluten.utils.PartitionsUtil
 import org.apache.gluten.vectorized.PlanEvaluatorJniWrapper
 
@@ -43,7 +44,7 @@ import org.apache.spark.util.collection.BitSet
 import com.google.protobuf.{Any, Message}
 import org.apache.commons.lang3.math.NumberUtils
 
-import java.util.{Map => JMap}
+import java.util.{List => JList, Map => JMap}
 
 import scala.collection.JavaConverters._
 
@@ -125,23 +126,18 @@ class VeloxTransformerApi extends TransformerApi with Logging {
   override def packPBMessage(message: Message): Any = Any.pack(message, "")
 
   override def packIcebergReadExtension(
-      fieldIds: JMap[String, Integer],
+      fieldIds: JList[IcebergFieldId],
       initialDefaults: JMap[String, String]): Any = {
     val extensionBuilder = IcebergReadExtension.newBuilder()
-    fieldIds.asScala.toSeq.sortBy(_._1).foreach {
-      case (name, fieldId) =>
-        extensionBuilder.addColumnFieldIds(
-          IcebergReadExtension.ColumnFieldId
-            .newBuilder()
-            .setName(name)
-            .setFieldId(fieldId))
+    fieldIds.asScala.sortBy(_.getName).foreach {
+      field => extensionBuilder.addColumnFieldIds(toColumnFieldId(field))
     }
+    val fieldIdsByName = fieldIds.asScala.map(field => field.getName -> field.getFieldId).toMap
     initialDefaults.asScala.toSeq.sortBy(_._1).foreach {
       case (name, initialDefault) =>
-        val fieldId = fieldIds.get(name)
-        if (fieldId == null) {
-          throw new IllegalArgumentException(s"Missing Iceberg field ID for column $name")
-        }
+        val fieldId = fieldIdsByName.getOrElse(
+          name,
+          throw new IllegalArgumentException(s"Missing Iceberg field ID for column $name"))
         extensionBuilder.addColumnDefaults(
           IcebergReadExtension.ColumnDefault
             .newBuilder()
@@ -150,6 +146,15 @@ class VeloxTransformerApi extends TransformerApi with Logging {
             .setInitialDefault(initialDefault))
     }
     packPBMessage(extensionBuilder.build())
+  }
+
+  private def toColumnFieldId(field: IcebergFieldId): IcebergReadExtension.ColumnFieldId = {
+    val builder = IcebergReadExtension.ColumnFieldId
+      .newBuilder()
+      .setName(field.getName)
+      .setFieldId(field.getFieldId)
+    field.getChildren.asScala.foreach(child => builder.addChildren(toColumnFieldId(child)))
+    builder.build()
   }
 
   override def invalidateSQLExecutionResource(executionId: String): Unit = {

--- a/cpp/velox/compute/iceberg/IcebergPlanConverter.cc
+++ b/cpp/velox/compute/iceberg/IcebergPlanConverter.cc
@@ -17,6 +17,8 @@
 
 #include "IcebergPlanConverter.h"
 
+#include <folly/String.h>
+
 #include "IcebergReadExtension.pb.h"
 
 namespace gluten {
@@ -37,7 +39,71 @@ std::unordered_map<int32_t, std::string> parseBounds(const SubstraitDeleteBounds
   return parsed;
 }
 
+IcebergFieldIdInfo parseFieldId(const ::gluten::IcebergReadExtension::ColumnFieldId& field) {
+  IcebergFieldIdInfo parsed{field.name(), field.field_id(), {}};
+  parsed.children.reserve(field.children_size());
+  for (const auto& child : field.children()) {
+    parsed.children.emplace_back(parseFieldId(child));
+  }
+  return parsed;
+}
+
+const IcebergFieldIdInfo* findChild(const IcebergFieldIdInfo& field, const std::string& name, bool asLowerCase) {
+  for (const auto& child : field.children) {
+    if (child.name == name) {
+      return &child;
+    }
+    if (asLowerCase) {
+      auto normalizedName = child.name;
+      folly::toLowerAscii(normalizedName);
+      if (normalizedName == name) {
+        return &child;
+      }
+    }
+  }
+  return nullptr;
+}
+
 } // namespace
+
+facebook::velox::parquet::ParquetFieldId IcebergPlanConverter::toParquetFieldId(
+    const IcebergFieldIdInfo& field,
+    const facebook::velox::TypePtr& type,
+    bool asLowerCase) {
+  facebook::velox::parquet::ParquetFieldId result{field.fieldId, {}};
+  // Plans produced before nested field IDs were added only contain the root ID.
+  if (field.children.empty()) {
+    return result;
+  }
+  auto appendChild = [&](const std::string& childName, const facebook::velox::TypePtr& childType) {
+    const auto* child = findChild(field, childName, asLowerCase);
+    VELOX_USER_CHECK(child != nullptr, "Missing Iceberg field ID for nested field '{}.{}'", field.name, childName);
+    result.children.emplace_back(toParquetFieldId(*child, childType, asLowerCase));
+  };
+
+  switch (type->kind()) {
+    case facebook::velox::TypeKind::ROW: {
+      const auto& rowType = type->asRow();
+      result.children.reserve(rowType.size());
+      for (facebook::velox::column_index_t i = 0; i < rowType.size(); ++i) {
+        appendChild(rowType.nameOf(i), rowType.childAt(i));
+      }
+      break;
+    }
+    case facebook::velox::TypeKind::ARRAY:
+      result.children.reserve(1);
+      appendChild("element", type->childAt(0));
+      break;
+    case facebook::velox::TypeKind::MAP:
+      result.children.reserve(2);
+      appendChild("key", type->childAt(0));
+      appendChild("value", type->childAt(1));
+      break;
+    default:
+      break;
+  }
+  return result;
+}
 
 std::shared_ptr<IcebergSplitInfo> IcebergPlanConverter::parseIcebergSplitInfo(
     substrait::ReadRel_LocalFiles_FileOrFiles file,
@@ -67,19 +133,27 @@ std::shared_ptr<IcebergSplitInfo> IcebergPlanConverter::parseIcebergSplitInfo(
     ::gluten::IcebergReadExtension icebergExtension;
     VELOX_USER_CHECK(extension.enhancement().UnpackTo(&icebergExtension), "Failed to unpack Iceberg read extension");
     for (const auto& column : icebergExtension.column_field_ids()) {
+      auto parsedField = parseFieldId(column);
       auto [it, inserted] =
-          icebergSplitInfo->columns.try_emplace(column.name(), IcebergColumnInfo{column.field_id(), std::nullopt});
+          icebergSplitInfo->columns.try_emplace(column.name(), IcebergColumnInfo{std::move(parsedField), std::nullopt});
       if (!inserted) {
         VELOX_USER_CHECK_EQ(
-            it->second.fieldId, column.field_id(), "Conflicting Iceberg field IDs for column '{}'", column.name());
+            it->second.field.fieldId,
+            column.field_id(),
+            "Conflicting Iceberg field IDs for column '{}'",
+            column.name());
       }
     }
     for (const auto& column : icebergExtension.column_defaults()) {
       auto [it, inserted] = icebergSplitInfo->columns.try_emplace(
-          column.name(), IcebergColumnInfo{column.field_id(), column.initial_default()});
+          column.name(),
+          IcebergColumnInfo{IcebergFieldIdInfo{column.name(), column.field_id(), {}}, column.initial_default()});
       if (!inserted) {
         VELOX_USER_CHECK_EQ(
-            it->second.fieldId, column.field_id(), "Conflicting Iceberg field IDs for column '{}'", column.name());
+            it->second.field.fieldId,
+            column.field_id(),
+            "Conflicting Iceberg field IDs for column '{}'",
+            column.name());
         it->second.initialDefault = column.initial_default();
       }
     }

--- a/cpp/velox/compute/iceberg/IcebergPlanConverter.h
+++ b/cpp/velox/compute/iceberg/IcebergPlanConverter.h
@@ -20,15 +20,23 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "substrait/SubstraitToVeloxPlan.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/dwio/common/ParquetFieldId.h"
 
 using namespace facebook::velox::connector::hive::iceberg;
 
 namespace gluten {
-struct IcebergColumnInfo {
+struct IcebergFieldIdInfo {
+  std::string name;
   int32_t fieldId;
+  std::vector<IcebergFieldIdInfo> children;
+};
+
+struct IcebergColumnInfo {
+  IcebergFieldIdInfo field;
   std::optional<std::string> initialDefault;
 };
 
@@ -44,6 +52,9 @@ struct IcebergSplitInfo : SplitInfo {
 
 class IcebergPlanConverter {
  public:
+  static facebook::velox::parquet::ParquetFieldId
+  toParquetFieldId(const IcebergFieldIdInfo& field, const facebook::velox::TypePtr& type, bool asLowerCase);
+
   static std::shared_ptr<IcebergSplitInfo> parseIcebergSplitInfo(
       substrait::ReadRel_LocalFiles_FileOrFiles file,
       const substrait::extensions::AdvancedExtension& extension,

--- a/cpp/velox/substrait/SubstraitToVeloxPlan.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlan.cc
@@ -1656,7 +1656,7 @@ core::PlanNodePtr SubstraitToVeloxPlanConverter::toVeloxPlan(const ::substrait::
           colNameList[idx],
           columnType,
           veloxTypeList[idx],
-          facebook::velox::parquet::ParquetFieldId(icebergColumn->fieldId),
+          IcebergPlanConverter::toParquetFieldId(icebergColumn->field, veloxTypeList[idx], asLowerCase),
           std::vector<common::Subfield>{},
           icebergColumn->initialDefault);
     } else {

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -129,6 +129,7 @@ add_velox_test(
   Substrait2VeloxValuesNodeConversionTest.cc
   SubstraitExtensionCollectorTest.cc
   SubstraitVeloxExprConverterTest.cc
+  iceberg/IcebergPlanConverterTest.cc
   VeloxSubstraitRoundTripTest.cc
   VeloxSubstraitSignatureTest.cc
   VeloxToSubstraitTypeTest.cc)

--- a/cpp/velox/tests/iceberg/IcebergPlanConverterTest.cc
+++ b/cpp/velox/tests/iceberg/IcebergPlanConverterTest.cc
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "compute/iceberg/IcebergPlanConverter.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+namespace gluten {
+namespace {
+
+TEST(IcebergPlanConverterTest, projectsRenamedAndReorderedNestedFields) {
+  const IcebergFieldIdInfo field{
+      "profile",
+      1,
+      {
+          {"display_name", 2, {}},
+          {"address", 3, {{"city", 4, {}}, {"zip", 5, {}}}},
+      }};
+  const auto requestedType = ROW({"address", "display_name"}, {ROW({"zip"}, {VARCHAR()}), VARCHAR()});
+
+  const auto actual = IcebergPlanConverter::toParquetFieldId(field, requestedType, false);
+
+  ASSERT_EQ(actual.fieldId, 1);
+  ASSERT_EQ(actual.children.size(), 2);
+  EXPECT_EQ(actual.children[0].fieldId, 3);
+  ASSERT_EQ(actual.children[0].children.size(), 1);
+  EXPECT_EQ(actual.children[0].children[0].fieldId, 5);
+  EXPECT_EQ(actual.children[1].fieldId, 2);
+}
+
+TEST(IcebergPlanConverterTest, projectsCollectionElementFields) {
+  const IcebergFieldIdInfo field{"items", 1, {{"element", 2, {{"label", 3, {}}, {"amount", 4, {}}}}}};
+  const auto requestedType = ARRAY(ROW({"amount"}, {BIGINT()}));
+
+  const auto actual = IcebergPlanConverter::toParquetFieldId(field, requestedType, false);
+
+  ASSERT_EQ(actual.children.size(), 1);
+  EXPECT_EQ(actual.children[0].fieldId, 2);
+  ASSERT_EQ(actual.children[0].children.size(), 1);
+  EXPECT_EQ(actual.children[0].children[0].fieldId, 4);
+}
+
+TEST(IcebergPlanConverterTest, projectsMapValueFields) {
+  const IcebergFieldIdInfo field{"attributes", 1, {{"key", 2, {}}, {"value", 3, {{"label", 4, {}}, {"rank", 5, {}}}}}};
+  const auto requestedType = MAP(VARCHAR(), ROW({"rank"}, {INTEGER()}));
+
+  const auto actual = IcebergPlanConverter::toParquetFieldId(field, requestedType, false);
+
+  ASSERT_EQ(actual.children.size(), 2);
+  EXPECT_EQ(actual.children[0].fieldId, 2);
+  EXPECT_EQ(actual.children[1].fieldId, 3);
+  ASSERT_EQ(actual.children[1].children.size(), 1);
+  EXPECT_EQ(actual.children[1].children[0].fieldId, 5);
+}
+
+TEST(IcebergPlanConverterTest, acceptsLegacyRootOnlyFieldId) {
+  const IcebergFieldIdInfo field{"profile", 1, {}};
+
+  const auto actual = IcebergPlanConverter::toParquetFieldId(field, ROW({"name"}, {VARCHAR()}), false);
+
+  EXPECT_EQ(actual.fieldId, 1);
+  EXPECT_TRUE(actual.children.empty());
+}
+
+} // namespace
+} // namespace gluten

--- a/gluten-iceberg/src/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
+++ b/gluten-iceberg/src/main/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNode.java
@@ -29,7 +29,7 @@ import java.util.*;
 
 public class IcebergLocalFilesNode extends LocalFilesNode {
   private final List<List<DeleteFile>> deleteFilesList;
-  private final Map<String, Integer> fieldIds;
+  private final List<IcebergFieldId> fieldIds;
   private final Map<String, String> initialDefaults;
 
   IcebergLocalFilesNode(
@@ -42,7 +42,7 @@ public class IcebergLocalFilesNode extends LocalFilesNode {
       List<String> preferredLocations,
       List<List<DeleteFile>> deleteFilesList,
       List<Map<String, String>> metadataColumns,
-      Map<String, Integer> fieldIds,
+      List<IcebergFieldId> fieldIds,
       Map<String, String> initialDefaults) {
     super(
         index,
@@ -65,7 +65,7 @@ public class IcebergLocalFilesNode extends LocalFilesNode {
   @Override
   public ReadRel.LocalFiles toProtobuf() {
     ReadRel.LocalFiles localFiles = super.toProtobuf();
-    if (initialDefaults.isEmpty()) {
+    if (fieldIds.isEmpty() && initialDefaults.isEmpty()) {
       return localFiles;
     }
 

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -21,6 +21,7 @@ import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.IcebergScanTransformer.{containsMetadataColumn, containsUuidOrFixedType}
 import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.rel.{LocalFilesNode, SplitInfo}
+import org.apache.gluten.substrait.rel.IcebergFieldId
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.Partition
@@ -41,7 +42,7 @@ import org.apache.iceberg.types.{Type, Types}
 import org.apache.iceberg.types.Type.TypeID
 import org.apache.iceberg.types.Types.{ListType, MapType, NestedField}
 
-import java.util.{HashMap => JHashMap}
+import java.util.{ArrayList => JArrayList}
 import java.util.Locale
 
 case class IcebergScanTransformer(
@@ -70,10 +71,10 @@ case class IcebergScanTransformer(
     GlutenIcebergSourceUtil.getInitialDefaults(scan)
 
   private lazy val icebergFieldIds =
-    if (icebergInitialDefaults.isEmpty) {
-      new JHashMap[String, Integer]()
-    } else {
+    if (BackendsApiManager.getSettings.supportIcebergFieldIdRead()) {
       GlutenIcebergSourceUtil.getFieldIds(scan)
+    } else {
+      new JArrayList[IcebergFieldId]()
     }
 
   override def withNewPushdownFilters(filters: Seq[Expression]): BatchScanExecTransformerBase = {
@@ -143,7 +144,7 @@ case class IcebergScanTransformer(
         return ValidationResult.failed("Contains equality delete files")
       }
 
-      if (hasRenamedColumn) {
+      if (!BackendsApiManager.getSettings.supportIcebergFieldIdRead() && hasRenamedColumn) {
         return ValidationResult.failed(
           "The column is renamed or data type mismatch, cannot read it.")
       }

--- a/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/iceberg/spark/source/GlutenIcebergSourceUtil.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.IcebergDefaultValueUtil
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenNotSupportException
 import org.apache.gluten.execution.SparkDataSourceRDDPartition
-import org.apache.gluten.substrait.rel.{IcebergLocalFilesBuilder, SplitInfo}
+import org.apache.gluten.substrait.rel.{IcebergFieldId, IcebergLocalFilesBuilder, SplitInfo}
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 
 import org.apache.spark.softaffinity.SoftAffinity
@@ -30,6 +30,7 @@ import org.apache.spark.sql.types.StructType
 
 import org.apache.iceberg._
 import org.apache.iceberg.spark.SparkSchemaUtil
+import org.apache.iceberg.types.{Type, Types}
 
 import java.lang.{Class, Long => JLong}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
@@ -59,7 +60,7 @@ object GlutenIcebergSourceUtil {
       partition: SparkDataSourceRDDPartition,
       readPartitionSchema: StructType,
       metadataColumnNames: Seq[String],
-      fieldIds: JMap[String, Integer],
+      fieldIds: JList[IcebergFieldId],
       initialDefaults: JMap[String, String]): SplitInfo = {
     val paths = new JArrayList[String]()
     val starts = new JArrayList[JLong]()
@@ -112,12 +113,12 @@ object GlutenIcebergSourceUtil {
     )
   }
 
-  def getFieldIds(sparkScan: Scan): JHashMap[String, Integer] = {
-    val fieldIds = new JHashMap[String, Integer]()
+  def getFieldIds(sparkScan: Scan): JArrayList[IcebergFieldId] = {
+    val fieldIds = new JArrayList[IcebergFieldId]()
     sparkScan match {
       case scan: SparkBatchQueryScan =>
-        scan.table().schema().columns().asScala.foreach {
-          field => fieldIds.put(field.name(), field.fieldId())
+        scan.expectedSchema().columns().asScala.foreach {
+          field => fieldIds.add(toFieldId(field))
         }
       case _ =>
         throw new GlutenNotSupportException("Only support iceberg SparkBatchQueryScan.")
@@ -125,11 +126,27 @@ object GlutenIcebergSourceUtil {
     fieldIds
   }
 
+  private def toFieldId(field: Types.NestedField): IcebergFieldId = {
+    new IcebergFieldId(field.name(), field.fieldId(), childFieldIds(field.`type`()))
+  }
+
+  private def childFieldIds(dataType: Type): JArrayList[IcebergFieldId] = {
+    val children = new JArrayList[IcebergFieldId]()
+    if (dataType.isNestedType) {
+      dataType
+        .asNestedType()
+        .fields()
+        .asScala
+        .foreach(field => children.add(toFieldId(field)))
+    }
+    children
+  }
+
   def getInitialDefaults(sparkScan: Scan): JHashMap[String, String] = {
     val initialDefaults = new JHashMap[String, String]()
     sparkScan match {
       case scan: SparkBatchQueryScan =>
-        scan.table().schema().columns().asScala.foreach {
+        scan.expectedSchema().columns().asScala.foreach {
           field =>
             val defaultValue = IcebergDefaultValueUtil.getInitialDefault(field)
             if (defaultValue != null) {

--- a/gluten-iceberg/src/test/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNodeBoundsTest.java
+++ b/gluten-iceberg/src/test/java/org/apache/gluten/substrait/rel/IcebergLocalFilesNodeBoundsTest.java
@@ -60,7 +60,7 @@ public class IcebergLocalFilesNodeBoundsTest {
             Collections.emptyList(),
             Collections.singletonList(Collections.singletonList(deleteFile)),
             Collections.singletonList(Collections.emptyMap()),
-            Collections.emptyMap(),
+            Collections.emptyList(),
             Collections.emptyMap());
 
     ReadRel.LocalFiles.FileOrFiles.Builder fileBuilder =

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/IcebergFieldId.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/rel/IcebergFieldId.java
@@ -16,35 +16,33 @@
  */
 package org.apache.gluten.substrait.rel;
 
-import org.apache.iceberg.DeleteFile;
-
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
-public class IcebergLocalFilesBuilder {
-  public static IcebergLocalFilesNode makeIcebergLocalFiles(
-      Integer index,
-      List<String> paths,
-      List<Long> starts,
-      List<Long> lengths,
-      List<Map<String, String>> partitionColumns,
-      LocalFilesNode.ReadFileFormat fileFormat,
-      List<String> preferredLocations,
-      List<List<DeleteFile>> deleteFilesList,
-      List<Map<String, String>> metadataColumns,
-      List<IcebergFieldId> fieldIds,
-      Map<String, String> initialDefaults) {
-    return new IcebergLocalFilesNode(
-        index,
-        paths,
-        starts,
-        lengths,
-        partitionColumns,
-        fileFormat,
-        preferredLocations,
-        deleteFilesList,
-        metadataColumns,
-        fieldIds,
-        initialDefaults);
+public final class IcebergFieldId implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String name;
+  private final int fieldId;
+  private final List<IcebergFieldId> children;
+
+  public IcebergFieldId(String name, int fieldId, List<IcebergFieldId> children) {
+    this.name = name;
+    this.fieldId = fieldId;
+    this.children = Collections.unmodifiableList(new ArrayList<>(children));
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getFieldId() {
+    return fieldId;
+  }
+
+  public List<IcebergFieldId> getChildren() {
+    return children;
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/BackendSettingsApi.scala
@@ -154,6 +154,8 @@ trait BackendSettingsApi {
 
   def supportIcebergInitialDefaultRead(): Boolean = false
 
+  def supportIcebergFieldIdRead(): Boolean = false
+
   def reorderColumnsForPartitionWrite(): Boolean = false
 
   def enableEnhancedFeatures(): Boolean = false

--- a/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/TransformerApi.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/backendsapi/TransformerApi.scala
@@ -19,6 +19,7 @@ package org.apache.gluten.backendsapi
 import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.expression.ExpressionNode
+import org.apache.gluten.substrait.rel.IcebergFieldId
 
 import org.apache.spark.Partition
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
@@ -74,11 +75,11 @@ trait TransformerApi {
 
   def packPBMessage(message: Message): Any
 
-  /** Packs Iceberg column initial defaults into a backend-specific read extension. */
+  /** Packs Iceberg field identities and initial defaults into a backend-specific read extension. */
   def packIcebergReadExtension(
-      fieldIds: util.Map[String, Integer],
+      fieldIds: util.List[IcebergFieldId],
       initialDefaults: util.Map[String, String]): Any = {
-    throw new UnsupportedOperationException("Iceberg initial-default reads are not supported")
+    throw new UnsupportedOperationException("Iceberg field-ID reads are not supported")
   }
 
   /** This method is only used for CH backend tests */


### PR DESCRIPTION
Gluten previously passed only top-level Iceberg field IDs to Velox. Consequently, native reads could not reliably resolve renamed, reordered, deleted/re-added, or projected nested fields and fell back for evolved schemas.

This change propagates recursive field-ID trees for structs, arrays, and maps. Velox now builds recursive ParquetFieldId mappings and reads evolved schemas by identity instead of name.

