### PR TITLE
[GLUTEN-12807][CORE] Clean up Spark shims APIs after Spark 3.3 deprecation

### DIFF
--- a/.github/skills/ansi-analysis/SKILL.md
+++ b/.github/skills/ansi-analysis/SKILL.md
@@ -66,7 +66,7 @@ The script loads the same shared prompt and calls the GitHub Models API.
 
 When the user pastes one failing test:
 1. Locate its JSON entry under `target/ansi-offload/`
-2. Apply the self-investigation steps from shared.md (extract Velox file:line, check `isAnsiSupported`, cross-check `withAnsiEvalMode` in the shim)
+2. Apply the self-investigation steps from shared.md (extract Velox file:line, check `isAnsiSupported`, cross-check `withAnsiEvalMode` in ExpressionUtils)
 3. Output: Symptom / Root Cause / Fix Point / Representative Tests / Estimated Impact
 
 ## Step 5 — Optional PR comment

--- a/.github/skills/ansi-analysis/shared.md
+++ b/.github/skills/ansi-analysis/shared.md
@@ -53,7 +53,7 @@ Each recommendation includes:
 Key source locations (for reference):
 
 Spark plan layer (Scala):
-- ANSI Cast/arithmetic detection: shims/sparkXX/src/main/scala/org/apache/gluten/sql/shims/sparkXX/SparkXXShims.scala (withAnsiEvalMode). Variants per Spark version: shims/spark34/, shims/spark35/, shims/spark40/, shims/spark41/
+- ANSI Cast/arithmetic detection: gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala (withAnsiEvalMode)
 - ANSI fallback rule: gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/FallbackRules.scala (enableAnsiMode && enableAnsiFallback check)
 - ANSI config: gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala (enableAnsiFallback, GLUTEN_ANSI_FALLBACK_ENABLED = spark.gluten.sql.ansiFallback.enabled, default true)
 
@@ -97,7 +97,7 @@ You SHOULD:
 1. Extract Velox file path + line number from failCause strings
 2. Read those Velox source files to verify your root cause analysis
 3. Always check `isAnsiSupported()` in SparkCastExpr.cpp when the failure involves Cast — this function gates which casts honor ANSI semantics. Currently only String→{Boolean, Date, Integral} are supported; all other ANSI casts silently fall back to try_cast (most common root cause of NO_EXCEPTION failures involving Cast). Use grep to locate the current implementation.
-4. Cross-reference with `withAnsiEvalMode` in the appropriate shims/sparkXX/.../SparkXXShims.scala to confirm the Spark plan sent the expression with the ANSI tag.
+4. Cross-reference with `withAnsiEvalMode` in gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala to confirm the Spark plan sent the expression with the ANSI tag.
 5. **For Fallback (🔴) records — the highest-priority class — you MUST trace which validator rejected the expression**:
    a. First grep `getTypeNode` and `GlutenNotSupportException` in `gluten-substrait/.../ConverterUtils.scala` to check whether the expression's input/output Spark DataType is in the unsupported list (interval types, certain complex/nested types, etc.). This is the single most common Fallback cause.
    b. If the type is supported, check `Validators.scala` (`fallbackByBackendSettings`, `fallbackByUserOptions`, `fallbackByTimestampNTZ`, `fallbackByNativeValidation`, etc.) to identify which gate fires.

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHIteratorApi.scala
@@ -25,6 +25,7 @@ import org.apache.gluten.sql.shims.{DeltaShimLoader, SparkShimLoader}
 import org.apache.gluten.substrait.plan.PlanNode
 import org.apache.gluten.substrait.rel._
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
+import org.apache.gluten.utils.FileMetadataUtil
 import org.apache.gluten.vectorized.{BatchIterator, CHNativeExpressionEvaluator, CloseableCHColumnBatchIterator}
 
 import org.apache.spark.{InterruptibleIterator, Partition, SparkConf, TaskContext}
@@ -175,7 +176,7 @@ class CHIteratorApi extends IteratorApi with Logging with LogLevelUtil {
             lengths.add(JLong.valueOf(file.length))
             val metadataColumn =
               if (needMetadataColumns) {
-                SparkShimLoader.getSparkShims
+                FileMetadataUtil
                   .generateMetadataColumns(file, metadataColumnNames)
                   .asJava
               } else {

--- a/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
+++ b/backends-clickhouse/src/main/scala/org/apache/gluten/backendsapi/clickhouse/CHRuleApi.scala
@@ -29,7 +29,6 @@ import org.apache.gluten.extension.columnar.validator.{Validator, Validators}
 import org.apache.gluten.extension.injector.{Injector, SparkInjector}
 import org.apache.gluten.extension.injector.GlutenInjector.LegacyInjector
 import org.apache.gluten.parser.{GlutenCacheFilesSqlParser, GlutenClickhouseSqlParser}
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.{CHAggregateFunctionRewriteRule, EqualToRewrite}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -146,9 +145,6 @@ object CHRuleApi {
     // Gluten columnar: Post rules.
     injector.injectPost(c => RemoveTopmostColumnarToRow(c.session, c.caller.isAqe()))
     injector.injectPost(c => CHRemoveTopmostColumnarToRow(c.session, c.caller.isAqe()))
-    SparkShimLoader.getSparkShims
-      .getExtendedColumnarPostRules()
-      .foreach(each => injector.injectPost(c => intercept(each(c.session))))
     injector.injectPost(c => ColumnarCollapseTransformStages(new GlutenConfig(c.sqlConf)))
     injector.injectPost(_ => GenerateTransformStageId())
     injector.injectPost(

--- a/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHAggAndShuffleBenchmark.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/spark/sql/execution/benchmarks/CHAggAndShuffleBenchmark.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.benchmarks
 import org.apache.gluten.backendsapi.clickhouse.CHBackendSettings
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution.{FileSourceScanExecTransformer, ProjectExecTransformer, WholeStageTransformer}
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.benchmark.Benchmark
@@ -29,8 +28,9 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.{ColumnarCollapseTransformStages, ColumnarShuffleExchangeExec, FileSourceScanExec, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.benchmark.SqlBasedBenchmark
 import org.apache.spark.sql.execution.benchmarks.utils.FakeFileOutputStream
-import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
+import org.apache.spark.sql.execution.datasources.{FilePartition, FileScanRDD, PartitionedFile}
 import org.apache.spark.sql.execution.exchange.{ENSURE_REQUIREMENTS, ShuffleExchangeExec}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.storage.ShuffleBlockId
 
@@ -330,9 +330,15 @@ object CHAggAndShuffleBenchmark extends SqlBasedBenchmark with CHSqlBasedBenchma
         )
 
       val newFileScanRDD =
-        SparkShimLoader.getSparkShims
-          .generateFileScanRDD(spark, readFile, filePartitions, sparkFileScan)
-          .asInstanceOf[RDD[ColumnarBatch]]
+        new FileScanRDD(
+          spark,
+          readFile,
+          filePartitions,
+          new StructType(
+            sparkFileScan.requiredSchema.fields ++
+              sparkFileScan.relation.partitionSchema.fields),
+          sparkFileScan.fileConstantMetadataColumns
+        ).asInstanceOf[RDD[ColumnarBatch]]
 
       // Get the total row count
       val rowCnt = newFileScanRDD

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxBackend.scala
@@ -25,7 +25,6 @@ import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
 import org.apache.gluten.extension.columnar.cost.{LegacyCoster, LongCoster, RoughCoster}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionFunc}
-import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.rel.LocalFilesNode
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}
@@ -550,9 +549,7 @@ object VeloxBackendSettings extends BackendSettingsApi {
   override def staticPartitionWriteOnly(): Boolean = true
 
   override def enableNativeWriteFiles(): Boolean = {
-    GlutenConfig.get.enableNativeWriter.getOrElse(
-      SparkShimLoader.getSparkShims.enableNativeWriteFilesByDefault()
-    )
+    GlutenConfig.get.enableNativeWriter.getOrElse(true)
   }
 
   override def shouldRewriteCount(): Boolean = {

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxIteratorApi.scala
@@ -27,6 +27,7 @@ import org.apache.gluten.substrait.plan.PlanNode
 import org.apache.gluten.substrait.rel.{LocalFilesBuilder, LocalFilesNode, SplitInfo}
 import org.apache.gluten.substrait.rel.LocalFilesNode.ColumnMappingMode
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
+import org.apache.gluten.utils.FileMetadataUtil
 import org.apache.gluten.vectorized._
 
 import org.apache.spark.{Partition, SparkConf, TaskContext}
@@ -128,7 +129,7 @@ class VeloxIteratorApi extends IteratorApi with Logging {
         partitionFiles
           .map(
             f =>
-              SparkShimLoader.getSparkShims.generateMetadataColumns(f, metadataColumnNames).asJava)
+              FileMetadataUtil.generateMetadataColumns(f, metadataColumnNames).asJava)
           .asJava
       } else {
         java.util.Collections.nCopies(partitionFiles.size, emptyMetadataColumn)

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxRuleApi.scala
@@ -138,9 +138,6 @@ object VeloxRuleApi {
 
     // Gluten columnar: Post rules.
     injector.injectPost(c => RemoveTopmostColumnarToRow(c.session, c.caller.isAqe()))
-    SparkShimLoader.getSparkShims
-      .getExtendedColumnarPostRules()
-      .foreach(each => injector.injectPost(c => each(c.session)))
     injector.injectPost(c => ColumnarCollapseTransformStages(new GlutenConfig(c.sqlConf)))
     injector.injectPost(_ => GenerateTransformStageId())
     injector.injectPost(c => CudfNodeValidationRule(new GlutenConfig(c.sqlConf)))

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -1467,13 +1467,12 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
       left: ExpressionTransformer,
       right: ExpressionTransformer,
       original: Expression): ExpressionTransformer = {
-    // Since spark 3.3.0
-    val extract =
-      SparkShimLoader.getSparkShims.extractExpressionTimestampDiffUnit(original)
-    if (extract.isEmpty) {
-      throw new UnsupportedOperationException(s"Not support expression TimestampDiff.")
+    val unit = original match {
+      case timestampDiff: TimestampDiff => timestampDiff.unit
+      case _ =>
+        throw new UnsupportedOperationException(s"Not support expression TimestampDiff.")
     }
-    TimestampDiffTransformer(substraitExprName, extract.get, left, right, original)
+    TimestampDiffTransformer(substraitExprName, unit, left, right, original)
   }
 
   override def genToUnixTimestampTransformer(

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -1457,7 +1457,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
     val extract =
       SparkShimLoader.getSparkShims.extractExpressionTimestampAddUnit(original)
     if (extract.isEmpty) {
-      throw new UnsupportedOperationException(s"Not support expression TimestampAdd.")
+      throw new UnsupportedOperationException("Not support expression TimestampAdd.")
     }
     TimestampAddTransformer(substraitExprName, extract.get.head, left, right, original)
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -1470,7 +1470,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
     val unit = original match {
       case timestampDiff: TimestampDiff => timestampDiff.unit
       case _ =>
-        throw new UnsupportedOperationException(s"Not support expression TimestampDiff.")
+        throw new UnsupportedOperationException("Not support expression TimestampDiff.")
     }
     TimestampDiffTransformer(substraitExprName, unit, left, right, original)
   }

--- a/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/backendsapi/velox/VeloxSparkPlanExecApi.scala
@@ -148,7 +148,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
       right: ExpressionTransformer,
       original: Expression,
       checkArithmeticExprName: String): ExpressionTransformer = {
-    if (SparkShimLoader.getSparkShims.withTryEvalMode(original)) {
+    if (ExpressionUtils.withTryEvalMode(original)) {
       original.dataType match {
         case LongType | IntegerType | ShortType | ByteType =>
         case _ =>
@@ -159,7 +159,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
         ExpressionMappings.expressionsMap(classOf[TryEval]),
         Seq(GenericExpressionTransformer(checkArithmeticExprName, Seq(left, right), original)),
         original)
-    } else if (SparkShimLoader.getSparkShims.withAnsiEvalMode(original)) {
+    } else if (ExpressionUtils.withAnsiEvalMode(original)) {
       GenericExpressionTransformer(checkArithmeticExprName, Seq(left, right), original)
     } else {
       GenericExpressionTransformer(substraitExprName, Seq(left, right), original)
@@ -1240,7 +1240,7 @@ class VeloxSparkPlanExecApi extends SparkPlanExecApi with Logging {
       substraitExprName: String,
       child: ExpressionTransformer,
       expr: UnBase64): ExpressionTransformer = {
-    if (SparkShimLoader.getSparkShims.unBase64FunctionFailsOnError(expr)) {
+    if (expr.failOnError) {
       GlutenExceptionUtil
         .throwsNotFullySupported(
           ExpressionNames.UNBASE64,

--- a/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
+++ b/gluten-iceberg/src/main/scala/org/apache/gluten/execution/IcebergScanTransformer.scala
@@ -356,8 +356,8 @@ object IcebergScanTransformer {
       batchScan.output.map(a => a.withName(AvroSchemaUtil.makeCompatibleName(a.name))),
       batchScan.scan,
       batchScan.runtimeFilters,
-      table = SparkShimLoader.getSparkShims.getBatchScanExecTable(batchScan),
-      keyGroupedPartitioning = SparkShimLoader.getSparkShims.getKeyGroupedPartitioning(batchScan),
+      table = batchScan.table,
+      keyGroupedPartitioning = batchScan.keyGroupedPartitioning,
       commonPartitionValues = SparkShimLoader.getSparkShims.getCommonPartitionValues(batchScan)
     )
   }

--- a/gluten-paimon/src-paimon/main/scala/org/apache/gluten/execution/PaimonScanTransformer.scala
+++ b/gluten-paimon/src-paimon/main/scala/org/apache/gluten/execution/PaimonScanTransformer.scala
@@ -221,8 +221,8 @@ object PaimonScanTransformer {
       batchScan.output,
       batchScan.scan,
       batchScan.runtimeFilters,
-      table = SparkShimLoader.getSparkShims.getBatchScanExecTable(batchScan),
-      keyGroupedPartitioning = SparkShimLoader.getSparkShims.getKeyGroupedPartitioning(batchScan),
+      table = batchScan.table,
+      keyGroupedPartitioning = batchScan.keyGroupedPartitioning,
       commonPartitionValues = SparkShimLoader.getSparkShims.getCommonPartitionValues(batchScan)
     )
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/execution/ScanTransformerFactory.scala
@@ -44,9 +44,8 @@ object ScanTransformerFactory {
       batchScanExec.output,
       batchScanExec.scan,
       batchScanExec.runtimeFilters,
-      keyGroupedPartitioning =
-        SparkShimLoader.getSparkShims.getKeyGroupedPartitioning(batchScanExec),
-      table = SparkShimLoader.getSparkShims.getBatchScanExecTable(batchScanExec)
+      keyGroupedPartitioning = batchScanExec.keyGroupedPartitioning,
+      table = batchScanExec.table
     )
   }
 }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionConverter.scala
@@ -845,9 +845,12 @@ object ExpressionConverter extends SQLConfHelper with Logging {
           replaceWithExpressionTransformer0(a.function, attributeSeq, expressionsMap),
           a
         )
-      case arrayInsert if arrayInsert.getClass.getSimpleName.equals("ArrayInsert") =>
-        // Since spark 3.4.0
-        val children = SparkShimLoader.getSparkShims.extractExpressionArrayInsert(arrayInsert)
+      case arrayInsert: ArrayInsert =>
+        val children = Seq(
+          arrayInsert.srcArrayExpr,
+          arrayInsert.posExpr,
+          arrayInsert.itemExpr,
+          Literal(arrayInsert.legacyNegativeIndex))
         BackendsApiManager.getSparkPlanExecApiInstance.genArrayInsertTransformer(
           substraitExprName,
           children.map(replaceWithExpressionTransformer0(_, attributeSeq, expressionsMap)),

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/ExpressionUtils.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.gluten.expression
 
-import org.apache.spark.sql.catalyst.expressions.{Expression, LeafExpression}
+import org.apache.spark.sql.catalyst.expressions.{Add, Cast, Divide, EvalMode, Expression, IntegralDivide, LeafExpression, Multiply, Subtract}
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructType}
 
@@ -48,6 +48,29 @@ object ExpressionUtils {
       case ArrayType(elementType, _) => hasUppercaseStructFieldName(elementType)
       case MapType(keyType, valueType, _) =>
         hasUppercaseStructFieldName(keyType) || hasUppercaseStructFieldName(valueType)
+      case _ => false
+    }
+  }
+
+  def withTryEvalMode(expr: Expression): Boolean = {
+    expr match {
+      case a: Add => a.evalMode == EvalMode.TRY
+      case s: Subtract => s.evalMode == EvalMode.TRY
+      case d: Divide => d.evalMode == EvalMode.TRY
+      case m: Multiply => m.evalMode == EvalMode.TRY
+      case c: Cast => c.evalMode == EvalMode.TRY
+      case _ => false
+    }
+  }
+
+  def withAnsiEvalMode(expr: Expression): Boolean = {
+    expr match {
+      case a: Add => a.evalMode == EvalMode.ANSI
+      case s: Subtract => s.evalMode == EvalMode.ANSI
+      case d: Divide => d.evalMode == EvalMode.ANSI
+      case m: Multiply => m.evalMode == EvalMode.ANSI
+      case c: Cast => c.evalMode == EvalMode.ANSI
+      case i: IntegralDivide => i.evalMode == EvalMode.ANSI
       case _ => false
     }
   }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/expression/UnaryExpressionTransformer.scala
@@ -18,7 +18,6 @@ package org.apache.gluten.expression
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.exception.GlutenNotSupportException
-import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.`type`.ListNode
 import org.apache.gluten.substrait.`type`.MapNode
 import org.apache.gluten.substrait.SubstraitContext
@@ -45,11 +44,10 @@ case class CastTransformer(substraitExprName: String, child: ExpressionTransform
   extends UnaryExpressionTransformer {
   override def doTransform(context: SubstraitContext): ExpressionNode = {
     val typeNode = ConverterUtils.getTypeNode(dataType, original.nullable)
-    val sparkShims = SparkShimLoader.getSparkShims
     // Store-assignment casts can carry EvalMode.ANSI even when session ANSI is disabled.
-    val castMode = if (sparkShims.withTryEvalMode(original)) {
+    val castMode = if (ExpressionUtils.withTryEvalMode(original)) {
       CastNode.CastMode.TRY
-    } else if (sparkShims.withAnsiEvalMode(original)) {
+    } else if (ExpressionUtils.withAnsiEvalMode(original)) {
       CastNode.CastMode.ANSI
     } else {
       CastNode.CastMode.LEGACY

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/CollectLimitTransformerRule.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/CollectLimitTransformerRule.scala
@@ -18,7 +18,6 @@ package org.apache.gluten.extension.columnar
 
 import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.config.GlutenConfig
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{CollectLimitExec, SparkPlan}
@@ -34,7 +33,7 @@ case class CollectLimitTransformerRule() extends Rule[SparkPlan] {
           if exec.child.supportsColumnar &&
             (exec.child.output.nonEmpty ||
               BackendsApiManager.getSettings.supportEmptySchemaColumnarShuffle()) =>
-        val offset = SparkShimLoader.getSparkShims.getCollectLimitOffset(exec)
+        val offset = exec.offset
         BackendsApiManager.getSparkPlanExecApiInstance
           .genColumnarCollectLimitExec(exec.limit, exec.child, offset)
     }

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/EnsureLocalSortRequirements.scala
@@ -18,12 +18,11 @@ package org.apache.gluten.extension.columnar
 
 import org.apache.gluten.execution.GlutenPlan
 import org.apache.gluten.extension.columnar.heuristic.HeuristicTransform
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.{ColumnarWriteFilesExec, SortExec, SparkPlan}
-import org.apache.spark.sql.execution.datasources.WriteFilesExec
+import org.apache.spark.sql.execution.datasources.{V1WritesUtils, WriteFilesExec}
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -55,7 +54,7 @@ object EnsureLocalSortRequirements extends Rule[SparkPlan] {
       case writeFiles: WriteFilesExec
           if ColumnarWriteFilesExec.OnNoopLeafPath.unapply(writeFiles).isEmpty =>
         Seq(
-          SparkShimLoader.getSparkShims.getV1WriteRequiredOrdering(
+          V1WritesUtils.getSortOrder(
             writeFiles.child.output,
             writeFiles.partitionColumns,
             writeFiles.bucketSpec,

--- a/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/extension/columnar/offload/OffloadSingleNodeRules.scala
@@ -183,6 +183,16 @@ case class OffloadOthers() extends OffloadSingleNode with LogLevelUtil {
 }
 
 object OffloadOthers {
+  // A limit of -1 means only an offset was given, so fetch every remaining row.
+  private def limitAndOffset(limit: Int, offset: Int): (Int, Int) = {
+    if (limit == -1) {
+      (Int.MaxValue, offset)
+    } else {
+      assert(limit > offset)
+      (limit - offset, offset)
+    }
+  }
+
   // Utility to replace single node within transformed Gluten node.
   // Children will be preserved as they are as children of the output node.
   //
@@ -243,7 +253,7 @@ object OffloadOthers {
           SortExecTransformer(plan.sortOrder, plan.global, child, plan.testSpillFrequency)
         case plan: TakeOrderedAndProjectExec =>
           val child = plan.child
-          val (limit, offset) = SparkShimLoader.getSparkShims.getLimitAndOffsetFromTopK(plan)
+          val (limit, offset) = limitAndOffset(plan.limit, plan.offset)
           TakeOrderedAndProjectExecTransformer(
             limit,
             plan.sortOrder,
@@ -269,8 +279,7 @@ object OffloadOthers {
           )
         case plan: GlobalLimitExec =>
           val child = plan.child
-          val (limit, offset) =
-            SparkShimLoader.getSparkShims.getLimitAndOffsetFromGlobalLimit(plan)
+          val (limit, offset) = limitAndOffset(plan.limit, plan.offset)
           LimitExecTransformer(child, offset, limit)
         case plan: LocalLimitExec =>
           val child = plan.child

--- a/gluten-substrait/src/main/scala/org/apache/gluten/utils/FileMetadataUtil.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/utils/FileMetadataUtil.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.utils
+
+import org.apache.spark.sql.catalyst.expressions.{InputFileBlockLength, InputFileBlockStart, InputFileName}
+import org.apache.spark.sql.catalyst.util.TimestampFormatter
+import org.apache.spark.sql.execution.datasources.{FileFormat, PartitionedFile}
+
+import org.apache.hadoop.fs.Path
+
+import java.time.ZoneOffset
+
+import scala.collection.mutable
+
+object FileMetadataUtil {
+
+  /**
+   * Collects the values of the requested metadata columns for one file. `metadataColumnNames`
+   * carries both the `input_file_*` function names and the `_metadata` field names, so the two
+   * groups are resolved separately.
+   */
+  def generateMetadataColumns(
+      file: PartitionedFile,
+      metadataColumnNames: Seq[String] = Seq.empty): Map[String, String] = {
+    val requested = metadataColumnNames.toSet
+    val originMetadataColumn = Seq(
+      InputFileName().prettyName -> file.filePath.toString,
+      InputFileBlockStart().prettyName -> file.start.toString,
+      InputFileBlockLength().prettyName -> file.length.toString
+    ).collect { case (name, value) if requested.contains(name) => name -> value }.toMap
+    val metadataColumn: mutable.Map[String, String] = mutable.Map(originMetadataColumn.toSeq: _*)
+    val path = new Path(file.filePath.toString)
+    for (columnName <- metadataColumnNames) {
+      columnName match {
+        case FileFormat.FILE_PATH => metadataColumn += (FileFormat.FILE_PATH -> path.toString)
+        case FileFormat.FILE_NAME => metadataColumn += (FileFormat.FILE_NAME -> path.getName)
+        case FileFormat.FILE_SIZE =>
+          metadataColumn += (FileFormat.FILE_SIZE -> file.fileSize.toString)
+        case FileFormat.FILE_MODIFICATION_TIME =>
+          val fileModifyTime = TimestampFormatter
+            .getFractionFormatter(ZoneOffset.UTC)
+            .format(file.modificationTime * 1000L)
+          metadataColumn += (FileFormat.FILE_MODIFICATION_TIME -> fileModifyTime)
+        case FileFormat.FILE_BLOCK_START =>
+          metadataColumn += (FileFormat.FILE_BLOCK_START -> file.start.toString)
+        case FileFormat.FILE_BLOCK_LENGTH =>
+          metadataColumn += (FileFormat.FILE_BLOCK_LENGTH -> file.length.toString)
+        case _ =>
+      }
+    }
+    metadataColumn.toMap
+  }
+}

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarBroadcastExchangeExec.scala
@@ -23,6 +23,7 @@ import org.apache.gluten.metrics.GlutenTimeMetric
 import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.{broadcast, SparkException}
+import org.apache.spark.SparkContextUtils
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -86,9 +87,7 @@ case class ColumnarBroadcastExchangeExec(mode: BroadcastMode, child: SparkPlan)
         val broadcasted = GlutenTimeMetric.millis(longMetric("broadcastTime")) {
           _ =>
             // Broadcast the relation
-            SparkShimLoader.getSparkShims.broadcastInternal(
-              sparkContext,
-              relation.asInstanceOf[Any])
+            SparkContextUtils.broadcastInternal(sparkContext, relation.asInstanceOf[Any])
         }
 
         // Update driver metrics

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarWriteFilesExec.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.execution.{ValidatablePlan, WriteFilesExecTransformer}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
 import org.apache.gluten.extension.columnar.transition.Convention.RowType
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.io.FileCommitProtocol
@@ -96,7 +95,7 @@ abstract class ColumnarWriteFilesExec protected (
         val sparkPartitionId = TaskContext.get().partitionId()
         val sparkAttemptNumber = TaskContext.get().taskAttemptId().toInt & Int.MaxValue
 
-        val ret = SparkShimLoader.getSparkShims.writeFilesExecuteTask(
+        val ret = GlutenFileFormatWriter.writeFilesExecuteTask(
           description,
           jobTrackerID,
           sparkStageId,

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GenerateTransformStageId.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GenerateTransformStageId.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution
 
 import org.apache.gluten.exception.GlutenException
 import org.apache.gluten.execution.WholeStageTransformer
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.adaptive.{AdaptiveSparkPlanExec, AdaptiveSparkPlanHelper, BroadcastQueryStageExec, ShuffleQueryStageExec}
@@ -62,7 +61,7 @@ case class GenerateTransformStageId() extends Rule[SparkPlan] with AdaptiveSpark
           case _ =>
             throw new GlutenException(s"wrong plan for shuffle stage:\n ${plan.treeString}")
         }
-      case aqe: AdaptiveSparkPlanExec if SparkShimLoader.getSparkShims.isFinalAdaptivePlan(aqe) =>
+      case aqe: AdaptiveSparkPlanExec if aqe.isFinalPlan =>
         updateStageId(stripAQEPlan(aqe))
       case wst: WholeStageTransformer if !wholeStageTransformerCache.contains(wst) =>
         updateStageId(wst.child)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/GlutenImplicits.scala
@@ -91,10 +91,6 @@ object GlutenImplicits {
     }
   }
 
-  private def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean = {
-    SparkShimLoader.getSparkShims.isFinalAdaptivePlan(p)
-  }
-
   private def collectFallbackNodes(
       spark: SparkSession,
       plan: QueryPlan[_]): GlutenExplainUtils.FallbackInfo = {
@@ -107,7 +103,7 @@ object GlutenImplicits {
         case p: V2CommandExec
             if !GlutenExplainUtils.shouldIgnoreInFallbackStats(p) =>
           GlutenExplainUtils.handleVanillaSparkPlan(p, fallbackNodeToReason)
-        case p: AdaptiveSparkPlanExec if isFinalAdaptivePlan(p) =>
+        case p: AdaptiveSparkPlanExec if p.isFinalPlan =>
           collect(p.executedPlan)
         case p: AdaptiveSparkPlanExec =>
           // if we are here that means we are inside table cache.
@@ -196,7 +192,7 @@ object GlutenImplicits {
     // For query, e.g., `SELECT * FROM ...`
     if (qe.executedPlan.find(_.isInstanceOf[CommandResultExec]).isEmpty) {
       val isMaterialized = qe.executedPlan.find {
-        case a: AdaptiveSparkPlanExec if isFinalAdaptivePlan(a) => true
+        case a: AdaptiveSparkPlanExec if a.isFinalPlan => true
         case _ => false
       }.isDefined
       handlePlanWithAQEAndTableCache(qe.executedPlan, qe.analyzed, isMaterialized)

--- a/gluten-substrait/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/softaffinity/SoftAffinitySuite.scala
@@ -18,20 +18,27 @@ package org.apache.spark.softaffinity
 
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.softaffinity.SoftAffinityManager
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.scheduler.{SparkListenerExecutorAdded, SparkListenerExecutorRemoved}
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
-import org.apache.spark.sql.execution.datasources.FilePartition
+import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.test.SharedSparkSession
 
 import scala.collection.mutable.ListBuffer
 
 class SoftAffinitySuite extends QueryTest with SharedSparkSession with PredicateHelper {
+
+  private def partitionedFile(
+      path: String,
+      start: Long,
+      length: Long,
+      locations: Array[String]): PartitionedFile =
+    PartitionedFile(InternalRow.empty, SparkPath.fromPathString(path), start, length, locations)
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(GlutenConfig.GLUTEN_SOFT_AFFINITY_ENABLED.key, "true")
@@ -45,20 +52,8 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     val partition = FilePartition(
       0,
       Seq(
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath0",
-          0,
-          100,
-          Array("host-1", "host-2")
-        ),
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath1",
-          0,
-          200,
-          Array("host-2", "host-3")
-        )
+        partitionedFile("fakePath0", 0, 100, Array("host-1", "host-2")),
+        partitionedFile("fakePath1", 0, 200, Array("host-2", "host-3"))
       ).toArray
     )
 
@@ -75,20 +70,8 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     val partition = FilePartition(
       0,
       Seq(
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath0",
-          0,
-          100,
-          Array("192.168.22.1", "host-2")
-        ),
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath1",
-          0,
-          200,
-          Array("192.168.22.1", "host-5")
-        )
+        partitionedFile("fakePath0", 0, 100, Array("192.168.22.1", "host-2")),
+        partitionedFile("fakePath1", 0, 200, Array("192.168.22.1", "host-5"))
       ).toArray
     )
 
@@ -105,20 +88,8 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     val partition = FilePartition(
       0,
       Seq(
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath0",
-          0,
-          100,
-          Array("host-1", "host-2")
-        ),
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath1",
-          0,
-          200,
-          Array("host-5", "host-6")
-        )
+        partitionedFile("fakePath0", 0, 100, Array("host-1", "host-2")),
+        partitionedFile("fakePath1", 0, 200, Array("host-5", "host-6"))
       ).toArray
     )
 
@@ -135,20 +106,8 @@ class SoftAffinitySuite extends QueryTest with SharedSparkSession with Predicate
     val partition = FilePartition(
       0,
       Seq(
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath0",
-          0,
-          100,
-          Array("host-1", "host-2")
-        ),
-        SparkShimLoader.getSparkShims.generatePartitionedFile(
-          InternalRow.empty,
-          "fakePath1",
-          0,
-          200,
-          Array("host-5", "host-6")
-        )
+        partitionedFile("fakePath0", 0, 100, Array("host-1", "host-2")),
+        partitionedFile("fakePath1", 0, 200, Array("host-5", "host-6"))
       ).toArray
     )
 

--- a/gluten-substrait/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/softaffinity/SoftAffinityWithRDDInfoSuite.scala
@@ -18,15 +18,15 @@ package org.apache.spark.softaffinity
 
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.softaffinity.{AffinityManager, SoftAffinityManager}
-import org.apache.gluten.sql.shims.SparkShimLoader
 
 import org.apache.spark.SparkConf
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
-import org.apache.spark.sql.execution.datasources.FilePartition
+import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.storage.{RDDInfo, StorageLevel}
 
@@ -41,6 +41,13 @@ object FakeSoftAffinityManager extends AffinityManager {
 }
 
 class SoftAffinityWithRDDInfoSuite extends QueryTest with SharedSparkSession with PredicateHelper {
+
+  private def partitionedFile(
+      path: String,
+      start: Long,
+      length: Long,
+      locations: Array[String]): PartitionedFile =
+    PartitionedFile(InternalRow.empty, SparkPath.fromPathString(path), start, length, locations)
 
   override protected def sparkConf: SparkConf = super.sparkConf
     .set(GlutenConfig.GLUTEN_SOFT_AFFINITY_ENABLED.key, "true")
@@ -77,18 +84,8 @@ class SoftAffinityWithRDDInfoSuite extends QueryTest with SharedSparkSession wit
       null
     )
     val files = Seq(
-      SparkShimLoader.getSparkShims.generatePartitionedFile(
-        InternalRow.empty,
-        "fakePath0",
-        0,
-        100,
-        Array("host-3")),
-      SparkShimLoader.getSparkShims.generatePartitionedFile(
-        InternalRow.empty,
-        "fakePath0",
-        100,
-        200,
-        Array("host-3"))
+      partitionedFile("fakePath0", 0, 100, Array("host-3")),
+      partitionedFile("fakePath0", 100, 200, Array("host-3"))
     ).toArray
     val filePartition = FilePartition(-1, files)
     val softAffinityListener = new SoftAffinityListener()
@@ -119,18 +116,8 @@ class SoftAffinityWithRDDInfoSuite extends QueryTest with SharedSparkSession wit
     // This test simulate the case listener bus stucks. We need to make sure the middle states
     // count would not exceed the configed threshold.
     val files = Seq(
-      SparkShimLoader.getSparkShims.generatePartitionedFile(
-        InternalRow.empty,
-        "fakePath0",
-        0,
-        100,
-        Array("host-3")),
-      SparkShimLoader.getSparkShims.generatePartitionedFile(
-        InternalRow.empty,
-        "fakePath0",
-        100,
-        200,
-        Array("host-3"))
+      partitionedFile("fakePath0", 0, 100, Array("host-3")),
+      partitionedFile("fakePath0", 100, 200, Array("host-3"))
     ).toArray
     val filePartition = FilePartition(-1, files)
     FakeSoftAffinityManager.updatePartitionMap(filePartition, 1)

--- a/shims/common/src/main/scala/org/apache/gluten/execution/datasource/GlutenFormatWriterInjects.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/execution/datasource/GlutenFormatWriterInjects.scala
@@ -76,13 +76,6 @@ object GlutenFormatFactory {
     postRuleFactory = factory
   }
 
-  def getExtendedColumnarPostRule(session: SparkSession): Rule[SparkPlan] = {
-    if (postRuleFactory == null) {
-      throw new IllegalStateException("GlutenFormatFactory is not initialized")
-    }
-    postRuleFactory(session)
-  }
-
   def register(rowSplitter: GlutenRowSplitter): Unit = {
     rowSplitterInstance = rowSplitter
   }

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -218,8 +218,7 @@ trait SparkShims {
     batchScan.keyGroupedPartitioning
   }
 
-  def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] =
-    Option(Seq())
+  def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]]
 
   /**
    * Most of the code in this method is copied from
@@ -234,13 +233,20 @@ trait SparkShims {
       commonPartitionValues: Option[Seq[(InternalRow, Int)]],
       applyPartialClustering: Boolean,
       replicatePartitions: Boolean,
-      joinKeyPositions: Option[Seq[Int]] = None): Seq[Seq[InputPartition]] =
-    filteredPartitions
+      joinKeyPositions: Option[Seq[Int]] = None): Seq[Seq[InputPartition]]
 
-  def extractExpressionTimestampAddUnit(timestampAdd: Expression): Option[Seq[String]] =
-    Option.empty
+  def extractExpressionTimestampAddUnit(timestampAdd: Expression): Option[Seq[String]]
 
-  def withTryEvalMode(expr: Expression): Boolean
+  def withTryEvalMode(expr: Expression): Boolean = {
+    expr match {
+      case a: Add => a.evalMode == EvalMode.TRY
+      case s: Subtract => s.evalMode == EvalMode.TRY
+      case d: Divide => d.evalMode == EvalMode.TRY
+      case m: Multiply => m.evalMode == EvalMode.TRY
+      case c: Cast => c.evalMode == EvalMode.TRY
+      case _ => false
+    }
+  }
 
   def withAnsiEvalMode(expr: Expression): Boolean = {
     expr match {

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.TimestampFormatter
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
@@ -123,11 +122,9 @@ trait SparkShims {
 
   def getWindowGroupLimitExec(windowGroupLimitExecShim: WindowGroupLimitExecShim): SparkPlan = null
 
-  def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = (plan.limit, 0)
+  def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int)
 
-  def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = (plan.limit, 0)
-
-  def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]]
+  def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int)
 
   def writeFilesExecuteTask(
       description: WriteJobDescription,
@@ -136,28 +133,18 @@ trait SparkShims {
       sparkPartitionId: Int,
       sparkAttemptNumber: Int,
       committer: FileCommitProtocol,
-      iterator: Iterator[InternalRow]): WriteTaskResult = {
-    throw new UnsupportedOperationException()
-  }
+      iterator: Iterator[InternalRow]): WriteTaskResult
 
-  def enableNativeWriteFilesByDefault(): Boolean = false
+  def enableNativeWriteFilesByDefault(): Boolean
 
-  // Planned V1 writes were introduced in Spark 3.4. Older versions do not expose a required
-  // ordering utility and keep the default empty ordering.
-  // TODO: Remove this shim after dropping Spark 3.3 support.
   def getV1WriteRequiredOrdering(
       outputColumns: Seq[Attribute],
       partitionColumns: Seq[Attribute],
       bucketSpec: Option[BucketSpec],
       options: Map[String, String],
-      numStaticPartitionCols: Int): Seq[SortOrder] = Seq.empty
+      numStaticPartitionCols: Int): Seq[SortOrder]
 
-  def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
-    // Since Spark 3.4, the `sc.broadcast` has been optimized to use `sc.broadcastInternal`.
-    // More details see SPARK-39983.
-    // TODO, remove this shim once we drop Spark3.3 and previous
-    sc.broadcast(value)
-  }
+  def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T]
 
   // To be compatible with Spark-3.5 and later
   // See https://github.com/apache/spark/pull/41440
@@ -253,7 +240,7 @@ trait SparkShims {
   def extractExpressionTimestampAddUnit(timestampAdd: Expression): Option[Seq[String]] =
     Option.empty
 
-  def withTryEvalMode(expr: Expression): Boolean = false
+  def withTryEvalMode(expr: Expression): Boolean
 
   def withAnsiEvalMode(expr: Expression): Boolean = {
     expr match {
@@ -274,9 +261,7 @@ trait SparkShims {
       schema: MessageType,
       caseSensitive: Option[Boolean] = None): ParquetFilters
 
-  def extractExpressionArrayInsert(arrayInsert: Expression): Seq[Expression] = {
-    throw new UnsupportedOperationException("ArrayInsert not supported.")
-  }
+  def extractExpressionArrayInsert(arrayInsert: Expression): Seq[Expression]
 
   /** Shim method for usages from GlutenExplainUtils.scala. */
   def withOperatorIdMap[T](idMap: java.util.Map[QueryPlan[_], Int])(body: => T): T = {
@@ -307,9 +292,9 @@ trait SparkShims {
   def getOtherConstantMetadataColumnValues(file: PartitionedFile): JMap[String, Object] =
     Map.empty[String, Any].asJava.asInstanceOf[JMap[String, Object]]
 
-  def getCollectLimitOffset(plan: CollectLimitExec): Int = 0
+  def getCollectLimitOffset(plan: CollectLimitExec): Int
 
-  def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean = false
+  def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean
 
   def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType
 

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -22,15 +22,17 @@ import org.apache.gluten.expression.Sig
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{Attribute, BinaryArithmetic, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, RaiseError, SortOrder, UnBase64}
+import org.apache.spark.sql.catalyst.expressions.{Add, Attribute, BinaryArithmetic, Cast, Divide, EvalMode, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, IntegralDivide, Multiply, RaiseError, SortOrder, Subtract, UnBase64}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util.TimestampFormatter
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
@@ -50,9 +52,11 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.hadoop.metadata.{CompressionCodecName, ParquetMetadata}
 import org.apache.parquet.schema.MessageType
 
+import java.time.ZoneOffset
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
 case class SparkShimDescriptor(major: Int, minor: Int, patch: Int) {
@@ -89,21 +93,30 @@ trait SparkShims {
       sparkSession: SparkSession,
       readFunction: PartitionedFile => Iterator[InternalRow],
       filePartitions: Seq[FilePartition],
-      fileSourceScanExec: FileSourceScanExec): FileScanRDD
+      fileSourceScanExec: FileSourceScanExec): FileScanRDD = {
+    new FileScanRDD(
+      sparkSession,
+      readFunction,
+      filePartitions,
+      new StructType(
+        fileSourceScanExec.requiredSchema.fields ++
+          fileSourceScanExec.relation.partitionSchema.fields),
+      fileSourceScanExec.fileConstantMetadataColumns
+    )
+  }
 
   def filesGroupedToBuckets(
       selectedPartitions: Array[PartitionDirectory]): Map[Int, Array[PartitionedFile]]
 
-  // Spark3.4 new add table parameter in BatchScanExec.
-  def getBatchScanExecTable(batchScan: BatchScanExec): Table
+  def getBatchScanExecTable(batchScan: BatchScanExec): Table = batchScan.table
 
-  // The PartitionedFile API changed in spark 3.4
   def generatePartitionedFile(
       partitionValues: InternalRow,
       filePath: String,
       start: Long,
       length: Long,
-      @transient locations: Array[String] = Array.empty): PartitionedFile
+      @transient locations: Array[String] = Array.empty): PartitionedFile =
+    PartitionedFile(partitionValues, SparkPath.fromPathString(filePath), start, length, locations)
 
   def isWindowGroupLimitExec(plan: SparkPlan): Boolean = false
 
@@ -184,17 +197,40 @@ trait SparkShims {
       file: PartitionedFile,
       metadataColumnNames: Seq[String] = Seq.empty): Map[String, String] = {
     val requested = metadataColumnNames.toSet
-    Seq(
+    val originMetadataColumn = Seq(
       InputFileName().prettyName -> file.filePath.toString,
       InputFileBlockStart().prettyName -> file.start.toString,
       InputFileBlockLength().prettyName -> file.length.toString
     ).collect { case (name, value) if requested.contains(name) => name -> value }.toMap
+    val metadataColumn: mutable.Map[String, String] = mutable.Map(originMetadataColumn.toSeq: _*)
+    val path = new Path(file.filePath.toString)
+    for (columnName <- metadataColumnNames) {
+      columnName match {
+        case FileFormat.FILE_PATH => metadataColumn += (FileFormat.FILE_PATH -> path.toString)
+        case FileFormat.FILE_NAME => metadataColumn += (FileFormat.FILE_NAME -> path.getName)
+        case FileFormat.FILE_SIZE =>
+          metadataColumn += (FileFormat.FILE_SIZE -> file.fileSize.toString)
+        case FileFormat.FILE_MODIFICATION_TIME =>
+          val fileModifyTime = TimestampFormatter
+            .getFractionFormatter(ZoneOffset.UTC)
+            .format(file.modificationTime * 1000L)
+          metadataColumn += (FileFormat.FILE_MODIFICATION_TIME -> fileModifyTime)
+        case FileFormat.FILE_BLOCK_START =>
+          metadataColumn += (FileFormat.FILE_BLOCK_START -> file.start.toString)
+        case FileFormat.FILE_BLOCK_LENGTH =>
+          metadataColumn += (FileFormat.FILE_BLOCK_LENGTH -> file.length.toString)
+        case _ =>
+      }
+    }
+    metadataColumn.toMap
   }
 
   // For compatibility with Spark-3.5.
   def getAnalysisExceptionPlan(ae: AnalysisException): Option[LogicalPlan]
 
-  def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = Option(Seq())
+  def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = {
+    batchScan.keyGroupedPartitioning
+  }
 
   def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] =
     Option(Seq())
@@ -223,7 +259,17 @@ trait SparkShims {
 
   def withTryEvalMode(expr: Expression): Boolean = false
 
-  def withAnsiEvalMode(expr: Expression): Boolean = false
+  def withAnsiEvalMode(expr: Expression): Boolean = {
+    expr match {
+      case a: Add => a.evalMode == EvalMode.ANSI
+      case s: Subtract => s.evalMode == EvalMode.ANSI
+      case d: Divide => d.evalMode == EvalMode.ANSI
+      case m: Multiply => m.evalMode == EvalMode.ANSI
+      case c: Cast => c.evalMode == EvalMode.ANSI
+      case i: IntegralDivide => i.evalMode == EvalMode.ANSI
+      case _ => false
+    }
+  }
 
   def isNullIntolerant(expr: Expression): Boolean
 

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -37,7 +37,6 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanExecBase}
@@ -254,9 +253,6 @@ trait SparkShims {
   def extractExpressionTimestampAddUnit(timestampAdd: Expression): Option[Seq[String]] =
     Option.empty
 
-  def extractExpressionTimestampDiffUnit(timestampDiff: Expression): Option[String] =
-    Option.empty
-
   def withTryEvalMode(expr: Expression): Boolean = false
 
   def withAnsiEvalMode(expr: Expression): Boolean = {
@@ -357,8 +353,6 @@ trait SparkShims {
       sparkSession: SparkSession,
       planner: SparkPlanner,
       plan: LogicalPlan): SparkPlan
-
-  def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean
 
   /**
    * Checks if the given JoinType is LeftSingle. LeftSingle is a Spark 4.0+ join type, semantically

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -20,19 +20,14 @@ import org.apache.gluten.GlutenBuildInfo.SPARK_COMPILE_VERSION
 import org.apache.gluten.expression.Sig
 
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
-import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
-import org.apache.spark.sql.catalyst.expressions.{Add, Attribute, BinaryArithmetic, Cast, Divide, EvalMode, Expression, InputFileBlockLength, InputFileBlockStart, InputFileName, IntegralDivide, Multiply, RaiseError, SortOrder, Subtract, UnBase64}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, BinaryArithmetic, Expression, RaiseError}
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.catalyst.util.TimestampFormatter
-import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{InputPartition, Scan}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
@@ -50,12 +45,9 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.hadoop.metadata.{CompressionCodecName, ParquetMetadata}
 import org.apache.parquet.schema.MessageType
 
-import java.time.ZoneOffset
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
-import scala.reflect.ClassTag
 
 case class SparkShimDescriptor(major: Int, minor: Int, patch: Int) {
   override def toString(): String = s"$major.$minor.$patch"
@@ -87,44 +79,14 @@ trait SparkShims {
 
   def runtimeReplaceableExpressionMappings: Seq[Sig]
 
-  def generateFileScanRDD(
-      sparkSession: SparkSession,
-      readFunction: PartitionedFile => Iterator[InternalRow],
-      filePartitions: Seq[FilePartition],
-      fileSourceScanExec: FileSourceScanExec): FileScanRDD = {
-    new FileScanRDD(
-      sparkSession,
-      readFunction,
-      filePartitions,
-      new StructType(
-        fileSourceScanExec.requiredSchema.fields ++
-          fileSourceScanExec.relation.partitionSchema.fields),
-      fileSourceScanExec.fileConstantMetadataColumns
-    )
-  }
-
   def filesGroupedToBuckets(
       selectedPartitions: Array[PartitionDirectory]): Map[Int, Array[PartitionedFile]]
-
-  def getBatchScanExecTable(batchScan: BatchScanExec): Table = batchScan.table
-
-  def generatePartitionedFile(
-      partitionValues: InternalRow,
-      filePath: String,
-      start: Long,
-      length: Long,
-      @transient locations: Array[String] = Array.empty): PartitionedFile =
-    PartitionedFile(partitionValues, SparkPath.fromPathString(filePath), start, length, locations)
 
   def isWindowGroupLimitExec(plan: SparkPlan): Boolean = false
 
   def getWindowGroupLimitExecShim(plan: SparkPlan): WindowGroupLimitExecShim = null
 
   def getWindowGroupLimitExec(windowGroupLimitExecShim: WindowGroupLimitExecShim): SparkPlan = null
-
-  def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int)
-
-  def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int)
 
   def writeFilesExecuteTask(
       description: WriteJobDescription,
@@ -134,17 +96,6 @@ trait SparkShims {
       sparkAttemptNumber: Int,
       committer: FileCommitProtocol,
       iterator: Iterator[InternalRow]): WriteTaskResult
-
-  def enableNativeWriteFilesByDefault(): Boolean
-
-  def getV1WriteRequiredOrdering(
-      outputColumns: Seq[Attribute],
-      partitionColumns: Seq[Attribute],
-      bucketSpec: Option[BucketSpec],
-      options: Map[String, String],
-      numStaticPartitionCols: Int): Seq[SortOrder]
-
-  def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T]
 
   // To be compatible with Spark-3.5 and later
   // See https://github.com/apache/spark/pull/41440
@@ -179,44 +130,8 @@ trait SparkShims {
 
   def attributesFromStruct(structType: StructType): Seq[Attribute]
 
-  def generateMetadataColumns(
-      file: PartitionedFile,
-      metadataColumnNames: Seq[String] = Seq.empty): Map[String, String] = {
-    val requested = metadataColumnNames.toSet
-    val originMetadataColumn = Seq(
-      InputFileName().prettyName -> file.filePath.toString,
-      InputFileBlockStart().prettyName -> file.start.toString,
-      InputFileBlockLength().prettyName -> file.length.toString
-    ).collect { case (name, value) if requested.contains(name) => name -> value }.toMap
-    val metadataColumn: mutable.Map[String, String] = mutable.Map(originMetadataColumn.toSeq: _*)
-    val path = new Path(file.filePath.toString)
-    for (columnName <- metadataColumnNames) {
-      columnName match {
-        case FileFormat.FILE_PATH => metadataColumn += (FileFormat.FILE_PATH -> path.toString)
-        case FileFormat.FILE_NAME => metadataColumn += (FileFormat.FILE_NAME -> path.getName)
-        case FileFormat.FILE_SIZE =>
-          metadataColumn += (FileFormat.FILE_SIZE -> file.fileSize.toString)
-        case FileFormat.FILE_MODIFICATION_TIME =>
-          val fileModifyTime = TimestampFormatter
-            .getFractionFormatter(ZoneOffset.UTC)
-            .format(file.modificationTime * 1000L)
-          metadataColumn += (FileFormat.FILE_MODIFICATION_TIME -> fileModifyTime)
-        case FileFormat.FILE_BLOCK_START =>
-          metadataColumn += (FileFormat.FILE_BLOCK_START -> file.start.toString)
-        case FileFormat.FILE_BLOCK_LENGTH =>
-          metadataColumn += (FileFormat.FILE_BLOCK_LENGTH -> file.length.toString)
-        case _ =>
-      }
-    }
-    metadataColumn.toMap
-  }
-
   // For compatibility with Spark-3.5.
   def getAnalysisExceptionPlan(ae: AnalysisException): Option[LogicalPlan]
-
-  def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = {
-    batchScan.keyGroupedPartitioning
-  }
 
   def getCommonPartitionValues(batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]]
 
@@ -237,37 +152,12 @@ trait SparkShims {
 
   def extractExpressionTimestampAddUnit(timestampAdd: Expression): Option[Seq[String]]
 
-  def withTryEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.TRY
-      case s: Subtract => s.evalMode == EvalMode.TRY
-      case d: Divide => d.evalMode == EvalMode.TRY
-      case m: Multiply => m.evalMode == EvalMode.TRY
-      case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
-  def withAnsiEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.ANSI
-      case s: Subtract => s.evalMode == EvalMode.ANSI
-      case d: Divide => d.evalMode == EvalMode.ANSI
-      case m: Multiply => m.evalMode == EvalMode.ANSI
-      case c: Cast => c.evalMode == EvalMode.ANSI
-      case i: IntegralDivide => i.evalMode == EvalMode.ANSI
-      case _ => false
-    }
-  }
-
   def isNullIntolerant(expr: Expression): Boolean
 
   def createParquetFilters(
       conf: SQLConf,
       schema: MessageType,
       caseSensitive: Option[Boolean] = None): ParquetFilters
-
-  def extractExpressionArrayInsert(arrayInsert: Expression): Seq[Expression]
 
   /** Shim method for usages from GlutenExplainUtils.scala. */
   def withOperatorIdMap[T](idMap: java.util.Map[QueryPlan[_], Int])(body: => T): T = {
@@ -297,10 +187,6 @@ trait SparkShims {
 
   def getOtherConstantMetadataColumnValues(file: PartitionedFile): JMap[String, Object] =
     Map.empty[String, Any].asJava.asInstanceOf[JMap[String, Object]]
-
-  def getCollectLimitOffset(plan: CollectLimitExec): Int
-
-  def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean
 
   def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType
 

--- a/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
+++ b/shims/common/src/main/scala/org/apache/gluten/sql/shims/SparkShims.scala
@@ -20,7 +20,6 @@ import org.apache.gluten.GlutenBuildInfo.SPARK_COMPILE_VERSION
 import org.apache.gluten.expression.Sig
 
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, BinaryArithmetic, Expression, RaiseError}
@@ -87,15 +86,6 @@ trait SparkShims {
   def getWindowGroupLimitExecShim(plan: SparkPlan): WindowGroupLimitExecShim = null
 
   def getWindowGroupLimitExec(windowGroupLimitExecShim: WindowGroupLimitExecShim): SparkPlan = null
-
-  def writeFilesExecuteTask(
-      description: WriteJobDescription,
-      jobTrackerID: String,
-      sparkStageId: Int,
-      sparkPartitionId: Int,
-      sparkAttemptNumber: Int,
-      committer: FileCommitProtocol,
-      iterator: Iterator[InternalRow]): WriteTaskResult
 
   // To be compatible with Spark-3.5 and later
   // See https://github.com/apache/spark/pull/41440

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -368,17 +368,6 @@ class Spark34Shims extends SparkShims {
     }
   }
 
-  override def withTryEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.TRY
-      case s: Subtract => s.evalMode == EvalMode.TRY
-      case d: Divide => d.evalMode == EvalMode.TRY
-      case m: Multiply => m.evalMode == EvalMode.TRY
-      case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
   override def createParquetFilters(
       conf: SQLConf,
       schema: MessageType,

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -23,7 +23,6 @@ import org.apache.gluten.utils.ExceptionUtils
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
-import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
@@ -34,9 +33,8 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.util.{InternalRowComparableWrapper, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
-import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
@@ -55,9 +53,6 @@ import org.apache.parquet.crypto.ParquetCryptoRuntimeException
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
 import org.apache.parquet.schema.MessageType
 
-import java.time.ZoneOffset
-
-import scala.collection.mutable
 import scala.reflect.ClassTag
 
 class Spark34Shims extends SparkShims {
@@ -94,22 +89,6 @@ class Spark34Shims extends SparkShims {
 
   override def isNullIntolerant(expr: Expression): Boolean = expr.isInstanceOf[NullIntolerant]
 
-  override def generateFileScanRDD(
-      sparkSession: SparkSession,
-      readFunction: PartitionedFile => Iterator[InternalRow],
-      filePartitions: Seq[FilePartition],
-      fileSourceScanExec: FileSourceScanExec): FileScanRDD = {
-    new FileScanRDD(
-      sparkSession,
-      readFunction,
-      filePartitions,
-      new StructType(
-        fileSourceScanExec.requiredSchema.fields ++
-          fileSourceScanExec.relation.partitionSchema.fields),
-      fileSourceScanExec.fileConstantMetadataColumns
-    )
-  }
-
   override def filesGroupedToBuckets(
       selectedPartitions: Array[PartitionDirectory]): Map[Int, Array[PartitionedFile]] = {
     selectedPartitions
@@ -122,43 +101,6 @@ class Spark34Shims extends SparkShims {
             .getBucketId(f.toPath.getName)
             .getOrElse(throw invalidBucketFile(f.urlEncodedPath))
       }
-  }
-
-  override def getBatchScanExecTable(batchScan: BatchScanExec): Table = batchScan.table
-
-  override def generatePartitionedFile(
-      partitionValues: InternalRow,
-      filePath: String,
-      start: Long,
-      length: Long,
-      @transient locations: Array[String] = Array.empty): PartitionedFile =
-    PartitionedFile(partitionValues, SparkPath.fromPathString(filePath), start, length, locations)
-
-  override def generateMetadataColumns(
-      file: PartitionedFile,
-      metadataColumnNames: Seq[String]): Map[String, String] = {
-    val originMetadataColumn = super.generateMetadataColumns(file, metadataColumnNames)
-    val metadataColumn: mutable.Map[String, String] = mutable.Map(originMetadataColumn.toSeq: _*)
-    val path = new Path(file.filePath.toString)
-    for (columnName <- metadataColumnNames) {
-      columnName match {
-        case FileFormat.FILE_PATH => metadataColumn += (FileFormat.FILE_PATH -> path.toString)
-        case FileFormat.FILE_NAME => metadataColumn += (FileFormat.FILE_NAME -> path.getName)
-        case FileFormat.FILE_SIZE =>
-          metadataColumn += (FileFormat.FILE_SIZE -> file.fileSize.toString)
-        case FileFormat.FILE_MODIFICATION_TIME =>
-          val fileModifyTime = TimestampFormatter
-            .getFractionFormatter(ZoneOffset.UTC)
-            .format(file.modificationTime * 1000L)
-          metadataColumn += (FileFormat.FILE_MODIFICATION_TIME -> fileModifyTime)
-        case FileFormat.FILE_BLOCK_START =>
-          metadataColumn += (FileFormat.FILE_BLOCK_START -> file.start.toString)
-        case FileFormat.FILE_BLOCK_LENGTH =>
-          metadataColumn += (FileFormat.FILE_BLOCK_LENGTH -> file.length.toString)
-        case _ =>
-      }
-    }
-    metadataColumn.toMap
   }
 
   // https://issues.apache.org/jira/browse/SPARK-40400
@@ -309,10 +251,6 @@ class Spark34Shims extends SparkShims {
     ae.plan
   }
 
-  override def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = {
-    batchScan.keyGroupedPartitioning
-  }
-
   override def getCommonPartitionValues(
       batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] = {
     batchScan.commonPartitionValues
@@ -441,18 +379,6 @@ class Spark34Shims extends SparkShims {
       case d: Divide => d.evalMode == EvalMode.TRY
       case m: Multiply => m.evalMode == EvalMode.TRY
       case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
-  override def withAnsiEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.ANSI
-      case s: Subtract => s.evalMode == EvalMode.ANSI
-      case d: Divide => d.evalMode == EvalMode.ANSI
-      case m: Multiply => m.evalMode == EvalMode.ANSI
-      case c: Cast => c.evalMode == EvalMode.ANSI
-      case i: IntegralDivide => i.evalMode == EvalMode.ANSI
       case _ => false
     }
   }

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, Partitioning}
-import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
@@ -127,8 +126,6 @@ class Spark34Shims extends SparkShims {
   override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
     (getLimit(plan.limit, plan.offset), plan.offset)
   }
-
-  override def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = List()
 
   override def writeFilesExecuteTask(
       description: WriteJobDescription,

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -37,7 +37,6 @@ import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFilters
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanExecBase}
@@ -442,14 +441,6 @@ class Spark34Shims extends SparkShims {
     }
   }
 
-  override def extractExpressionTimestampDiffUnit(exp: Expression): Option[String] = {
-    exp match {
-      case timestampDiff: TimestampDiff =>
-        Some(timestampDiff.unit)
-      case _ => Option.empty
-    }
-  }
-
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecision.widerDecimalType(d1, d2)
   }
@@ -473,10 +464,6 @@ class Spark34Shims extends SparkShims {
       planner: SparkPlanner,
       plan: LogicalPlan): SparkPlan =
     QueryExecution.createSparkPlan(sparkSession, planner, plan)
-
-  override def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean = {
-    p.isFinalPlan
-  }
 
   override def getShuffleBlockFetcherIterator(params: ShuffleBlockFetcherIteratorParams)
       : GlutenShuffleBlockFetcherIteratorBase = {

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.sql.shims.SparkShims
 import org.apache.gluten.utils.ExceptionUtils
 
 import org.apache.spark._
-import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
@@ -103,25 +102,6 @@ class Spark34Shims extends SparkShims {
       errorClass = "INVALID_BUCKET_FILE",
       messageParameters = Map("path" -> path),
       cause = null)
-  }
-
-  override def writeFilesExecuteTask(
-      description: WriteJobDescription,
-      jobTrackerID: String,
-      sparkStageId: Int,
-      sparkPartitionId: Int,
-      sparkAttemptNumber: Int,
-      committer: FileCommitProtocol,
-      iterator: Iterator[InternalRow]): WriteTaskResult = {
-    GlutenFileFormatWriter.writeFilesExecuteTask(
-      description,
-      jobTrackerID,
-      sparkStageId,
-      sparkPartitionId,
-      sparkAttemptNumber,
-      committer,
-      iterator
-    )
   }
 
   def setJobDescriptionOrTagForBroadcastExchange(

--- a/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
+++ b/shims/spark34/src/main/scala/org/apache/gluten/sql/shims/spark34/Spark34Shims.scala
@@ -21,12 +21,10 @@ import org.apache.gluten.sql.shims.SparkShims
 import org.apache.gluten.utils.ExceptionUtils
 
 import org.apache.spark._
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
@@ -50,8 +48,6 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
 import org.apache.parquet.schema.MessageType
-
-import scala.reflect.ClassTag
 
 class Spark34Shims extends SparkShims {
 
@@ -109,24 +105,6 @@ class Spark34Shims extends SparkShims {
       cause = null)
   }
 
-  private def getLimit(limit: Int, offset: Int): Int = {
-    if (limit == -1) {
-      // Only offset specified, so fetch the maximum number rows
-      Int.MaxValue
-    } else {
-      assert(limit > offset)
-      limit - offset
-    }
-  }
-
-  override def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
-  override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
   override def writeFilesExecuteTask(
       description: WriteJobDescription,
       jobTrackerID: String,
@@ -144,26 +122,6 @@ class Spark34Shims extends SparkShims {
       committer,
       iterator
     )
-  }
-
-  override def enableNativeWriteFilesByDefault(): Boolean = true
-
-  override def getV1WriteRequiredOrdering(
-      outputColumns: Seq[Attribute],
-      partitionColumns: Seq[Attribute],
-      bucketSpec: Option[BucketSpec],
-      options: Map[String, String],
-      numStaticPartitionCols: Int): Seq[SortOrder] = {
-    V1WritesUtils.getSortOrder(
-      outputColumns,
-      partitionColumns,
-      bucketSpec,
-      options,
-      numStaticPartitionCols)
-  }
-
-  override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
-    SparkContextUtils.broadcastInternal(sc, value)
   }
 
   def setJobDescriptionOrTagForBroadcastExchange(
@@ -384,11 +342,6 @@ class Spark34Shims extends SparkShims {
     )
   }
 
-  override def extractExpressionArrayInsert(arrayInsert: Expression): Seq[Expression] = {
-    val expr = arrayInsert.asInstanceOf[ArrayInsert]
-    Seq(expr.srcArrayExpr, expr.posExpr, expr.itemExpr, Literal(expr.legacyNegativeIndex))
-  }
-
   override def getOperatorId(plan: QueryPlan[_]): Option[Int] = {
     plan.getTagValue(QueryPlan.OP_ID_TAG)
   }
@@ -412,12 +365,6 @@ class Spark34Shims extends SparkShims {
         false
     }
   }
-
-  override def getCollectLimitOffset(plan: CollectLimitExec): Int = {
-    plan.offset
-  }
-
-  override def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean = unBase64.failOnError
 
   override def extractExpressionTimestampAddUnit(exp: Expression): Option[Seq[String]] = {
     exp match {

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -38,7 +38,6 @@ import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanExecBase}
@@ -500,14 +499,6 @@ class Spark35Shims extends SparkShims {
     }
   }
 
-  override def extractExpressionTimestampDiffUnit(exp: Expression): Option[String] = {
-    exp match {
-      case timestampDiff: TimestampDiff =>
-        Some(timestampDiff.unit)
-      case _ => Option.empty
-    }
-  }
-
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecision.widerDecimalType(d1, d2)
   }
@@ -527,10 +518,6 @@ class Spark35Shims extends SparkShims {
       planner: SparkPlanner,
       plan: LogicalPlan): SparkPlan =
     QueryExecution.createSparkPlan(sparkSession, planner, plan)
-
-  override def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean = {
-    p.isFinalPlan
-  }
 
   override def getShuffleBlockFetcherIterator(params: ShuffleBlockFetcherIteratorParams)
       : GlutenShuffleBlockFetcherIteratorBase = {

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, Partitioning}
-import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
@@ -169,8 +168,6 @@ class Spark35Shims extends SparkShims {
   override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
     (getLimit(plan.limit, plan.offset), plan.offset)
   }
-
-  override def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = List()
 
   override def writeFilesExecuteTask(
       description: WriteJobDescription,

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -408,17 +408,6 @@ class Spark35Shims extends SparkShims {
     }
   }
 
-  override def withTryEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.TRY
-      case s: Subtract => s.evalMode == EvalMode.TRY
-      case d: Divide => d.evalMode == EvalMode.TRY
-      case m: Multiply => m.evalMode == EvalMode.TRY
-      case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
   override def createParquetFilters(
       conf: SQLConf,
       schema: MessageType,

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -23,7 +23,6 @@ import org.apache.gluten.sql.shims.SparkShims
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
-import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
@@ -35,9 +34,8 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{InternalRowComparableWrapper, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.InternalRowComparableWrapper
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
-import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
@@ -55,11 +53,9 @@ import org.apache.parquet.hadoop.metadata.FileMetaData.EncryptionType
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
 import org.apache.parquet.schema.MessageType
 
-import java.time.ZoneOffset
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.reflect.ClassTag
 
 class Spark35Shims extends SparkShims {
@@ -100,22 +96,6 @@ class Spark35Shims extends SparkShims {
 
   override def isNullIntolerant(expr: Expression): Boolean = expr.isInstanceOf[NullIntolerant]
 
-  override def generateFileScanRDD(
-      sparkSession: SparkSession,
-      readFunction: PartitionedFile => Iterator[InternalRow],
-      filePartitions: Seq[FilePartition],
-      fileSourceScanExec: FileSourceScanExec): FileScanRDD = {
-    new FileScanRDD(
-      sparkSession,
-      readFunction,
-      filePartitions,
-      new StructType(
-        fileSourceScanExec.requiredSchema.fields ++
-          fileSourceScanExec.relation.partitionSchema.fields),
-      fileSourceScanExec.fileConstantMetadataColumns
-    )
-  }
-
   override def filesGroupedToBuckets(
       selectedPartitions: Array[PartitionDirectory]): Map[Int, Array[PartitionedFile]] = {
     selectedPartitions
@@ -126,43 +106,6 @@ class Spark35Shims extends SparkShims {
             .getBucketId(f.toPath.getName)
             .getOrElse(throw invalidBucketFile(f.urlEncodedPath))
       }
-  }
-
-  override def getBatchScanExecTable(batchScan: BatchScanExec): Table = batchScan.table
-
-  override def generatePartitionedFile(
-      partitionValues: InternalRow,
-      filePath: String,
-      start: Long,
-      length: Long,
-      @transient locations: Array[String] = Array.empty): PartitionedFile =
-    PartitionedFile(partitionValues, SparkPath.fromPathString(filePath), start, length, locations)
-
-  override def generateMetadataColumns(
-      file: PartitionedFile,
-      metadataColumnNames: Seq[String]): Map[String, String] = {
-    val originMetadataColumn = super.generateMetadataColumns(file, metadataColumnNames)
-    val metadataColumn: mutable.Map[String, String] = mutable.Map(originMetadataColumn.toSeq: _*)
-    val path = new Path(file.filePath.toString)
-    for (columnName <- metadataColumnNames) {
-      columnName match {
-        case FileFormat.FILE_PATH => metadataColumn += (FileFormat.FILE_PATH -> path.toString)
-        case FileFormat.FILE_NAME => metadataColumn += (FileFormat.FILE_NAME -> path.getName)
-        case FileFormat.FILE_SIZE =>
-          metadataColumn += (FileFormat.FILE_SIZE -> file.fileSize.toString)
-        case FileFormat.FILE_MODIFICATION_TIME =>
-          val fileModifyTime = TimestampFormatter
-            .getFractionFormatter(ZoneOffset.UTC)
-            .format(file.modificationTime * 1000L)
-          metadataColumn += (FileFormat.FILE_MODIFICATION_TIME -> fileModifyTime)
-        case FileFormat.FILE_BLOCK_START =>
-          metadataColumn += (FileFormat.FILE_BLOCK_START -> file.start.toString)
-        case FileFormat.FILE_BLOCK_LENGTH =>
-          metadataColumn += (FileFormat.FILE_BLOCK_LENGTH -> file.length.toString)
-        case _ =>
-      }
-    }
-    metadataColumn.toMap
   }
 
   // https://issues.apache.org/jira/browse/SPARK-40400
@@ -348,10 +291,6 @@ class Spark35Shims extends SparkShims {
         None
     }
   }
-  override def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = {
-    batchScan.keyGroupedPartitioning
-  }
-
   override def getCommonPartitionValues(
       batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] = {
     batchScan.spjParams.commonPartitionValues
@@ -480,18 +419,6 @@ class Spark35Shims extends SparkShims {
       case d: Divide => d.evalMode == EvalMode.TRY
       case m: Multiply => m.evalMode == EvalMode.TRY
       case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
-  override def withAnsiEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.ANSI
-      case s: Subtract => s.evalMode == EvalMode.ANSI
-      case d: Divide => d.evalMode == EvalMode.ANSI
-      case m: Multiply => m.evalMode == EvalMode.ANSI
-      case c: Cast => c.evalMode == EvalMode.ANSI
-      case i: IntegralDivide => i.evalMode == EvalMode.ANSI
       case _ => false
     }
   }

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -21,12 +21,10 @@ import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 
 import org.apache.spark._
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.QueryPlan
@@ -54,7 +52,6 @@ import org.apache.parquet.schema.MessageType
 import java.util.{Map => JMap}
 
 import scala.collection.JavaConverters._
-import scala.reflect.ClassTag
 
 class Spark35Shims extends SparkShims {
 
@@ -114,20 +111,6 @@ class Spark35Shims extends SparkShims {
       cause = null)
   }
 
-  private def getLimit(limit: Int, offset: Int): Int = {
-    if (limit == -1) {
-      // Only offset specified, so fetch the maximum number rows
-      Int.MaxValue
-    } else {
-      assert(limit > offset)
-      limit - offset
-    }
-  }
-
-  override def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
   override def isWindowGroupLimitExec(plan: SparkPlan): Boolean = plan match {
     case _: WindowGroupLimitExec => true
     case _ => false
@@ -165,10 +148,6 @@ class Spark35Shims extends SparkShims {
     )
   }
 
-  override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
   override def writeFilesExecuteTask(
       description: WriteJobDescription,
       jobTrackerID: String,
@@ -186,26 +165,6 @@ class Spark35Shims extends SparkShims {
       committer,
       iterator
     )
-  }
-
-  override def enableNativeWriteFilesByDefault(): Boolean = true
-
-  override def getV1WriteRequiredOrdering(
-      outputColumns: Seq[Attribute],
-      partitionColumns: Seq[Attribute],
-      bucketSpec: Option[BucketSpec],
-      options: Map[String, String],
-      numStaticPartitionCols: Int): Seq[SortOrder] = {
-    V1WritesUtils.getSortOrder(
-      outputColumns,
-      partitionColumns,
-      bucketSpec,
-      options,
-      numStaticPartitionCols)
-  }
-
-  override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
-    SparkContextUtils.broadcastInternal(sc, value)
   }
 
   override def setJobDescriptionOrTagForBroadcastExchange(
@@ -424,11 +383,6 @@ class Spark35Shims extends SparkShims {
     )
   }
 
-  override def extractExpressionArrayInsert(arrayInsert: Expression): Seq[Expression] = {
-    val expr = arrayInsert.asInstanceOf[ArrayInsert]
-    Seq(expr.srcArrayExpr, expr.posExpr, expr.itemExpr, Literal(expr.legacyNegativeIndex))
-  }
-
   override def withOperatorIdMap[T](idMap: java.util.Map[QueryPlan[_], Int])(body: => T): T = {
     val prevIdMap = QueryPlan.localIdMap.get()
     try {
@@ -470,12 +424,6 @@ class Spark35Shims extends SparkShims {
 
   override def getOtherConstantMetadataColumnValues(file: PartitionedFile): JMap[String, Object] =
     file.otherConstantMetadataColumnValues.asJava.asInstanceOf[JMap[String, Object]]
-
-  override def getCollectLimitOffset(plan: CollectLimitExec): Int = {
-    plan.offset
-  }
-
-  override def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean = unBase64.failOnError
 
   override def extractExpressionTimestampAddUnit(exp: Expression): Option[Seq[String]] = {
     exp match {

--- a/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
+++ b/shims/spark35/src/main/scala/org/apache/gluten/sql/shims/spark35/Spark35Shims.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 
 import org.apache.spark._
-import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecision
@@ -145,25 +144,6 @@ class Spark35Shims extends SparkShims {
       windowGroupLimitExecShim.limit,
       mode,
       windowGroupLimitExecShim.child
-    )
-  }
-
-  override def writeFilesExecuteTask(
-      description: WriteJobDescription,
-      jobTrackerID: String,
-      sparkStageId: Int,
-      sparkPartitionId: Int,
-      sparkAttemptNumber: Int,
-      committer: FileCommitProtocol,
-      iterator: Iterator[InternalRow]): WriteTaskResult = {
-    GlutenFileFormatWriter.writeFilesExecuteTask(
-      description,
-      jobTrackerID,
-      sparkStageId,
-      sparkPartitionId,
-      sparkAttemptNumber,
-      committer,
-      iterator
     )
   }
 

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -437,17 +437,6 @@ class Spark40Shims extends SparkShims {
     }
   }
 
-  override def withTryEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.TRY
-      case s: Subtract => s.evalMode == EvalMode.TRY
-      case d: Divide => d.evalMode == EvalMode.TRY
-      case m: Multiply => m.evalMode == EvalMode.TRY
-      case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
   override def createParquetFilters(
       conf: SQLConf,
       schema: MessageType,

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, KeyGroupedShuffleSpec, Partitioning}
-import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{CollationFactory, InternalRowComparableWrapper, MapData}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
@@ -179,8 +178,6 @@ class Spark40Shims extends SparkShims {
   override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
     (getLimit(plan.limit, plan.offset), plan.offset)
   }
-
-  override def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = List()
 
   override def writeFilesExecuteTask(
       description: WriteJobDescription,

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -23,7 +23,6 @@ import org.apache.gluten.sql.shims.SparkShims
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
-import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
@@ -36,10 +35,9 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, KeyGroupedShuffleSpec, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{CollationFactory, InternalRowComparableWrapper, MapData, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.{CollationFactory, InternalRowComparableWrapper, MapData}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.classic.ClassicConversions._
-import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
@@ -58,10 +56,8 @@ import org.apache.parquet.hadoop.metadata.{CompressionCodecName, ParquetMetadata
 import org.apache.parquet.hadoop.metadata.FileMetaData.EncryptionType
 import org.apache.parquet.schema.MessageType
 
-import java.time.ZoneOffset
 import java.util.{Map => JMap}
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
@@ -110,22 +106,6 @@ class Spark40Shims extends SparkShims {
 
   override def isNullIntolerant(expr: Expression): Boolean = expr.nullIntolerant
 
-  override def generateFileScanRDD(
-      sparkSession: SparkSession,
-      readFunction: PartitionedFile => Iterator[InternalRow],
-      filePartitions: Seq[FilePartition],
-      fileSourceScanExec: FileSourceScanExec): FileScanRDD = {
-    new FileScanRDD(
-      sparkSession,
-      readFunction,
-      filePartitions,
-      new StructType(
-        fileSourceScanExec.requiredSchema.fields ++
-          fileSourceScanExec.relation.partitionSchema.fields),
-      fileSourceScanExec.fileConstantMetadataColumns
-    )
-  }
-
   override def filesGroupedToBuckets(
       selectedPartitions: Array[PartitionDirectory]): Map[Int, Array[PartitionedFile]] = {
     selectedPartitions
@@ -136,43 +116,6 @@ class Spark40Shims extends SparkShims {
             .getBucketId(f.toPath.getName)
             .getOrElse(throw invalidBucketFile(f.urlEncodedPath))
       }
-  }
-
-  override def getBatchScanExecTable(batchScan: BatchScanExec): Table = batchScan.table
-
-  override def generatePartitionedFile(
-      partitionValues: InternalRow,
-      filePath: String,
-      start: Long,
-      length: Long,
-      @transient locations: Array[String] = Array.empty): PartitionedFile =
-    PartitionedFile(partitionValues, SparkPath.fromPathString(filePath), start, length, locations)
-
-  override def generateMetadataColumns(
-      file: PartitionedFile,
-      metadataColumnNames: Seq[String]): Map[String, String] = {
-    val originMetadataColumn = super.generateMetadataColumns(file, metadataColumnNames)
-    val metadataColumn: mutable.Map[String, String] = mutable.Map(originMetadataColumn.toSeq: _*)
-    val path = new Path(file.filePath.toString)
-    for (columnName <- metadataColumnNames) {
-      columnName match {
-        case FileFormat.FILE_PATH => metadataColumn += (FileFormat.FILE_PATH -> path.toString)
-        case FileFormat.FILE_NAME => metadataColumn += (FileFormat.FILE_NAME -> path.getName)
-        case FileFormat.FILE_SIZE =>
-          metadataColumn += (FileFormat.FILE_SIZE -> file.fileSize.toString)
-        case FileFormat.FILE_MODIFICATION_TIME =>
-          val fileModifyTime = TimestampFormatter
-            .getFractionFormatter(ZoneOffset.UTC)
-            .format(file.modificationTime * 1000L)
-          metadataColumn += (FileFormat.FILE_MODIFICATION_TIME -> fileModifyTime)
-        case FileFormat.FILE_BLOCK_START =>
-          metadataColumn += (FileFormat.FILE_BLOCK_START -> file.start.toString)
-        case FileFormat.FILE_BLOCK_LENGTH =>
-          metadataColumn += (FileFormat.FILE_BLOCK_LENGTH -> file.length.toString)
-        case _ =>
-      }
-    }
-    metadataColumn.toMap
   }
 
   // https://issues.apache.org/jira/browse/SPARK-40400
@@ -359,10 +302,6 @@ class Spark40Shims extends SparkShims {
         None
     }
   }
-  override def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = {
-    batchScan.keyGroupedPartitioning
-  }
-
   override def getCommonPartitionValues(
       batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] = {
     batchScan.spjParams.commonPartitionValues
@@ -509,18 +448,6 @@ class Spark40Shims extends SparkShims {
       case d: Divide => d.evalMode == EvalMode.TRY
       case m: Multiply => m.evalMode == EvalMode.TRY
       case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
-  override def withAnsiEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.ANSI
-      case s: Subtract => s.evalMode == EvalMode.ANSI
-      case d: Divide => d.evalMode == EvalMode.ANSI
-      case m: Multiply => m.evalMode == EvalMode.ANSI
-      case c: Cast => c.evalMode == EvalMode.ANSI
-      case i: IntegralDivide => i.evalMode == EvalMode.ANSI
       case _ => false
     }
   }

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -41,7 +41,6 @@ import org.apache.spark.sql.classic.ClassicConversions._
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, BatchScanExecShim, DataSourceV2ScanExecBase}
@@ -532,14 +531,6 @@ class Spark40Shims extends SparkShims {
     }
   }
 
-  override def extractExpressionTimestampDiffUnit(exp: Expression): Option[String] = {
-    exp match {
-      case timestampDiff: TimestampDiff =>
-        Some(timestampDiff.unit)
-      case _ => Option.empty
-    }
-  }
-
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecisionTypeCoercion.widerDecimalType(d1, d2)
   }
@@ -589,10 +580,6 @@ class Spark40Shims extends SparkShims {
       planner: SparkPlanner,
       plan: LogicalPlan): SparkPlan =
     QueryExecution.createSparkPlan(sparkSession, planner, plan)
-
-  override def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean = {
-    p.isFinalPlan
-  }
 
   override def isLeftSingleJoinType(joinType: JoinType): Boolean = {
     joinType == LeftSingle

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 
 import org.apache.spark._
-import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
@@ -155,25 +154,6 @@ class Spark40Shims extends SparkShims {
       windowGroupLimitExecShim.limit,
       mode,
       windowGroupLimitExecShim.child
-    )
-  }
-
-  override def writeFilesExecuteTask(
-      description: WriteJobDescription,
-      jobTrackerID: String,
-      sparkStageId: Int,
-      sparkPartitionId: Int,
-      sparkAttemptNumber: Int,
-      committer: FileCommitProtocol,
-      iterator: Iterator[InternalRow]): WriteTaskResult = {
-    GlutenFileFormatWriter.writeFilesExecuteTask(
-      description,
-      jobTrackerID,
-      sparkStageId,
-      sparkPartitionId,
-      sparkAttemptNumber,
-      committer,
-      iterator
     )
   }
 

--- a/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
+++ b/shims/spark40/src/main/scala/org/apache/gluten/sql/shims/spark40/Spark40Shims.scala
@@ -21,12 +21,10 @@ import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 
 import org.apache.spark._
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
@@ -57,7 +55,6 @@ import org.apache.parquet.schema.MessageType
 import java.util.{Map => JMap}
 
 import scala.jdk.CollectionConverters._
-import scala.reflect.ClassTag
 
 class Spark40Shims extends SparkShims {
 
@@ -124,20 +121,6 @@ class Spark40Shims extends SparkShims {
       cause = null)
   }
 
-  private def getLimit(limit: Int, offset: Int): Int = {
-    if (limit == -1) {
-      // Only offset specified, so fetch the maximum number rows
-      Int.MaxValue
-    } else {
-      assert(limit > offset)
-      limit - offset
-    }
-  }
-
-  override def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
   override def isWindowGroupLimitExec(plan: SparkPlan): Boolean = plan match {
     case _: WindowGroupLimitExec => true
     case _ => false
@@ -175,10 +158,6 @@ class Spark40Shims extends SparkShims {
     )
   }
 
-  override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
   override def writeFilesExecuteTask(
       description: WriteJobDescription,
       jobTrackerID: String,
@@ -196,26 +175,6 @@ class Spark40Shims extends SparkShims {
       committer,
       iterator
     )
-  }
-
-  override def enableNativeWriteFilesByDefault(): Boolean = true
-
-  override def getV1WriteRequiredOrdering(
-      outputColumns: Seq[Attribute],
-      partitionColumns: Seq[Attribute],
-      bucketSpec: Option[BucketSpec],
-      options: Map[String, String],
-      numStaticPartitionCols: Int): Seq[SortOrder] = {
-    V1WritesUtils.getSortOrder(
-      outputColumns,
-      partitionColumns,
-      bucketSpec,
-      options,
-      numStaticPartitionCols)
-  }
-
-  override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
-    SparkContextUtils.broadcastInternal(sc, value)
   }
 
   override def setJobDescriptionOrTagForBroadcastExchange(
@@ -453,11 +412,6 @@ class Spark40Shims extends SparkShims {
     )
   }
 
-  override def extractExpressionArrayInsert(arrayInsert: Expression): Seq[Expression] = {
-    val expr = arrayInsert.asInstanceOf[ArrayInsert]
-    Seq(expr.srcArrayExpr, expr.posExpr, expr.itemExpr, Literal(expr.legacyNegativeIndex))
-  }
-
   override def withOperatorIdMap[T](idMap: java.util.Map[QueryPlan[_], Int])(body: => T): T = {
     val prevIdMap = QueryPlan.localIdMap.get()
     try {
@@ -499,12 +453,6 @@ class Spark40Shims extends SparkShims {
 
   override def getOtherConstantMetadataColumnValues(file: PartitionedFile): JMap[String, Object] =
     file.otherConstantMetadataColumnValues.asJava.asInstanceOf[JMap[String, Object]]
-
-  override def getCollectLimitOffset(plan: CollectLimitExec): Int = {
-    plan.offset
-  }
-
-  override def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean = unBase64.failOnError
 
   override def extractExpressionTimestampAddUnit(exp: Expression): Option[Seq[String]] = {
     exp match {

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -40,7 +40,6 @@ import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
-import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetFilters}
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, BatchScanExecShim, DataSourceV2ScanExecBase}
@@ -548,14 +547,6 @@ class Spark41Shims extends SparkShims {
     }
   }
 
-  override def extractExpressionTimestampDiffUnit(exp: Expression): Option[String] = {
-    exp match {
-      case timestampDiff: TimestampDiff =>
-        Some(timestampDiff.unit)
-      case _ => Option.empty
-    }
-  }
-
   override def widerDecimalType(d1: DecimalType, d2: DecimalType): DecimalType = {
     DecimalPrecisionTypeCoercion.widerDecimalType(d1, d2)
   }
@@ -616,10 +607,6 @@ class Spark41Shims extends SparkShims {
       planner: SparkPlanner,
       plan: LogicalPlan): SparkPlan =
     QueryExecution.createSparkPlan(planner, plan)
-
-  override def isFinalAdaptivePlan(p: AdaptiveSparkPlanExec): Boolean = {
-    p.isFinalPlan
-  }
 
   override def isLeftSingleJoinType(joinType: JoinType): Boolean = {
     joinType == LeftSingle

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -436,17 +436,6 @@ class Spark41Shims extends SparkShims {
     }
   }
 
-  override def withTryEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.TRY
-      case s: Subtract => s.evalMode == EvalMode.TRY
-      case d: Divide => d.evalMode == EvalMode.TRY
-      case m: Multiply => m.evalMode == EvalMode.TRY
-      case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
   override def createParquetFilters(
       conf: SQLConf,
       schema: MessageType,

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, KeyGroupedShuffleSpec, Partitioning}
-import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{CollationFactory, InternalRowComparableWrapper, MapData}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
@@ -178,8 +177,6 @@ class Spark41Shims extends SparkShims {
   override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
     (getLimit(plan.limit, plan.offset), plan.offset)
   }
-
-  override def getExtendedColumnarPostRules(): List[SparkSession => Rule[SparkPlan]] = List()
 
   override def writeFilesExecuteTask(
       description: WriteJobDescription,

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -23,7 +23,6 @@ import org.apache.gluten.sql.shims.SparkShims
 import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
-import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
@@ -36,9 +35,8 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.physical.{KeyGroupedPartitioning, KeyGroupedShuffleSpec, Partitioning}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
-import org.apache.spark.sql.catalyst.util.{CollationFactory, InternalRowComparableWrapper, MapData, TimestampFormatter}
+import org.apache.spark.sql.catalyst.util.{CollationFactory, InternalRowComparableWrapper, MapData}
 import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
-import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, Scan}
 import org.apache.spark.sql.connector.read.streaming.SparkDataStream
 import org.apache.spark.sql.execution._
@@ -57,10 +55,8 @@ import org.apache.parquet.hadoop.metadata.{CompressionCodecName, ParquetMetadata
 import org.apache.parquet.hadoop.metadata.FileMetaData.EncryptionType
 import org.apache.parquet.schema.{GroupType, LogicalTypeAnnotation, MessageType}
 
-import java.time.ZoneOffset
 import java.util.{Map => JMap}
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
@@ -109,22 +105,6 @@ class Spark41Shims extends SparkShims {
 
   override def isNullIntolerant(expr: Expression): Boolean = expr.nullIntolerant
 
-  override def generateFileScanRDD(
-      sparkSession: SparkSession,
-      readFunction: PartitionedFile => Iterator[InternalRow],
-      filePartitions: Seq[FilePartition],
-      fileSourceScanExec: FileSourceScanExec): FileScanRDD = {
-    new FileScanRDD(
-      sparkSession,
-      readFunction,
-      filePartitions,
-      new StructType(
-        fileSourceScanExec.requiredSchema.fields ++
-          fileSourceScanExec.relation.partitionSchema.fields),
-      fileSourceScanExec.fileConstantMetadataColumns
-    )
-  }
-
   override def filesGroupedToBuckets(
       selectedPartitions: Array[PartitionDirectory]): Map[Int, Array[PartitionedFile]] = {
     selectedPartitions
@@ -135,43 +115,6 @@ class Spark41Shims extends SparkShims {
             .getBucketId(f.toPath.getName)
             .getOrElse(throw invalidBucketFile(f.urlEncodedPath))
       }
-  }
-
-  override def getBatchScanExecTable(batchScan: BatchScanExec): Table = batchScan.table
-
-  override def generatePartitionedFile(
-      partitionValues: InternalRow,
-      filePath: String,
-      start: Long,
-      length: Long,
-      @transient locations: Array[String] = Array.empty): PartitionedFile =
-    PartitionedFile(partitionValues, SparkPath.fromPathString(filePath), start, length, locations)
-
-  override def generateMetadataColumns(
-      file: PartitionedFile,
-      metadataColumnNames: Seq[String]): Map[String, String] = {
-    val originMetadataColumn = super.generateMetadataColumns(file, metadataColumnNames)
-    val metadataColumn: mutable.Map[String, String] = mutable.Map(originMetadataColumn.toSeq: _*)
-    val path = new Path(file.filePath.toString)
-    for (columnName <- metadataColumnNames) {
-      columnName match {
-        case FileFormat.FILE_PATH => metadataColumn += (FileFormat.FILE_PATH -> path.toString)
-        case FileFormat.FILE_NAME => metadataColumn += (FileFormat.FILE_NAME -> path.getName)
-        case FileFormat.FILE_SIZE =>
-          metadataColumn += (FileFormat.FILE_SIZE -> file.fileSize.toString)
-        case FileFormat.FILE_MODIFICATION_TIME =>
-          val fileModifyTime = TimestampFormatter
-            .getFractionFormatter(ZoneOffset.UTC)
-            .format(file.modificationTime * 1000L)
-          metadataColumn += (FileFormat.FILE_MODIFICATION_TIME -> fileModifyTime)
-        case FileFormat.FILE_BLOCK_START =>
-          metadataColumn += (FileFormat.FILE_BLOCK_START -> file.start.toString)
-        case FileFormat.FILE_BLOCK_LENGTH =>
-          metadataColumn += (FileFormat.FILE_BLOCK_LENGTH -> file.length.toString)
-        case _ =>
-      }
-    }
-    metadataColumn.toMap
   }
 
   // https://issues.apache.org/jira/browse/SPARK-40400
@@ -358,10 +301,6 @@ class Spark41Shims extends SparkShims {
         None
     }
   }
-  override def getKeyGroupedPartitioning(batchScan: BatchScanExec): Option[Seq[Expression]] = {
-    batchScan.keyGroupedPartitioning
-  }
-
   override def getCommonPartitionValues(
       batchScan: BatchScanExec): Option[Seq[(InternalRow, Int)]] = {
     batchScan.spjParams.commonPartitionValues
@@ -508,18 +447,6 @@ class Spark41Shims extends SparkShims {
       case d: Divide => d.evalMode == EvalMode.TRY
       case m: Multiply => m.evalMode == EvalMode.TRY
       case c: Cast => c.evalMode == EvalMode.TRY
-      case _ => false
-    }
-  }
-
-  override def withAnsiEvalMode(expr: Expression): Boolean = {
-    expr match {
-      case a: Add => a.evalMode == EvalMode.ANSI
-      case s: Subtract => s.evalMode == EvalMode.ANSI
-      case d: Divide => d.evalMode == EvalMode.ANSI
-      case m: Multiply => m.evalMode == EvalMode.ANSI
-      case c: Cast => c.evalMode == EvalMode.ANSI
-      case i: IntegralDivide => i.evalMode == EvalMode.ANSI
       case _ => false
     }
   }

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -21,7 +21,6 @@ import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 
 import org.apache.spark._
-import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
@@ -154,25 +153,6 @@ class Spark41Shims extends SparkShims {
       windowGroupLimitExecShim.limit,
       mode,
       windowGroupLimitExecShim.child
-    )
-  }
-
-  override def writeFilesExecuteTask(
-      description: WriteJobDescription,
-      jobTrackerID: String,
-      sparkStageId: Int,
-      sparkPartitionId: Int,
-      sparkAttemptNumber: Int,
-      committer: FileCommitProtocol,
-      iterator: Iterator[InternalRow]): WriteTaskResult = {
-    GlutenFileFormatWriter.writeFilesExecuteTask(
-      description,
-      jobTrackerID,
-      sparkStageId,
-      sparkPartitionId,
-      sparkAttemptNumber,
-      committer,
-      iterator
     )
   }
 

--- a/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
+++ b/shims/spark41/src/main/scala/org/apache/gluten/sql/shims/spark41/Spark41Shims.scala
@@ -21,12 +21,10 @@ import org.apache.gluten.expression.{ExpressionNames, Sig}
 import org.apache.gluten.sql.shims.SparkShims
 
 import org.apache.spark._
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.{ExtendedAnalysisException, InternalRow}
 import org.apache.spark.sql.catalyst.analysis.DecimalPrecisionTypeCoercion
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.{JoinType, LeftSingle}
@@ -56,7 +54,6 @@ import org.apache.parquet.schema.{GroupType, LogicalTypeAnnotation, MessageType}
 import java.util.{Map => JMap}
 
 import scala.jdk.CollectionConverters._
-import scala.reflect.ClassTag
 
 class Spark41Shims extends SparkShims {
 
@@ -123,20 +120,6 @@ class Spark41Shims extends SparkShims {
       cause = null)
   }
 
-  private def getLimit(limit: Int, offset: Int): Int = {
-    if (limit == -1) {
-      // Only offset specified, so fetch the maximum number rows
-      Int.MaxValue
-    } else {
-      assert(limit > offset)
-      limit - offset
-    }
-  }
-
-  override def getLimitAndOffsetFromGlobalLimit(plan: GlobalLimitExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
   override def isWindowGroupLimitExec(plan: SparkPlan): Boolean = plan match {
     case _: WindowGroupLimitExec => true
     case _ => false
@@ -174,10 +157,6 @@ class Spark41Shims extends SparkShims {
     )
   }
 
-  override def getLimitAndOffsetFromTopK(plan: TakeOrderedAndProjectExec): (Int, Int) = {
-    (getLimit(plan.limit, plan.offset), plan.offset)
-  }
-
   override def writeFilesExecuteTask(
       description: WriteJobDescription,
       jobTrackerID: String,
@@ -195,26 +174,6 @@ class Spark41Shims extends SparkShims {
       committer,
       iterator
     )
-  }
-
-  override def enableNativeWriteFilesByDefault(): Boolean = true
-
-  override def getV1WriteRequiredOrdering(
-      outputColumns: Seq[Attribute],
-      partitionColumns: Seq[Attribute],
-      bucketSpec: Option[BucketSpec],
-      options: Map[String, String],
-      numStaticPartitionCols: Int): Seq[SortOrder] = {
-    V1WritesUtils.getSortOrder(
-      outputColumns,
-      partitionColumns,
-      bucketSpec,
-      options,
-      numStaticPartitionCols)
-  }
-
-  override def broadcastInternal[T: ClassTag](sc: SparkContext, value: T): Broadcast[T] = {
-    SparkContextUtils.broadcastInternal(sc, value)
   }
 
   override def setJobDescriptionOrTagForBroadcastExchange(
@@ -452,11 +411,6 @@ class Spark41Shims extends SparkShims {
     )
   }
 
-  override def extractExpressionArrayInsert(arrayInsert: Expression): Seq[Expression] = {
-    val expr = arrayInsert.asInstanceOf[ArrayInsert]
-    Seq(expr.srcArrayExpr, expr.posExpr, expr.itemExpr, Literal(expr.legacyNegativeIndex))
-  }
-
   override def withOperatorIdMap[T](idMap: java.util.Map[QueryPlan[_], Int])(body: => T): T = {
     val prevIdMap = QueryPlan.localIdMap.get()
     try {
@@ -515,12 +469,6 @@ class Spark41Shims extends SparkShims {
 
   override def getOtherConstantMetadataColumnValues(file: PartitionedFile): JMap[String, Object] =
     file.otherConstantMetadataColumnValues.asJava.asInstanceOf[JMap[String, Object]]
-
-  override def getCollectLimitOffset(plan: CollectLimitExec): Int = {
-    plan.offset
-  }
-
-  override def unBase64FunctionFailsOnError(unBase64: UnBase64): Boolean = unBase64.failOnError
 
   override def extractExpressionTimestampAddUnit(exp: Expression): Option[Seq[String]] = {
     exp match {


### PR DESCRIPTION
## What changes are proposed in this pull request?

With Spark 3.3 gone, most of `SparkShims` no longer varies by version. Following review feedback this deletes those methods rather than lifting their bodies into the trait: the caller reads the underlying Spark API directly, or the logic moves to a util object where more than one caller needs it.

Nineteen methods leave the trait, 64 down to 45.

Fifteen are inlined at the call site, each a single field read or a single forward: `getBatchScanExecTable`, `getKeyGroupedPartitioning`, `getCollectLimitOffset`, `unBase64FunctionFailsOnError`, `enableNativeWriteFilesByDefault`, `isFinalAdaptivePlan`, `broadcastInternal`, `getV1WriteRequiredOrdering`, `writeFilesExecuteTask`, `extractExpressionArrayInsert`, `extractExpressionTimestampDiffUnit`, `generatePartitionedFile`, `generateFileScanRDD`, `getLimitAndOffsetFromGlobalLimit` and `getLimitAndOffsetFromTopK`. Three of those land in a private helper instead of a raw inline. `getLimitAndOffsetFromGlobalLimit` and `getLimitAndOffsetFromTopK` shared a private `getLimit` duplicated in all four shims, and both callers are in `OffloadSingleNodeRules`, which now has one private helper. `generatePartitionedFile` had twelve call sites across two soft-affinity suites, so each suite got a private `partitionedFile`.

Three move into `gluten-substrait` because they have two callers each: `withTryEvalMode` and `withAnsiEvalMode` to `ExpressionUtils`, and `generateMetadataColumns` to a new `FileMetadataUtil`.

`getExtendedColumnarPostRules` is deleted outright. It returned `List()` in every remaining shim, so the register-these-rules blocks in `VeloxRuleApi` and `CHRuleApi` and their only callee, `GlutenFormatFactory.getExtendedColumnarPostRule`, were dead.

Three surviving defaults become abstract (`extractExpressionTimestampAddUnit`, `getCommonPartitionValues`, `orderPartitions`), so a new shim has to state an answer rather than inherit a value only 3.3 needed. Both `drop Spark 3.3` TODOs in `SparkShims.scala` are now gone.

Two look removable and are not. `createParquetFilters` needs `LegacyBehaviorPolicy`, which is nested in `SQLConf` on 3.4 and top-level from 3.5 on, so no single import in a shared module compiles against all four versions. `widerDecimalType` forwards to `DecimalPrecision` on 3.4/3.5 and `DecimalPrecisionTypeCoercion` on 4.0/4.1. Both become removable when 3.4 goes; #12953 tracks them.

One behavior change to flag: `ExpressionConverter` matched `ArrayInsert` through `getClass.getSimpleName` because the class did not exist on 3.3, and now uses a plain type match. A third-party class whose simple name is also `ArrayInsert` used to enter that arm and fail in the cast; it now falls through to the following arms.

## How was this patch tested?

Compile only, no suites were run.

| profile | what was built |
|-|-|
| 3.5 (2.13) | `gluten-substrait` incl. test sources, velox, iceberg, delta, package |
| 3.5 (2.12) | paimon (`paimon-spark-3.5_2.13` is not published upstream) |
| 3.5 (2.13) | clickhouse, `test-compile` |
| 3.4 | `gluten-substrait` incl. test sources, iceberg, shim |
| 4.0 / 4.1 | `gluten-substrait`, velox, shim |

`spotless:check` is clean on 3.4, 3.5, 4.0 and 4.1.

Not covered locally: velox on 3.4, where the untouched `FlushableHashAggregateRule` does not compile against the Spark 2.12 artifacts this machine resolves; iceberg on 4.0/4.1; clickhouse on 3.4. What this PR changes in those modules is either a call into a `gluten-substrait` util or a read of a public Spark field, neither of which varies by version.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-5


Related issue: #12807