### PR TITLE
[VL][Delta] Emit parquet field ids for UniForm tables on the native write path

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -583,6 +583,17 @@
       </dependencies>
     </profile>
     <profile>
+      <id>spark-3.5</id>
+      <dependencies>
+        <dependency>
+          <groupId>io.delta</groupId>
+          <artifactId>delta-iceberg_${scala.binary.version}</artifactId>
+          <version>${delta.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>delta</id>
       <dependencies>
         <dependency>

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFieldId.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFieldId.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import org.apache.gluten.config.GlutenConfig
+
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
+
+private[delta] object GlutenDeltaParquetFieldId {
+  private case class ParquetFieldId(fieldId: Int, children: Seq[ParquetFieldId])
+
+  def withParquetFieldIds(
+      options: Map[String, String],
+      dataSchema: StructType,
+      deltaMetadata: Metadata): Map[String, String] = {
+    if (!IcebergCompatV2.isEnabled(deltaMetadata)) {
+      options
+    } else {
+      val fieldIds = serialize(dataSchema)
+      if (fieldIds.isEmpty) {
+        options
+      } else {
+        options + (GlutenConfig.PARQUET_FIELD_IDS -> fieldIds)
+      }
+    }
+  }
+
+  private def serialize(schema: StructType): String =
+    schema.fields.map(field => encode(buildField(field))).mkString(",")
+
+  private def buildField(field: StructField): ParquetFieldId = {
+    ParquetFieldId(columnFieldId(field), childrenFor(field.dataType, field, Seq(field.name)))
+  }
+
+  private def buildSyntheticField(
+      ownerField: StructField,
+      fieldIdPath: Seq[String],
+      dataType: DataType): ParquetFieldId = {
+    ParquetFieldId(
+      nestedFieldId(ownerField, fieldIdPath),
+      childrenFor(dataType, ownerField, fieldIdPath))
+  }
+
+  private def childrenFor(
+      dataType: DataType,
+      ownerField: StructField,
+      fieldIdPath: Seq[String]): Seq[ParquetFieldId] = dataType match {
+    case StructType(fields) =>
+      fields.map(buildField)
+    case ArrayType(elementType, _) =>
+      Seq(
+        buildSyntheticField(
+          ownerField,
+          fieldIdPath :+ DeltaColumnMapping.PARQUET_LIST_ELEMENT_FIELD_NAME,
+          elementType))
+    case MapType(keyType, valueType, _) =>
+      Seq(
+        buildSyntheticField(
+          ownerField,
+          fieldIdPath :+ DeltaColumnMapping.PARQUET_MAP_KEY_FIELD_NAME,
+          keyType),
+        buildSyntheticField(
+          ownerField,
+          fieldIdPath :+ DeltaColumnMapping.PARQUET_MAP_VALUE_FIELD_NAME,
+          valueType)
+      )
+    case _ =>
+      Seq.empty
+  }
+
+  private def columnFieldId(field: StructField): Int = {
+    val key = DeltaColumnMapping.PARQUET_FIELD_ID_METADATA_KEY
+    if (field.metadata.contains(key)) field.metadata.getLong(key).toInt else -1
+  }
+
+  private def nestedFieldId(field: StructField, fieldIdPath: Seq[String]): Int = {
+    val key = DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY
+    if (!field.metadata.contains(key)) {
+      -1
+    } else {
+      val nestedIds = field.metadata.getMetadata(key)
+      val nestedKey = fieldIdPath.mkString(".")
+      if (nestedIds.contains(nestedKey)) nestedIds.getLong(nestedKey).toInt else -1
+    }
+  }
+
+  private def encode(fieldId: ParquetFieldId): String = {
+    if (fieldId.children.isEmpty) {
+      fieldId.fieldId.toString
+    } else {
+      fieldId.children.map(encode).mkString(s"${fieldId.fieldId}(", ",", ")")
+    }
+  }
+}

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
@@ -278,7 +278,8 @@ case class GlutenDeltaParquetFileFormat(
       job: Job,
       options: Map[String, String],
       dataSchema: StructType): OutputWriterFactory = {
-    val factory = super.prepareWrite(sparkSession, job, options, dataSchema)
+    val writeOptions = GlutenDeltaParquetFieldId.withParquetFieldIds(options, dataSchema, metadata)
+    val factory = super.prepareWrite(sparkSession, job, writeOptions, dataSchema)
     val conf = ContextUtil.getConfiguration(job)
     // Always write timestamp as TIMESTAMP_MICROS for Iceberg compat based on Iceberg spec
     if (IcebergCompatV1.isEnabled(metadata) || IcebergCompatV2.isEnabled(metadata)) {

--- a/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta33/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -129,6 +129,8 @@ object GlutenDeltaFileFormatWriter extends LoggingShims {
       } else dataColumns
 
     // Note: prepareWrite has side effect. It sets "job".
+    // Parquet field ids for IcebergCompatV2 are injected by
+    // GlutenDeltaParquetFileFormat.prepareWrite, which receives the same schema passed below.
     val outputWriterFactory =
       fileFormat.prepareWrite(
         sparkSession,

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaUniFormIcebergSuite.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/DeltaUniFormIcebergSuite.scala
@@ -1,0 +1,368 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.uniform.ParquetIcebergCompatV2Utils
+import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.tags.ExtendedSQLTest
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS
+
+import java.io.File
+import java.net.URI
+import java.util.Locale
+
+import scala.io.Source
+import scala.util.control.NonFatal
+
+@ExtendedSQLTest
+class DeltaUniFormIcebergSuite
+  extends QueryTest
+  with DeltaSQLCommandTest
+  with DeletionVectorsTestUtils {
+
+  private val icebergSparkExtension =
+    "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions"
+  private val icebergRequiredClasses = Seq(
+    "org.apache.iceberg.spark.source.IcebergSource",
+    icebergSparkExtension,
+    "org.apache.iceberg.hive.TestHiveMetastore")
+
+  private var metastore: AnyRef = _
+
+  override protected def beforeAll(): Unit = {
+    if (hasIcebergTestClasspath) {
+      super.beforeAll()
+    }
+  }
+
+  override protected def beforeEach(): Unit = {
+    if (hasIcebergTestClasspath) {
+      super.beforeEach()
+    }
+  }
+
+  override protected def afterEach(): Unit = {
+    if (hasIcebergTestClasspath) {
+      super.afterEach()
+    }
+  }
+
+  override protected def sparkConf: SparkConf = {
+    val conf = super.sparkConf
+    if (!hasIcebergTestClasspath) {
+      conf
+    } else {
+      val hiveConf = startMetastore()
+      val currentExtensions = conf.get(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key, "")
+      val extensions =
+        if (currentExtensions.isEmpty) icebergSparkExtension
+        else s"$currentExtensions,$icebergSparkExtension"
+      conf
+        .set(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key, extensions)
+        .set(StaticSQLConf.CATALOG_IMPLEMENTATION.key, "hive")
+        .set("spark.sql.catalog.uniform_hive", "org.apache.iceberg.spark.SparkCatalog")
+        .set("spark.sql.catalog.uniform_hive.type", "hive")
+        .set("spark.sql.catalog.uniform_hive.uri", hiveConf.get(METASTOREURIS.varname))
+        .set(s"spark.hadoop.${METASTOREURIS.varname}", hiveConf.get(METASTOREURIS.varname))
+    }
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      if (hasIcebergTestClasspath) {
+        super.afterAll()
+      }
+    } finally {
+      stopMetastore()
+    }
+  }
+
+  private def stopMetastore(): Unit = {
+    if (metastore != null) {
+      metastore.getClass.getMethod("stop").invoke(metastore)
+      metastore = null
+    }
+  }
+
+  private def startMetastore(): HiveConf = synchronized {
+    if (metastore == null) {
+      val metastoreClass = loadClass("org.apache.iceberg.hive.TestHiveMetastore")
+      metastore = metastoreClass.getConstructor().newInstance().asInstanceOf[AnyRef]
+      metastoreClass.getMethod("start").invoke(metastore)
+    }
+    metastore.getClass.getMethod("hiveConf").invoke(metastore).asInstanceOf[HiveConf]
+  }
+
+  test("write UniForm Iceberg Delta table and read through Iceberg") {
+    requireIcebergTestClasspath()
+
+    withTempDir {
+      tableDir =>
+        val tablePath = tableDir.getCanonicalPath
+        val tableName = s"uniform_delta_${math.abs(System.nanoTime())}"
+        val icebergTableName = s"uniform_hive.default.$tableName"
+        withTable(tableName) {
+          sql(s"""
+                 |CREATE TABLE $tableName (
+                 |  id BIGINT,
+                 |  name STRING,
+                 |  ts TIMESTAMP,
+                 |  payload STRUCT<
+                 |    items: ARRAY<STRUCT<sku: STRING, qty: INT>>,
+                 |    attrs: MAP<STRING, STRING>>,
+                 |  part INT)
+                 |USING DELTA
+                 |PARTITIONED BY (part)
+                 |LOCATION '$tablePath'
+                 |TBLPROPERTIES (
+                 |  'delta.columnMapping.mode' = 'name',
+                 |  'delta.minReaderVersion' = '2',
+                 |  'delta.minWriterVersion' = '7',
+                 |  'delta.enableIcebergCompatV2' = 'true',
+                 |  'delta.universalFormat.enabledFormats' = 'iceberg')
+                 |""".stripMargin)
+
+          sql(s"""
+                 |INSERT INTO $tableName VALUES
+                 |  (1, 'alice', TIMESTAMP '2024-01-01 00:00:00',
+                 |   named_struct(
+                 |     'items', array(named_struct('sku', 'a-1', 'qty', 2)),
+                 |     'attrs', map('source', 'gluten')),
+                 |   0),
+                 |  (2, 'bob', TIMESTAMP '2024-01-02 00:00:00',
+                 |   named_struct(
+                 |     'items', array(named_struct('sku', 'b-1', 'qty', 3)),
+                 |     'attrs', map('source', 'velox')),
+                 |   1)
+                 |""".stripMargin)
+
+          val dataFile = listFiles(tableDir).find(_.getName.endsWith(".parquet")).getOrElse {
+            fail(s"No Parquet data file found under $tablePath")
+          }
+          val parquetFooter =
+            ParquetIcebergCompatV2Utils.getParquetFooter(dataFile.getCanonicalPath)
+          assert(ParquetIcebergCompatV2Utils.isParquetIcebergCompatV2(parquetFooter))
+
+          val latestDeltaVersion = sql(s"DESCRIBE HISTORY $tableName")
+            .select("version")
+            .collect()
+            .map(_.getLong(0))
+            .max
+          val metadataFile =
+            waitForIcebergMetadata(tableDir, tableName, icebergTableName, latestDeltaVersion)
+          val metadata = readFile(metadataFile)
+          assert(metadata.contains(deltaVersionProperty(latestDeltaVersion)))
+          assert(metadata.contains("delta-timestamp"))
+          assert(!metadata.contains("\"current-snapshot-id\" : -1"))
+
+          checkAnswer(
+            spark.read
+              .format("iceberg")
+              .load(icebergTableName)
+              .select("id", "name", "part")
+              .orderBy("id"),
+            Seq(Row(1L, "alice", 0), Row(2L, "bob", 1)))
+        }
+    }
+  }
+
+  test("UniForm Iceberg rejects active deletion vectors") {
+    requireIcebergTestClasspath()
+
+    withTempDir {
+      tableDir =>
+        val tablePath = tableDir.getCanonicalPath
+        withDeletionVectorsEnabled() {
+          sql(s"""
+                 |CREATE TABLE delta.`$tablePath` (id BIGINT)
+                 |USING DELTA
+                 |TBLPROPERTIES ('${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key}' = 'true')
+                 |""".stripMargin)
+          sql(s"INSERT INTO delta.`$tablePath` VALUES (1), (2)")
+          sql(s"DELETE FROM delta.`$tablePath` WHERE id = 1")
+        }
+
+        val error = intercept[Throwable] {
+          sql(s"""
+                 |ALTER TABLE delta.`$tablePath` SET TBLPROPERTIES (
+                 |  'delta.columnMapping.mode' = 'name',
+                 |  'delta.minReaderVersion' = '2',
+                 |  'delta.minWriterVersion' = '7',
+                 |  'delta.enableIcebergCompatV2' = 'true',
+                 |  'delta.universalFormat.enabledFormats' = 'iceberg')
+                 |""".stripMargin)
+        }
+        val message = Option(error.getMessage).getOrElse("").toLowerCase(Locale.ROOT)
+        assert(
+          message.contains("deletion vector") ||
+            message.contains("iceberg") ||
+            message.contains("uniform"))
+    }
+  }
+
+  private def requireIcebergTestClasspath(): Unit = {
+    assume(
+      hasIcebergTestClasspath,
+      s"requires ${icebergRequiredClasses.mkString(", ")} on the test classpath"
+    )
+  }
+
+  private def hasIcebergTestClasspath: Boolean =
+    icebergRequiredClasses.forall(hasClass)
+
+  private def hasClass(className: String): Boolean = {
+    try {
+      loadClass(className)
+      true
+    } catch {
+      case _: ClassNotFoundException => false
+    }
+  }
+
+  private def loadClass(className: String): Class[_] =
+    Class.forName(className, false, Thread.currentThread().getContextClassLoader)
+
+  private def waitForIcebergMetadata(
+      tableDir: File,
+      deltaTableName: String,
+      icebergTableName: String,
+      expectedDeltaVersion: Long): File = {
+    val deadline = System.nanoTime() + 30L * 1000L * 1000L * 1000L
+    var files = listIcebergMetadataFiles(tableDir, deltaTableName)
+    var metadataLocation = getIcebergMetadataLocation(icebergTableName)
+    var convertedMetadata = findConvertedMetadata(files, metadataLocation, expectedDeltaVersion)
+    while (convertedMetadata.isEmpty && System.nanoTime() < deadline) {
+      spark.sparkContext.listenerBus.waitUntilEmpty(15000)
+      Thread.sleep(500)
+      files = listIcebergMetadataFiles(tableDir, deltaTableName)
+      metadataLocation = getIcebergMetadataLocation(icebergTableName)
+      convertedMetadata = findConvertedMetadata(files, metadataLocation, expectedDeltaVersion)
+    }
+    convertedMetadata.getOrElse {
+      fail(
+        s"No Iceberg metadata file for Delta version $expectedDeltaVersion generated under " +
+          s"${new File(tableDir, "metadata")}. " +
+          s"${icebergMetadataDebug(tableDir, deltaTableName, icebergTableName)}")
+    }
+  }
+
+  private def findConvertedMetadata(
+      files: Seq[File],
+      metadataLocation: Option[String],
+      expectedDeltaVersion: Long): Option[File] = {
+    val candidates = files ++ metadataLocation.map(metadataLocationToFile)
+    candidates.reverse.find {
+      file =>
+        file.isFile && {
+          val metadata = readFile(file)
+          metadata.contains(deltaVersionProperty(expectedDeltaVersion)) &&
+          metadata.contains("delta-timestamp") &&
+          !metadata.contains("\"current-snapshot-id\" : -1")
+        }
+    }
+  }
+
+  private def deltaVersionProperty(version: Long): String =
+    "\"" + "delta-version" + "\" : \"" + version + "\""
+
+  private def getIcebergMetadataLocation(tableName: String): Option[String] = {
+    try {
+      spark
+        .sql(s"SHOW TBLPROPERTIES $tableName")
+        .collect()
+        .find(row => row.getString(0) == IcebergConstants.ICEBERG_TBLPROP_METADATA_LOCATION)
+        .map(_.getString(1))
+        .filter(_.nonEmpty)
+    } catch {
+      case NonFatal(_) => None
+    }
+  }
+
+  private def metadataLocationToFile(location: String): File = {
+    val uri = new URI(location)
+    if (uri.getScheme == null) new File(location) else new File(uri)
+  }
+
+  private def icebergMetadataDebug(
+      tableDir: File,
+      deltaTableName: String,
+      icebergTableName: String): String = {
+    val deltaProperties = spark
+      .sql(s"SHOW TBLPROPERTIES $deltaTableName")
+      .collect()
+      .map(row => s"${row.getString(0)}=${row.getString(1)}")
+      .sorted
+      .mkString("[", ", ", "]")
+    val icebergProperties =
+      try {
+        spark
+          .sql(s"SHOW TBLPROPERTIES $icebergTableName")
+          .collect()
+          .map(row => s"${row.getString(0)}=${row.getString(1)}")
+          .sorted
+          .mkString("[", ", ", "]")
+      } catch {
+        case NonFatal(e) => s"unavailable: ${e.getMessage}"
+      }
+    val nearbyMetadata = listIcebergMetadataFiles(tableDir, deltaTableName)
+      .map(_.getCanonicalPath)
+      .sorted
+      .mkString("[", ", ", "]")
+    s"Delta table properties: $deltaProperties. " +
+      s"Iceberg table properties: $icebergProperties. Nearby metadata files: $nearbyMetadata"
+  }
+
+  private def listIcebergMetadataFiles(tableDir: File, tableName: String): Seq[File] = {
+    val deltaMetadataDir = new File(tableDir, "metadata")
+    val metadataFiles =
+      Option(deltaMetadataDir.listFiles())
+        .getOrElse(Array.empty)
+        .filter(file => file.isFile && file.getName.endsWith(".metadata.json")) ++
+        Option(tableDir.getParentFile)
+          .map(listFiles)
+          .getOrElse(Seq.empty)
+          .filter(
+            file =>
+              file.isFile &&
+                file.getName.endsWith(".metadata.json") &&
+                file.getCanonicalPath.contains(tableName))
+
+    metadataFiles
+      .groupBy(_.getCanonicalPath)
+      .values
+      .map(_.head)
+      .toSeq
+      .sortBy(_.getName)
+  }
+
+  private def listFiles(root: File): Seq[File] = {
+    Option(root.listFiles()).getOrElse(Array.empty).toSeq.flatMap {
+      file => if (file.isDirectory) listFiles(file) else Seq(file)
+    }
+  }
+
+  private def readFile(file: File): String = {
+    val source = Source.fromFile(file, "UTF-8")
+    try source.mkString
+    finally source.close()
+  }
+}

--- a/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFieldIdSuite.scala
+++ b/backends-velox/src-delta33/test/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFieldIdSuite.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import org.apache.gluten.config.GlutenConfig
+
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.types.{ArrayType, DataType, IntegerType, MapType, MetadataBuilder, StringType, StructField, StructType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Unit tests for the Delta column-mapping -> Velox Parquet field-id serialization.
+ *
+ * These run without a SparkSession, a metastore, or the `iceberg` build profile, so they execute in
+ * every CI lane. They pin the three non-local invariants the serializer depends on, none of which
+ * are visible from GlutenDeltaParquetFieldId.scala itself:
+ *
+ *   1. `StructField.name` is the PHYSICAL name by the time `prepareWrite` runs
+ *      (TransactionalWrite.createPhysicalAttributes -> DeltaColumnMapping.createPhysicalSchema).
+ *   2. The nested-ids lookup path RESETS at every StructField boundary -- a field nested three
+ *      levels deep is keyed `<ownName>.element`, not by a dotted path from the top-level column.
+ *      This mirrors DeltaColumnMapping's own producer, which recurses with `Seq(getPhysicalName)`.
+ *   3. The emitted tree is the LOGICAL (Spark/Velox) tree, not the Parquet physical tree: an array
+ *      contributes exactly ONE child (the element, with no intervening `list` group) and a map
+ *      exactly TWO (key then value, with no `key_value` group). This is what Velox's
+ *      validateSchemaRecursive requires.
+ *
+ * Invariant 2 in particular fails silently: a wrong path yields -1 for every element/key/value with
+ * no exception anywhere, and Delta's own `isParquetIcebergCompatV2` only checks that ids are
+ * present, not that they are correct.
+ */
+class GlutenDeltaParquetFieldIdSuite extends AnyFunSuite {
+
+  private val icebergCompatV2 =
+    Metadata(configuration = Map(DeltaConfigs.ICEBERG_COMPAT_V2_ENABLED.key -> "true"))
+
+  /** A StructField carrying Delta column-mapping metadata, as it looks at write time. */
+  private def mapped(
+      name: String,
+      dataType: DataType,
+      id: Long,
+      nestedIds: (String, Long)*): StructField = {
+    val builder = new MetadataBuilder()
+      .putLong(DeltaColumnMapping.PARQUET_FIELD_ID_METADATA_KEY, id)
+    if (nestedIds.nonEmpty) {
+      val nested = nestedIds.foldLeft(new MetadataBuilder()) {
+        case (acc, (key, value)) => acc.putLong(key, value)
+      }
+      builder.putMetadata(DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY, nested.build())
+    }
+    StructField(name, dataType, nullable = true, builder.build())
+  }
+
+  private def serialize(fields: StructField*): Option[String] =
+    GlutenDeltaParquetFieldId
+      .withParquetFieldIds(Map.empty, StructType(fields), icebergCompatV2)
+      .get(GlutenConfig.PARQUET_FIELD_IDS)
+
+  test("flat schema emits one id per column, in schema order") {
+    assert(serialize(mapped("a", IntegerType, 1), mapped("b", StringType, 2)).contains("1,2"))
+  }
+
+  test("ids follow column-mapping metadata, not ordinal position") {
+    // Under IcebergCompat, partition columns are appended to the END of the write schema, so the
+    // ids are non-monotonic. Anything derived from ordinal position would silently mis-assign.
+    val actual = serialize(
+      mapped("id", IntegerType, 1),
+      mapped("name", StringType, 3),
+      mapped("part", IntegerType, 2))
+    assert(actual.contains("1,3,2"))
+  }
+
+  test("struct children are emitted as a nested group") {
+    val actual = serialize(
+      mapped(
+        "s",
+        StructType(Seq(mapped("x", IntegerType, 2), mapped("y", IntegerType, 3))),
+        1))
+    assert(actual.contains("1(2,3)"))
+  }
+
+  test("array contributes exactly one child, keyed <field>.element") {
+    val actual = serialize(mapped("arr", ArrayType(IntegerType), 1, "arr.element" -> 101))
+    assert(actual.contains("1(101)"))
+  }
+
+  test("map contributes exactly two children, key then value") {
+    val actual = serialize(
+      mapped("m", MapType(StringType, StringType), 1, "m.key" -> 102, "m.value" -> 103))
+    assert(actual.contains("1(102,103)"))
+  }
+
+  test("array of struct nests the struct fields under the synthetic element node") {
+    val element = StructType(Seq(mapped("sku", StringType, 6), mapped("qty", IntegerType, 7)))
+    val actual = serialize(mapped("items", ArrayType(element), 5, "items.element" -> 105))
+    assert(actual.contains("5(105(6,7))"))
+  }
+
+  test("nested arrays accumulate the path within a single field") {
+    // No StructField boundary is crossed here, so the path DOES accumulate: `a.element.element`.
+    val actual = serialize(
+      mapped(
+        "a",
+        ArrayType(ArrayType(IntegerType)),
+        1,
+        "a.element" -> 107,
+        "a.element.element" -> 108))
+    assert(actual.contains("1(107(108))"))
+  }
+
+  test("nested-id paths reset at every struct boundary") {
+    // Invariant 2. `items` is nested inside `payload`, but its element is keyed by the field's own
+    // name alone -- `items.element`, NOT `payload.items.element`.
+    val payload = StructType(Seq(mapped("items", ArrayType(IntegerType), 2, "items.element" -> 3)))
+    assert(serialize(mapped("payload", payload, 1)).contains("1(2(3))"))
+  }
+
+  test("a dotted path from the top-level column does NOT resolve, and degrades silently") {
+    // The regression guard for invariant 2: keying the same schema the "obvious" way produces -1
+    // for the element with no error. This is what a well-meaning refactor of the path handling
+    // would do, and nothing downstream would catch it.
+    val payload =
+      StructType(Seq(mapped("items", ArrayType(IntegerType), 2, "payload.items.element" -> 3)))
+    assert(serialize(mapped("payload", payload, 1)).contains("1(2(-1))"))
+  }
+
+  test("a field with no column-mapping metadata degrades to the -1 sentinel") {
+    // Current behaviour, pinned deliberately. -1 is reachable for Delta's internal columns
+    // (row-tracking `_row-id-col-*` / `_row-commit-version-col-*`), which carry no field id.
+    // Velox drops negative ids, so those columns are written without a field_id -- byte-identical
+    // to what vanilla Spark emits for them. Making this explicit rather than accidental is
+    // tracked separately; this test exists so that change is a deliberate edit, not a surprise.
+    assert(serialize(StructField("plain", IntegerType)).contains("-1"))
+  }
+
+  test("no field ids are emitted when IcebergCompatV2 is disabled") {
+    val options = GlutenDeltaParquetFieldId.withParquetFieldIds(
+      Map.empty,
+      StructType(Seq(mapped("a", IntegerType, 1))),
+      Metadata())
+    assert(!options.contains(GlutenConfig.PARQUET_FIELD_IDS))
+  }
+
+  test("unrelated write options are preserved") {
+    val options = GlutenDeltaParquetFieldId.withParquetFieldIds(
+      Map("compression" -> "snappy"),
+      StructType(Seq(mapped("a", IntegerType, 1))),
+      icebergCompatV2)
+    assert(options.get("compression").contains("snappy"))
+    assert(options.get(GlutenConfig.PARQUET_FIELD_IDS).contains("1"))
+  }
+
+  test("an empty schema emits no option rather than an empty value") {
+    val options =
+      GlutenDeltaParquetFieldId.withParquetFieldIds(Map.empty, StructType(Nil), icebergCompatV2)
+    assert(!options.contains(GlutenConfig.PARQUET_FIELD_IDS))
+  }
+}

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFieldId.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFieldId.scala
@@ -1,0 +1,1 @@
+../../../../../../../../src-delta33/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFieldId.scala

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/GlutenDeltaParquetFileFormat.scala
@@ -275,7 +275,8 @@ case class GlutenDeltaParquetFileFormat(
                              job: Job,
                              options: Map[String, String],
                              dataSchema: StructType): OutputWriterFactory = {
-    val factory = super.prepareWrite(sparkSession, job, options, dataSchema)
+    val writeOptions = GlutenDeltaParquetFieldId.withParquetFieldIds(options, dataSchema, metadata)
+    val factory = super.prepareWrite(sparkSession, job, writeOptions, dataSchema)
     val conf = ContextUtil.getConfiguration(job)
     // Always write timestamp as TIMESTAMP_MICROS for Iceberg compat based on Iceberg spec
     if (IcebergCompatV1.isEnabled(metadata) || IcebergCompatV2.isEnabled(metadata)) {

--- a/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
+++ b/backends-velox/src-delta40/main/scala/org/apache/spark/sql/delta/files/GlutenDeltaFileFormatWriter.scala
@@ -135,6 +135,8 @@ object GlutenDeltaFileFormatWriter extends Logging {
       } else dataColumns
 
     // Note: prepareWrite has side effect. It sets "job".
+    // Parquet field ids for IcebergCompatV2 are injected by
+    // GlutenDeltaParquetFileFormat.prepareWrite, which receives the same schema passed below.
     val outputWriterFactory =
       fileFormat.prepareWrite(
         sparkSession,

--- a/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetWriterInjects.scala
+++ b/backends-velox/src/main/scala/org/apache/spark/sql/execution/datasources/velox/VeloxParquetWriterInjects.scala
@@ -56,7 +56,8 @@ class VeloxParquetWriterInjects extends VeloxFormatWriterInjects {
       GlutenConfig.PARQUET_DATAPAGE_SIZE,
       GlutenConfig.PARQUET_ENABLE_DICTIONARY,
       GlutenConfig.PARQUET_ENABLE_PAGE_INDEX,
-      GlutenConfig.PARQUET_WRITER_VERSION
+      GlutenConfig.PARQUET_WRITER_VERSION,
+      GlutenConfig.PARQUET_FIELD_IDS
     ).foreach(key => options.get(key).foreach(sparkOptions.put(key, _)))
     sparkOptions.asJava
   }

--- a/cpp/core/config/GlutenConfig.h
+++ b/cpp/core/config/GlutenConfig.h
@@ -74,6 +74,8 @@ const std::string kParquetEnablePageIndex = "parquet.enable.page.index";
 
 const std::string kParquetWriterVersion = "parquet.writer.version";
 
+const std::string kParquetFieldIds = "parquet.field.ids";
+
 const std::string kParquetCompressionCodec = "spark.sql.parquet.compression.codec";
 
 const std::string kLegacyParquetReturnNullStructIfAllFieldsMissing =

--- a/cpp/velox/utils/VeloxWriterUtils.cc
+++ b/cpp/velox/utils/VeloxWriterUtils.cc
@@ -19,6 +19,9 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <cctype>
+#include <string_view>
+
 #include "config/GlutenConfig.h"
 #include "utils/ConfigExtractor.h"
 #include "utils/Exception.h"
@@ -36,6 +39,110 @@ using namespace facebook::velox::common;
 namespace {
 const int32_t kGzipWindowBits4k = 12;
 const int32_t kZSTDDefaultCompressionLevel = 3;
+
+class ParquetFieldIdParser {
+ public:
+  explicit ParquetFieldIdParser(std::string_view value) : value_(value) {}
+
+  std::vector<ParquetFieldId> parse() {
+    skipWhitespace();
+    if (atEnd()) {
+      return {};
+    }
+    auto fieldIds = parseList('\0');
+    skipWhitespace();
+    if (!atEnd()) {
+      throw GlutenException("Invalid parquet field id tree: unexpected trailing input.");
+    }
+    return fieldIds;
+  }
+
+ private:
+  std::vector<ParquetFieldId> parseList(char terminator) {
+    std::vector<ParquetFieldId> fieldIds;
+    while (true) {
+      skipWhitespace();
+      if (atEnd()) {
+        if (terminator != '\0') {
+          throw GlutenException("Invalid parquet field id tree: missing closing delimiter.");
+        }
+        return fieldIds;
+      }
+      if (terminator != '\0' && value_[position_] == terminator) {
+        ++position_;
+        return fieldIds;
+      }
+
+      fieldIds.push_back(parseNode());
+      skipWhitespace();
+      if (atEnd()) {
+        if (terminator != '\0') {
+          throw GlutenException("Invalid parquet field id tree: missing closing delimiter.");
+        }
+        return fieldIds;
+      }
+      if (value_[position_] == ',') {
+        ++position_;
+      } else if (terminator != '\0' && value_[position_] == terminator) {
+        ++position_;
+        return fieldIds;
+      } else {
+        throw GlutenException("Invalid parquet field id tree: expected ',' or closing delimiter.");
+      }
+    }
+  }
+
+  ParquetFieldId parseNode() {
+    ParquetFieldId fieldId;
+    fieldId.fieldId = parseInteger();
+    skipWhitespace();
+    if (!atEnd() && value_[position_] == '(') {
+      ++position_;
+      fieldId.children = parseList(')');
+    }
+    return fieldId;
+  }
+
+  int32_t parseInteger() {
+    skipWhitespace();
+    if (atEnd()) {
+      throw GlutenException("Invalid parquet field id tree: expected integer.");
+    }
+
+    int sign = 1;
+    if (value_[position_] == '-') {
+      sign = -1;
+      ++position_;
+    }
+    if (atEnd() || !std::isdigit(static_cast<unsigned char>(value_[position_]))) {
+      throw GlutenException("Invalid parquet field id tree: expected integer.");
+    }
+
+    int64_t value = 0;
+    while (!atEnd() && std::isdigit(static_cast<unsigned char>(value_[position_]))) {
+      value = value * 10 + value_[position_] - '0';
+      ++position_;
+    }
+    return static_cast<int32_t>(sign * value);
+  }
+
+  void skipWhitespace() {
+    while (!atEnd() && std::isspace(static_cast<unsigned char>(value_[position_]))) {
+      ++position_;
+    }
+  }
+
+  bool atEnd() const {
+    return position_ >= value_.size();
+  }
+
+  std::string_view value_;
+  size_t position_{0};
+};
+
+std::vector<ParquetFieldId> parseParquetFieldIds(std::string_view value) {
+  return ParquetFieldIdParser(value).parse();
+}
 } // namespace
 
 std::shared_ptr<facebook::velox::dwio::common::WriterOptions> makeParquetWriteOption(
@@ -137,6 +244,9 @@ std::shared_ptr<facebook::velox::dwio::common::WriterOptions> makeParquetWriteOp
     enableWritePageIndex = boost::iequals(it->second, "true");
   }
   parquetOptions->enableWritePageIndex = enableWritePageIndex;
+  if (auto it = sparkConfs.find(kParquetFieldIds); it != sparkConfs.end()) {
+    parquetOptions->parquetFieldIds = parseParquetFieldIds(it->second);
+  }
   writeOption->formatSpecificOptions = std::move(parquetOptions);
   return writeOption;
 }

--- a/docs/get-started/VeloxDelta.md
+++ b/docs/get-started/VeloxDelta.md
@@ -46,9 +46,14 @@ Native change data feed scan offload is controlled by:
 | Deletion vectors | 7 | 3 | 3 | Reader and writer | Partial |
 | TimestampNTZ | 7 | 3 | 1 | Reader and writer | No |
 | Liquid clustering | 7 | 3 | 1 | Reader and writer | Yes |
-| Iceberg readers (UniForm) | 7 | 2 | N/A | Writer | Not tested |
+| Iceberg readers (UniForm) | 7 | 2 | N/A | Writer | Partial |
 | Type widening | 7 | 3 | N/A | Reader and writer | Partial |
 | Variant | 7 | 3 | 3 | Reader and writer | Not tested |
 | Variant shredding | 7 | 3 | 3 | Reader and writer | Not tested |
 | Collations | 7 | 3 | N/A | Reader and writer | Not tested |
 | Protected checkpoints | 7 | 1 | N/A | Writer | Not tested |
+
+Notes:
+
+- UniForm Iceberg is covered for Velox native Delta write with IcebergCompatV2, async Iceberg metadata generation, and Iceberg readback through a Hive-backed Iceberg catalog.
+- Native Velox Iceberg scans still fall back for UniForm column-mapping/name-mapping reads, so this is not full native Iceberg reader support yet.

--- a/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
+++ b/gluten-substrait/src/main/scala/org/apache/gluten/config/GlutenConfig.scala
@@ -420,6 +420,7 @@ object GlutenConfig extends ConfigRegistry {
   val PARQUET_ENABLE_DICTIONARY: String = "parquet.enable.dictionary"
   val PARQUET_ENABLE_PAGE_INDEX: String = "parquet.enable.page.index"
   val PARQUET_WRITER_VERSION: String = "parquet.writer.version"
+  val PARQUET_FIELD_IDS: String = "parquet.field.ids"
   // Hadoop config
   val HADOOP_PREFIX = "spark.hadoop."
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

A Delta table with IcebergCompatV2 is supposed to produce parquet files whose footers carry Iceberg-compatible field ids. Vanilla Delta arranges that in `prepareWrite` by installing `DeltaParquetWriteSupport`, but that only configures parquet-mr — when the write is offloaded, Velox writes the file directly and never consults it. The ids can't leak in through Arrow either, since `SparkArrowUtil.toArrowField` drops `StructField` metadata.

So a UniForm table written natively ends up with no field ids at all, with no error and no fallback, while the `IcebergConverter` happily publishes Iceberg metadata over those files.

This reads the ids Delta already recorded in the schema — `parquet.field.id` for columns, `parquet.field.nested.ids` for the synthetic list-element / map-key / map-value nodes — and passes them through the write options into `ParquetWriterOptions`. Gated on `IcebergCompatV2`, so nothing changes for other tables. Mirrored into `src-delta40`, where the helper is identical and symlinked.

Native Delta write is still experimental and off by default, so this closes a correctness hole ahead of that flag rather than fixing shipped behaviour.

### How was this patch tested?

`GlutenDeltaParquetFieldIdSuite` covers the encoding. `DeltaUniFormIcebergSuite` writes a partitioned table with nested struct/array/map columns, checks the footer with Delta's own `isParquetIcebergCompatV2`, and reads the table back through Iceberg.

### Notes

Draft, and there's a known gap I'd rather flag than hide: the end-to-end suite drives the write with `INSERT INTO`, which `OffloadDeltaCommand` doesn't offload, so it currently exercises the vanilla path and would pass with this change reverted. I'm reworking it onto an offloaded write with an explicit offload assertion before this is ready for review.

Two open questions I'd welcome opinions on:

- The gate could reasonably be "the schema carries `parquet.field.id`" rather than `IcebergCompatV2`. Delta enables field-id write for every session and writes the key for both `name` and `id` mapping, so the native writer is dropping ids for ordinary column-mapped tables too — the wider gate would cover IcebergCompatV1 and id mapping in the same guard.
- Missing metadata currently yields `-1`. Delta's own `getNestedFieldId` throws instead, and Velox omits the annotation entirely for negative ids, so failing fast is probably the better behaviour.

This is the write-side counterpart to #12884, which plumbs column mapping mode through scan splits.