### PR TITLE
[GLUTEN-12924][VL] Defer literal node construction for InSet to reduce memory

### DIFF
--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ExpressionBuilder.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/ExpressionBuilder.java
@@ -256,6 +256,11 @@ public class ExpressionBuilder {
     return new SingularOrListNode(value, expressionNodes);
   }
 
+  public static SingularOrListNode makeSingularOrListNode(
+      ExpressionNode value, List<Object> rawValues, org.apache.spark.sql.types.DataType dataType) {
+    return new SingularOrListNode(value, rawValues, dataType);
+  }
+
   public static WindowFunctionNode makeWindowFunction(
       Integer functionId,
       List<ExpressionNode> expressionNodes,

--- a/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/SingularOrListNode.java
+++ b/gluten-substrait/src/main/java/org/apache/gluten/substrait/expression/SingularOrListNode.java
@@ -17,6 +17,7 @@
 package org.apache.gluten.substrait.expression;
 
 import io.substrait.proto.Expression;
+import org.apache.spark.sql.types.DataType;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -25,18 +26,39 @@ import java.util.List;
 public class SingularOrListNode implements ExpressionNode, Serializable {
   private final ExpressionNode value;
   private final List<ExpressionNode> listNodes = new ArrayList<>();
+  // rawValues and dataType allow delaying literal node construction until toProtobuf()
+  private final List<Object> rawValues;
+  private final DataType dataType;
 
   SingularOrListNode(ExpressionNode value, List<ExpressionNode> listNodes) {
     this.value = value;
     this.listNodes.addAll(listNodes);
+    this.rawValues = null;
+    this.dataType = null;
+  }
+
+  SingularOrListNode(ExpressionNode value, List<Object> rawValues, DataType dataType) {
+    this.value = value;
+    this.rawValues = new ArrayList<>(rawValues);
+    this.dataType = dataType;
   }
 
   @Override
   public Expression toProtobuf() {
     Expression.SingularOrList.Builder builder = Expression.SingularOrList.newBuilder();
     builder.setValue(value.toProtobuf());
-    for (ExpressionNode expressionNode : listNodes) {
-      builder.addOptions(expressionNode.toProtobuf());
+    if (!listNodes.isEmpty()) {
+      for (ExpressionNode expressionNode : listNodes) {
+        builder.addOptions(expressionNode.toProtobuf());
+      }
+    } else if (rawValues != null) {
+      for (Object obj : rawValues) {
+        // construct a temporary LiteralNode and convert to protobuf to avoid keeping
+        // many LiteralNode objects in memory at once. Use per-value nullability.
+        LiteralNode literalNode =
+            (LiteralNode) ExpressionBuilder.makeLiteral(obj, dataType, obj == null);
+        builder.addOptions(literalNode.toProtobuf());
+      }
     }
     Expression.Builder expressionBuilder = Expression.newBuilder();
     expressionBuilder.setSingularOrList(builder);

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/PredicateExpressionTransformer.scala
@@ -40,10 +40,18 @@ case class InSetTransformer(
     original: InSet)
   extends UnaryExpressionTransformer {
   override def doTransform(context: SubstraitContext): ExpressionNode = {
-    InExpressionTransformer.toTransformer(
-      child.doTransform(context),
-      original.hset,
-      original.child.dataType)
+    val leftNode = child.doTransform(context)
+    val values = original.hset
+    val valueType = original.child.dataType
+
+    // Keep raw literal values and defer building LiteralNode objects until toProtobuf().
+    val rawValues = new java.util.ArrayList[Object](
+      values.toSeq
+        // Sort elements for deterministic behaviours.
+        .sortBy(Literal(_, valueType).toString())
+        .map(_.asInstanceOf[Object])
+        .asJava)
+    ExpressionBuilder.makeSingularOrListNode(leftNode, rawValues, valueType)
   }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR reduces driver-side memory usage when converting large `InSet` expressions to Substrait.

  Before this change, `InSetTransformer` eagerly materialized one Substrait `LiteralNode` for each element in the IN set and stored all of them in `SingularOrListNode`. For large IN lists, this creates a large
  number of intermediate objects and increases retained heap usage before protobuf serialization.

  This PR changes the flow as follows:

  - `InSetTransformer` keeps the raw IN-set values together with the child data type, instead of eagerly building one `LiteralNode` per value.
  - `SingularOrListNode` constructs the corresponding Substrait literal protobuf entries lazily in `toProtobuf()`.
  - During protobuf serialization, options are appended to the builder directly, instead of first collecting them into an extra temporary `List<Expression>`.
  - The existing deterministic ordering is preserved by sorting IN-set values with the same `Literal(_, valueType).toString()` logic as before.

  In short, this patch reduces the number of long-lived intermediate objects created for large `InSet` expressions and also avoids an extra temporary protobuf list during serialization.

  ## Why are the changes needed?

  Queries with very large `IN (...)` predicates may be optimized by Spark into `InSet`. In Gluten's Substrait conversion path, eagerly creating and retaining one `LiteralNode` per IN-set value can cause high memory
  pressure on the driver.

  The issue is especially visible for large IN lists, where the conversion step itself may consume much more memory than necessary even though the final serialized representation is only needed at protobuf
  generation time.

  By deferring literal node construction until `toProtobuf()`, we reduce retained heap usage in the expression tree and lower peak allocation pressure in the conversion path.

## How was this patch tested?
Manually.

## Was this patch authored or co-authored using generative AI tooling?
No.

Related issue: #12924