### PR TITLE
[VL] Refactor HashTableBuilder to use Velox API

### DIFF
--- a/cpp/velox/jni/VeloxJniWrapper.cc
+++ b/cpp/velox/jni/VeloxJniWrapper.cc
@@ -1109,7 +1109,7 @@ JNIEXPORT jlong JNICALL Java_org_apache_gluten_vectorized_HashJoinBuilder_native
           threadMemoryPool);
 
       hashTableBuilders[t] = std::move(builder);
-      otherTables[t] = std::move(hashTableBuilders[t]->uniqueTable());
+      otherTables[t] = hashTableBuilders[t]->uniqueTable();
     });
 
     futures.push_back(std::move(future));

--- a/cpp/velox/operators/hashjoin/HashTableBuilder.cc
+++ b/cpp/velox/operators/hashjoin/HashTableBuilder.cc
@@ -24,47 +24,6 @@
 #include "velox/exec/OperatorUtils.h"
 
 namespace gluten {
-namespace {
-facebook::velox::RowTypePtr hashJoinTableType(
-    const std::vector<facebook::velox::core::FieldAccessTypedExprPtr>& joinKeys,
-    const facebook::velox::RowTypePtr& inputType,
-    bool includeDependents) {
-  const auto numKeys = joinKeys.size();
-
-  std::vector<std::string> names;
-  names.reserve(includeDependents ? inputType->size() : numKeys);
-  std::vector<facebook::velox::TypePtr> types;
-  types.reserve(includeDependents ? inputType->size() : numKeys);
-  std::unordered_set<uint32_t> keyChannelSet;
-  keyChannelSet.reserve(inputType->size());
-
-  for (int i = 0; i < numKeys; ++i) {
-    auto& key = joinKeys[i];
-    auto channel = facebook::velox::exec::exprToChannel(key.get(), inputType);
-    keyChannelSet.insert(channel);
-    names.emplace_back(inputType->nameOf(channel));
-    types.emplace_back(inputType->childAt(channel));
-  }
-
-  if (!includeDependents) {
-    return ROW(std::move(names), std::move(types));
-  }
-
-  for (auto i = 0; i < inputType->size(); ++i) {
-    if (keyChannelSet.find(i) == keyChannelSet.end()) {
-      names.emplace_back(inputType->nameOf(i));
-      types.emplace_back(inputType->childAt(i));
-    }
-  }
-
-  return ROW(std::move(names), std::move(types));
-}
-
-bool isLeftNullAwareJoinWithFilter(facebook::velox::core::JoinType joinType, bool nullAware, bool withFilter) {
-  return (isAntiJoin(joinType) || isLeftSemiProjectJoin(joinType) || isLeftSemiFilterJoin(joinType)) && nullAware &&
-      withFilter;
-}
-} // namespace
 
 HashTableBuilder::HashTableBuilder(
     facebook::velox::core::JoinType joinType,
@@ -124,7 +83,7 @@ HashTableBuilder::HashTableBuilder(
     }
   }
 
-  tableType_ = hashJoinTableType(joinKeys, inputType, !dropDuplicates_);
+  tableType_ = facebook::velox::exec::hashJoinTableType(joinKeys, inputType, dropDuplicates_);
   setupTable();
 
   if (isAntiJoin(joinType_) && withFilter_ && filterPropagatesNulls_) {
@@ -219,7 +178,7 @@ void HashTableBuilder::setupTable() {
     // Right semi join needs to tag build rows that were probed.
     const bool needProbedFlag = isRightSemiFilterJoin(joinType_);
     const bool hasCountFlag = facebook::velox::core::isCountingJoin(joinType_);
-    if (isLeftNullAwareJoinWithFilter(joinType_, nullAware_, withFilter_)) {
+    if (facebook::velox::exec::isLeftNullAwareJoinWithFilter(joinType_, nullAware_, withFilter_)) {
       // We need to check null key rows in build side in case of null-aware anti
       // or left semi project join with filter set.
       uniqueTable_ = facebook::velox::exec::HashTable<false>::createForJoin(
@@ -266,7 +225,7 @@ void HashTableBuilder::addInput(facebook::velox::RowVectorPtr input) {
   }
 
   if (!isRightJoin(joinType_) && !isFullJoin(joinType_) && !isRightSemiProjectJoin(joinType_) &&
-      !isLeftNullAwareJoinWithFilter(joinType_, nullAware_, withFilter_)) {
+      !facebook::velox::exec::isLeftNullAwareJoinWithFilter(joinType_, nullAware_, withFilter_)) {
     deselectRowsWithNulls(hashers, activeRows_);
     if (nullAware_ && !joinHasNullKeys_ && activeRows_.countSelected() < input->size()) {
       joinHasNullKeys_ = true;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->

1. HashTableBuilder can directly call Velox API after https://github.com/facebookincubator/velox/pull/18322 merged.
2. Fix following warning :

```
[85/132] Building CXX object velox/CMakeFiles/velox.dir/jni/VeloxJniWrapper.cc.o

/Users/kejia/github/bob/incubator-gluten/cpp/velox/jni/VeloxJniWrapper.cc:1112:24: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]

 1112 |       otherTables[t] = std::move(hashTableBuilders[t]->uniqueTable());

      |                        ^

/Users/kejia/github/bob/incubator-gluten/cpp/velox/jni/VeloxJniWrapper.cc:1112:24: note: remove std::move call here

 1112 |       otherTables[t] = std::move(hashTableBuilders[t]->uniqueTable());

      |                        ^~~~~~~~~~                                   ~

1 warning generated. 

```
## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
Existing unit tests
## Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
