### PR TITLE
[GLUTEN-12858][TEST] Unpersist cached DataFrames in flatten test

### DIFF
--- a/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
+++ b/gluten-ut/spark33/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
@@ -70,7 +70,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testInt()
     // Test with cached relation, the Project will be evaluated with codegen
     intDF.cache()
-    testInt()
+    try {
+      testInt()
+    } finally {
+      intDF.unpersist()
+    }
 
     // Test cases with non-primitive types
     val strDF = Seq(
@@ -97,7 +101,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testString()
     // Test with cached relation, the Project will be evaluated with codegen
     strDF.cache()
-    testString()
+    try {
+      testString()
+    } finally {
+      strDF.unpersist()
+    }
 
     val arrDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
 
@@ -114,7 +122,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testArray()
     // Test with cached relation, the Project will be evaluated with codegen
     arrDF.cache()
-    testArray()
+    try {
+      testArray()
+    } finally {
+      arrDF.unpersist()
+    }
 
     // Error test cases
     val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")

--- a/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
+++ b/gluten-ut/spark34/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
@@ -132,7 +132,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testInt()
     // Test with cached relation, the Project will be evaluated with codegen
     intDF.cache()
-    testInt()
+    try {
+      testInt()
+    } finally {
+      intDF.unpersist()
+    }
 
     // Test cases with non-primitive types
     val strDF = Seq(
@@ -159,7 +163,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testString()
     // Test with cached relation, the Project will be evaluated with codegen
     strDF.cache()
-    testString()
+    try {
+      testString()
+    } finally {
+      strDF.unpersist()
+    }
 
     val arrDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
 
@@ -176,7 +184,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testArray()
     // Test with cached relation, the Project will be evaluated with codegen
     arrDF.cache()
-    testArray()
+    try {
+      testArray()
+    } finally {
+      arrDF.unpersist()
+    }
 
     // Error test cases
     val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")

--- a/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
+++ b/gluten-ut/spark35/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
@@ -70,7 +70,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testInt()
     // Test with cached relation, the Project will be evaluated with codegen
     intDF.cache()
-    testInt()
+    try {
+      testInt()
+    } finally {
+      intDF.unpersist()
+    }
 
     // Test cases with non-primitive types
     val strDF = Seq(
@@ -97,7 +101,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testString()
     // Test with cached relation, the Project will be evaluated with codegen
     strDF.cache()
-    testString()
+    try {
+      testString()
+    } finally {
+      strDF.unpersist()
+    }
 
     val arrDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
 
@@ -114,7 +122,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testArray()
     // Test with cached relation, the Project will be evaluated with codegen
     arrDF.cache()
-    testArray()
+    try {
+      testArray()
+    } finally {
+      arrDF.unpersist()
+    }
 
     // Error test cases
     val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")

--- a/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
+++ b/gluten-ut/spark40/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
@@ -298,7 +298,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testInt()
     // Test with cached relation, the Project will be evaluated with codegen
     intDF.cache()
-    testInt()
+    try {
+      testInt()
+    } finally {
+      intDF.unpersist()
+    }
 
     // Test cases with non-primitive types
     val strDF = Seq(
@@ -325,7 +329,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testString()
     // Test with cached relation, the Project will be evaluated with codegen
     strDF.cache()
-    testString()
+    try {
+      testString()
+    } finally {
+      strDF.unpersist()
+    }
 
     val arrDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
 
@@ -342,7 +350,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testArray()
     // Test with cached relation, the Project will be evaluated with codegen
     arrDF.cache()
-    testArray()
+    try {
+      testArray()
+    } finally {
+      arrDF.unpersist()
+    }
 
     // Error test cases
     val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")

--- a/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
+++ b/gluten-ut/spark41/src/test/scala/org/apache/spark/sql/GlutenDataFrameFunctionsSuite.scala
@@ -298,7 +298,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testInt()
     // Test with cached relation, the Project will be evaluated with codegen
     intDF.cache()
-    testInt()
+    try {
+      testInt()
+    } finally {
+      intDF.unpersist()
+    }
 
     // Test cases with non-primitive types
     val strDF = Seq(
@@ -325,7 +329,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testString()
     // Test with cached relation, the Project will be evaluated with codegen
     strDF.cache()
-    testString()
+    try {
+      testString()
+    } finally {
+      strDF.unpersist()
+    }
 
     val arrDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")
 
@@ -342,7 +350,11 @@ class GlutenDataFrameFunctionsSuite extends DataFrameFunctionsSuite with GlutenS
     testArray()
     // Test with cached relation, the Project will be evaluated with codegen
     arrDF.cache()
-    testArray()
+    try {
+      testArray()
+    } finally {
+      arrDF.unpersist()
+    }
 
     // Error test cases
     val oneRowDF = Seq((1, "a", Seq(1, 2, 3))).toDF("i", "s", "arr")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Wrap each cached branch of the `flatten function` test in `try`/`finally` and unpersist its DataFrame after the cached assertions complete. The same lifecycle fix is applied to the Spark 3.3, 3.4, 3.5, 4.0, and 4.1 suites.

Previously, each version left three DataFrames cached for the rest of the suite. The updated test keeps at most one of these relations cached and releases it on both success and assertion failure, reducing unnecessary CPU-memory pressure and order sensitivity.

Fixes #12858.

## How was this patch tested?

- Spotless passed for all five touched Spark modules
- Spark 3.5 targeted `test-compile` reactor: 12/12 modules passed, `BUILD SUCCESS`
- `javap` confirmed all three normal and exceptional paths call `Dataset.unpersist()`
- static lifecycle check per version: 3 `cache`, 3 `try`, 3 `finally`, and 3 `unpersist` calls
- `git diff --check`: passed

The JNI runtime suite was not run because this checkout has no prebuilt `libgluten.so`; building the native backend exceeds the available 30 GiB host-memory budget. The repository-wide formatter was also attempted but is currently blocked by a pre-existing formatting error in untouched `gluten-iceberg/.../IcebergLocalFilesNode.java`; all five touched modules pass their focused Spotless checks.

No GPU was used or required.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)

The implementation and this description were generated at the account owner's request. Codex re-checked the final diff against repository code and ran the validations listed above. No separate human line-by-line code review was performed before submission.
