### PR TITLE
[MINOR][VL] Flatten backends-velox pom

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -319,6 +319,10 @@
         <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
## What changes are proposed in this pull request?
Enable `flatten-maven-plugin` for `backends-velox`.

This is similar to https://github.com/apache/gluten/issues/11958, when running following test command in Spark 4.x, maven resolved arrow version 15, while Spark 4.x requires arrow 18, then the test failed:
```bash
 java.lang.NoClassDefFoundError: org/apache/arrow/vector/types/pojo/ArrowType$Utf8View
        at org.apache.arrow.c.SchemaExporter.export(SchemaExporter.java:70)
        at org.apache.arrow.c.Data.exportField(Data.java:55)
        at org.apache.arrow.c.Data.exportSchema(Data.java:72)
        at org.apache.gluten.utils.ArrowAbiUtil$.exportSchema(ArrowAbiUtil.scala:134)
        at org.apache.gluten.execution.RowToVeloxColumnarExec$.toColumnarBatchIterator(RowToVeloxColumnarExec.scala:140)
```

## How was this patch tested?
Pass test:
```bash
build/mvn test -Dtest=none -Pspark-4.1 -Pscala-2.13 -Pjava-17 -Pbackends-velox -Pspark-ut -DargLine="-Dspark.test.home=/opt/shims/spark41/spark_home/ -Dspark.testing=true" -pl gluten-ut/spark41 -Dsuites="org.apache.spark.sql.execution.datasources.parquet.GlutenParquetIOSuite"
```


## Was this patch authored or co-authored using generative AI tooling?
No.