### PR TITLE
[VL] Add Velox offload for Lance scans via Arrow C stream

### DIFF
--- a/backends-velox/pom.xml
+++ b/backends-velox/pom.xml
@@ -557,6 +557,28 @@
       </dependencies>
     </profile>
     <profile>
+      <id>lance</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <!--
+          First lance-spark release that carries the Arrow C stream forwarding
+          (LanceArrowStreamScanner, lance-spark#778). v0.8.0-beta.1 predates it;
+          bump this to the published version once it ships.
+        -->
+        <lance.version>0.8.0-beta.2</lance.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.lance</groupId>
+          <artifactId>lance-spark-base_${scala.binary.version}</artifactId>
+          <version>${lance.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>iceberg-test</id>
       <activation>
         <activeByDefault>false</activeByDefault>

--- a/backends-velox/src-lance/main/scala/org/apache/gluten/component/VeloxLanceComponent.scala
+++ b/backends-velox/src-lance/main/scala/org/apache/gluten/component/VeloxLanceComponent.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.component
+
+import org.apache.gluten.backendsapi.velox.VeloxBackend
+import org.apache.gluten.extension.OffloadLanceScan
+import org.apache.gluten.extension.injector.Injector
+
+import org.apache.spark.util.SparkReflectionUtil
+
+/**
+ * Registers the Lance-over-Velox scan offload. Inert unless lance-spark is on the runtime classpath,
+ * so the default Velox bundle carries this component without requiring Lance for other workloads.
+ */
+class VeloxLanceComponent extends Component {
+  override def name(): String = "velox-lance"
+
+  override def dependencies(): Seq[Class[_ <: Component]] = classOf[VeloxBackend] :: Nil
+
+  override def isRuntimeCompatible: Boolean =
+    SparkReflectionUtil.isClassPresent("org.lance.spark.read.LanceScan")
+
+  override def injectRules(injector: Injector): Unit = {
+    OffloadLanceScan.inject(injector)
+  }
+}

--- a/backends-velox/src-lance/main/scala/org/apache/gluten/execution/LanceScanTransformer.scala
+++ b/backends-velox/src-lance/main/scala/org/apache/gluten/execution/LanceScanTransformer.scala
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.gluten.backendsapi.arrow.ArrowBatchTypes.ArrowJavaBatchType
+import org.apache.gluten.extension.columnar.transition.Convention
+import org.apache.gluten.iterator.Iterators
+import org.apache.gluten.memory.arrow.alloc.ArrowBufferAllocators
+import org.apache.gluten.vectorized.ArrowWritableColumnVector
+
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.physical.{Partitioning, UnknownPartitioning}
+import org.apache.spark.sql.connector.read.{InputPartition, Scan}
+import org.apache.spark.sql.execution.LeafExecNode
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+
+import org.apache.arrow.c.{ArrowArrayStream, Data}
+import org.apache.arrow.vector.FieldVector
+
+import org.lance.spark.internal.LanceArrowStreamScanner
+import org.lance.spark.read.{LanceInputPartition, LanceScan}
+
+import scala.collection.JavaConverters._
+
+/**
+ * A Gluten leaf that reads a Lance table through the Arrow C Data Interface and produces
+ * [[ArrowJavaBatchType]] columnar batches, which Gluten then offloads to Velox via its automatic
+ * ArrowJava -> ArrowNative transition.
+ *
+ * This replaces a vanilla [[BatchScanExec]] over a [[LanceScan]]. Each Spark partition maps to one
+ * Lance fragment. For every fragment the leaf asks lance-spark to export the planned scan as an
+ * [[ArrowArrayStream]] ([[LanceArrowStreamScanner.export]]) and hands back only the C-struct
+ * address. The address is re-wrapped with Gluten's own Arrow build and imported here, so lance-spark
+ * and Gluten never share Arrow Java objects across their classloaders -- only the version-stable C
+ * ABI struct crosses the boundary. This is the consumer side of lance-core's
+ * {@code LanceScanner#exportArrowStream(long)} (lance#7259).
+ *
+ * Each imported batch is transferred out of the reader's root into independent Arrow buffers so the
+ * emitted [[ColumnarBatch]] owns its data: Gluten's offload transition C-exports then closes each
+ * batch, and the recycle callback closes it again, exactly as for [[ColumnarRangeExec]]. The reader
+ * and the lance-spark handle are closed on task completion, which releases the native scan and the
+ * caller-owned stream struct.
+ */
+case class LanceScanTransformer(@transient batchScan: BatchScanExec)
+  extends LeafExecNode
+  with ValidatablePlan {
+
+  @transient private lazy val lanceScan: LanceScan =
+    batchScan.scan.asInstanceOf[LanceScan]
+
+  @transient private lazy val inputPartitions: Array[InputPartition] =
+    lanceScan.toBatch.planInputPartitions()
+
+  override def output: Seq[Attribute] = batchScan.output
+
+  override def outputPartitioning: Partitioning = UnknownPartitioning(inputPartitions.length)
+
+  override def batchType(): Convention.BatchType = ArrowJavaBatchType
+
+  override def rowType(): Convention.RowType = Convention.RowType.None
+
+  override protected def doExecute(): RDD[InternalRow] =
+    throw new UnsupportedOperationException(s"$nodeName does not support row-based execution.")
+
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] =
+    new LanceColumnarRDD(sparkContext, inputPartitions)
+}
+
+object LanceScanTransformer {
+
+  /** Whether this DSv2 scan is a Lance scan that can be offloaded to Velox through Arrow C. */
+  def supportsBatchScan(scan: Scan): Boolean = scan.isInstanceOf[LanceScan]
+
+  /**
+   * Whether the planned Lance scan can actually be exported through the Arrow C stream.
+   *
+   * A pushed aggregation (e.g. {@code COUNT(*)}) or a full-text query makes the native fragment
+   * scan's output diverge from the partition's declared Spark schema: for an aggregation the
+   * partition's output is the aggregate result while the fragment scan returns data rows, and a
+   * full-text query auto-projects a {@code _score} column. [[LanceArrowStreamScanner.export]]
+   * rejects both at runtime (checkNoPushedAggregation / checkNativeSchemaMatchesPartition), but by
+   * then the node is already offloaded to Velox, so the throw fails the query instead of falling
+   * back. Detecting them here keeps such scans on vanilla Spark (e.g. the fast COUNT(*) metadata
+   * reader) rather than offloading a scan that can only crash.
+   */
+  def isExportable(batchScan: BatchScanExec): Boolean =
+    batchScan.inputPartitions.forall {
+      case p: LanceInputPartition =>
+        !p.getPushedAggregation.isPresent && p.getReadOptions.getFullTextQuery == null
+      case _ => false
+    }
+}
+
+/** One RDD partition per planned Lance [[InputPartition]] (one Lance fragment each). */
+private class LancePartition(override val index: Int, val inputPartition: LanceInputPartition)
+  extends Partition
+
+/**
+ * Executes the planned Lance partitions, importing each fragment's exported Arrow C stream with
+ * Gluten's Arrow build and yielding offloadable [[ArrowWritableColumnVector]] batches.
+ */
+private class LanceColumnarRDD(
+    @transient private val sc: SparkContext,
+    private val inputPartitions: Array[InputPartition])
+  extends RDD[ColumnarBatch](sc, Nil) {
+
+  override protected def getPartitions: Array[Partition] =
+    inputPartitions.zipWithIndex.map {
+      case (p, i) => new LancePartition(i, p.asInstanceOf[LanceInputPartition])
+    }
+
+  override def compute(split: Partition, context: TaskContext): Iterator[ColumnarBatch] = {
+    val lancePartition = split.asInstanceOf[LancePartition].inputPartition
+    val allocator = ArrowBufferAllocators.contextInstance()
+
+    val batches: Iterator[ColumnarBatch] =
+      lancePartition.getLanceSplit.getFragments.asScala.iterator.flatMap {
+        fragId =>
+          // Plan + export the fragment scan on the lance-spark side; only the C-struct address
+          // crosses over. wrap() views that struct with Gluten's Arrow, and importArrayStream()
+          // moves it into a reader that owns and drains the native scan.
+          val handle = LanceArrowStreamScanner.export(fragId.intValue(), lancePartition)
+          val stream = ArrowArrayStream.wrap(handle.streamAddress())
+          val reader = Data.importArrayStream(allocator, stream)
+          context.addTaskCompletionListener[Unit] {
+            _ =>
+              try {
+                // Drains + runs the C release callback, tearing down the native scan.
+                reader.close()
+              } finally {
+                // Frees the caller-owned stream struct and closes the scanner + dataset.
+                handle.close()
+              }
+          }
+
+          new Iterator[ColumnarBatch] {
+            private var advanced = false
+            private var hasMore = false
+
+            private def advance(): Unit =
+              if (!advanced) {
+                hasMore = reader.loadNextBatch()
+                advanced = true
+              }
+
+            override def hasNext: Boolean = {
+              advance()
+              hasMore
+            }
+
+            override def next(): ColumnarBatch = {
+              advance()
+              if (!hasMore) {
+                throw new NoSuchElementException()
+              }
+              advanced = false
+              val root = reader.getVectorSchemaRoot
+              val rowCount = root.getRowCount
+              // Transfer (zero-copy move) each column out of the reader's reused root so the emitted
+              // batch owns its buffers and is safe for the offload transition to close.
+              val transferred = new java.util.ArrayList[FieldVector](root.getFieldVectors.size())
+              root.getFieldVectors.asScala.foreach {
+                fv =>
+                  val pair = fv.getTransferPair(allocator)
+                  pair.transfer()
+                  transferred.add(pair.getTo.asInstanceOf[FieldVector])
+              }
+              val vectors = ArrowWritableColumnVector.loadColumns(rowCount, transferred)
+              new ColumnarBatch(vectors.asInstanceOf[Array[ColumnVector]], rowCount)
+            }
+          }
+      }
+
+    Iterators
+      .wrap(batches)
+      .recyclePayload((batch: ColumnarBatch) => batch.close())
+      .create()
+  }
+}

--- a/backends-velox/src-lance/main/scala/org/apache/gluten/extension/OffloadLanceScan.scala
+++ b/backends-velox/src-lance/main/scala/org/apache/gluten/extension/OffloadLanceScan.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.extension
+
+import org.apache.gluten.config.GlutenConfig
+import org.apache.gluten.execution.LanceScanTransformer
+import org.apache.gluten.extension.columnar.heuristic.HeuristicTransform
+import org.apache.gluten.extension.columnar.offload.OffloadSingleNode
+import org.apache.gluten.extension.columnar.validator.Validators
+import org.apache.gluten.extension.injector.Injector
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+/** Replaces a vanilla Lance [[BatchScanExec]] with a [[LanceScanTransformer]] offloaded to Velox. */
+case class OffloadLanceScan() extends OffloadSingleNode {
+  override def offload(plan: SparkPlan): SparkPlan = plan match {
+    case scan: BatchScanExec
+        if LanceScanTransformer.supportsBatchScan(scan.scan)
+          && LanceScanTransformer.isExportable(scan) =>
+      LanceScanTransformer(scan)
+    case other => other
+  }
+}
+
+object OffloadLanceScan {
+  def inject(injector: Injector): Unit = {
+    // Inject as a legacy heuristic transform, mirroring OffloadIcebergScan.
+    injector.gluten.legacy.injectTransform {
+      c =>
+        val offload = Seq(OffloadLanceScan())
+        HeuristicTransform.Simple(
+          Validators.newValidator(new GlutenConfig(c.sqlConf), offload),
+          offload
+        )
+    }
+  }
+}

--- a/backends-velox/src-lance/test/scala/org/apache/gluten/execution/VeloxLanceSuite.scala
+++ b/backends-velox/src-lance/test/scala/org/apache/gluten/execution/VeloxLanceSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gluten.execution
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+
+/**
+ * Exercises the read-only Lance offload: a columnar Lance scan is handed to Velox through the Arrow
+ * C stream ([[LanceScanTransformer]]), while scans that the export path cannot serve (pushed
+ * aggregation, full-text query) fall back to vanilla Spark.
+ *
+ * Requires the lance-spark runtime (and its native library) on the classpath, which is only
+ * published for linux-x86-64. On other platforms these tests do not run; see
+ * docs/get-started/VeloxLance.md for the supported local/CI environment.
+ */
+class VeloxLanceSuite extends VeloxWholeStageTransformerSuite {
+  override protected val resourcePath: String = "/tpch-data-parquet"
+  override protected val fileFormat: String = "parquet"
+
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.shuffle.manager", "org.apache.spark.shuffle.sort.ColumnarShuffleManager")
+      .set("spark.sql.files.maxPartitionBytes", "1g")
+      .set("spark.sql.shuffle.partitions", "1")
+      .set("spark.memory.offHeap.size", "2g")
+      .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      // Path-based reads use the DataSource directly; the catalog is registered for parity with
+      // lance-spark's own tests and any namespace-qualified access.
+      .set("spark.sql.catalog.lance", "org.lance.spark.LanceNamespaceSparkCatalog")
+  }
+
+  /** Writes a small Lance dataset and registers it as a temp view. */
+  private def withLanceView(view: String, rows: Int)(f: => Unit): Unit = {
+    withTempPath {
+      path =>
+        val uri = s"${path.getCanonicalPath}/$view.lance"
+        spark
+          .range(rows)
+          .selectExpr(
+            "cast(id as int) as id",
+            "cast(id * 2 as int) as v",
+            "concat('n', cast(id as string)) as name")
+          .write
+          .format("lance")
+          .option("path", uri)
+          .save()
+
+        spark.read.format("lance").option("path", uri).load().createOrReplaceTempView(view)
+        try f
+        finally spark.catalog.dropTempView(view)
+    }
+  }
+
+  test("lance scan offloads to LanceScanTransformer") {
+    withLanceView("lance_basic", 100) {
+      runQueryAndCompare("select id, v, name from lance_basic") {
+        checkGlutenPlan[LanceScanTransformer]
+      }
+    }
+  }
+
+  test("lance scan offloads with projection and pushed filter") {
+    withLanceView("lance_filtered", 100) {
+      runQueryAndCompare("select id, v from lance_filtered where id < 50") {
+        df =>
+          checkGlutenPlan[LanceScanTransformer](df)
+          checkAnswer(df, (0 until 50).map(i => Row(i, i * 2)))
+      }
+    }
+  }
+
+  test("lance scan falls back when an aggregation is pushed down") {
+    withLanceView("lance_agg", 100) {
+      // A filtered COUNT(*) is pushed into the Lance scan; the Arrow C stream export cannot serve a
+      // pushed aggregation, so the offload guard must leave it on a vanilla BatchScanExec.
+      val df: DataFrame = spark.sql("select count(*) from lance_agg where id < 50")
+      checkSparkPlan[BatchScanExec](df)
+      assert(
+        !getExecutedPlan(df).exists(_.isInstanceOf[LanceScanTransformer]),
+        "Lance scan with a pushed aggregation must not be offloaded")
+      checkAnswer(df, Seq(Row(50L)))
+    }
+  }
+}

--- a/docs/get-started/VeloxLance.md
+++ b/docs/get-started/VeloxLance.md
@@ -1,0 +1,76 @@
+---
+layout: page
+title: Lance Support in Velox Backend
+nav_order: 9
+parent: Getting-Started
+---
+
+# Lance Support in Velox Backend
+
+Gluten can offload reads of [Lance](https://lancedb.github.io/lance/) datasets (via
+[lance-spark](https://github.com/lance-format/lance-spark)) to the Velox backend. The scan is
+handed to Velox through the Arrow C Data Interface: lance-spark exports each fragment as an Arrow C
+stream and Gluten imports it, so only the Arrow C-struct address crosses the boundary and Gluten's
+Arrow version stays decoupled from lance-spark's.
+
+Only reads are supported. Writes fall back to vanilla Spark.
+
+## Requirements
+
+- **lance-spark** on the classpath, at a version that includes the Arrow C stream forwarding
+  (`LanceArrowStreamScanner`). See the `lance` Maven profile in `backends-velox/pom.xml` for the
+  pinned version.
+- **Platform:** lance-spark publishes its native library for `linux-x86-64` only, so the offload
+  runs on `linux-x86-64` hosts. On other platforms the Lance scan is unavailable and queries fall
+  back to vanilla Spark.
+- **Spark:** tested with Spark 3.5. lance-spark publishes Spark 3.4 / 3.5 artifacts; there is no
+  Lance runtime for Spark 4.0 yet.
+
+## Building
+
+Enable the `lance` profile alongside the Velox backend:
+
+```
+mvn clean package -Pbackends-velox -Pspark-3.5 -Plance -DskipTests
+```
+
+The read-only offload is entirely Velox-specific, so it lives under `backends-velox/src-lance`
+(mirroring `backends-velox/src-iceberg`) rather than in a top-level module. Add `-Plance-test` to
+also compile and run the Lance test suite.
+
+## Reading
+
+Offload / Fallback.
+
+A plain columnar Lance scan is offloaded:
+
+```scala
+spark.read.format("lance").option("path", "/data/table.lance").load().createOrReplaceTempView("t")
+spark.sql("SELECT id, v FROM t WHERE id < 100")
+```
+
+Projection and filters are pushed into the Lance scan by lance-spark before export, so they stay
+offloaded. A scan is left on vanilla Spark (fallback, not an error) when the export path cannot
+serve it:
+
+| Query shape                    | Behavior |
+|--------------------------------|----------|
+| Projection / filter            | Offload  |
+| Pushed-down aggregation (e.g. `COUNT(*)`) | Fallback |
+| Full-text query (`_score`)     | Fallback |
+
+The offload decision is made at plan time (`LanceScanTransformer.isExportable`), so a
+non-offloadable scan is detected before execution rather than failing inside Velox.
+
+## Configuration
+
+Catalog and read options are transparent to Gluten; configure lance-spark as usual. The offload
+engages automatically whenever lance-spark is present on the classpath.
+
+## Limitations
+
+- Read-only; writes and DDL fall back to vanilla Spark.
+- No native Velox scan pushdown for Lance — filters and projection are applied by lance-spark
+  (in the Lance reader) before the Arrow stream is exported, not inside Velox.
+- Rare schemas that require JVM post-processing (for example `_rowid` / `_rowaddr` / blob columns)
+  are not offloaded.

--- a/pom.xml
+++ b/pom.xml
@@ -1867,6 +1867,48 @@
       </build>
     </profile>
     <profile>
+      <id>lance</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-lance-sources</id>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <sources>
+                    <source>${project.basedir}/src-lance/main/scala</source>
+                  </sources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-lance-resources</id>
+                <goals>
+                  <goal>add-resource</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src-lance/main/resources</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>iceberg-test</id>
       <activation>
         <activeByDefault>false</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -1909,6 +1909,48 @@
       </build>
     </profile>
     <profile>
+      <id>lance-test</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-lance-test-sources</id>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <phase>generate-test-sources</phase>
+                <configuration>
+                  <sources>
+                    <source>${project.basedir}/src-lance/test/scala</source>
+                  </sources>
+                </configuration>
+              </execution>
+              <execution>
+                <id>add-lance-test-resources</id>
+                <goals>
+                  <goal>add-test-resource</goal>
+                </goals>
+                <phase>generate-test-resources</phase>
+                <configuration>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/src-lance/test/resources</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>iceberg-test</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Offloads read-only Lance `BatchScanExec` to the Velox backend through the Arrow C Data Interface. This is the Gluten consumer side of the three-step Lance integration; the two upstream pieces it builds on are already merged:

- `LanceScanner#exportArrowStream(long)` in lance-core (Arrow C stream export)
- `LanceArrowStreamScanner` forwarding in lance-spark (lance-spark#778)

### How it works

- A new `OffloadLanceScan` rule matches a Lance `BatchScanExec` and rewrites it to `LanceScanTransformer`, which produces an `ArrowJavaBatchType` columnar RDD.
- Per fragment, `LanceArrowStreamScanner.export(...)` hands back an Arrow C stream; Gluten wraps the stream address with `ArrowArrayStream.wrap(...)` / `Data.importArrayStream(...)` and loads the batches into `ArrowWritableColumnVector`. Only the Arrow C-struct address crosses the classloader boundary, so Gluten's Arrow version stays decoupled from lance-spark's.
- Offload is gated: it engages only for a plain columnar Lance scan (no pushed aggregation, no full-text query). Anything else falls back to vanilla Spark.
- A `velox-lance` `Component` registers the rule and activates only when lance-spark is on the classpath (`org.lance.spark.read.LanceScan` present).

### Relationship to the Iceberg scan transformer

`LanceScanTransformer` is intentionally different in shape from `IcebergScanTransformer`. Iceberg extends `BatchScanExecTransformerBase` and is a native Velox scan: it emits Substrait, pushes filters into Velox, and reports scan-level SQL metrics. Lance instead extends `LeafExecNode with ValidatablePlan` and bridges an already-produced Arrow stream into Velox: filters and projection are pushed into the Lance reader by lance-spark **before** export, not into Velox, and there is an Arrow-Java → Velox conversion at import. Consequences of this boundary:

- No native Velox scan pushdown for Lance; the Lance reader does the pruning.
- No scan-level SQL metrics on the Lance node.
- Schemas that require JVM post-processing (`_rowid` / `_rowaddr` / blob columns) are not offloaded.

These are follow-up opportunities, not blockers for the read-only offload.

### Where the code lives

The read path is entirely Velox-specific (`ArrowWritableColumnVector`, `ArrowBufferAllocators`, `ValidatablePlan`), so it is placed under `backends-velox/src-lance` behind a new `lance` Maven profile — mirroring the `src-iceberg` Velox-integration layout rather than adding a top-level module. Build with `-Pbackends-velox -Pspark-3.5 -Plance`. `docs/get-started/VeloxLance.md` documents the scope, build, and requirements.

**Open question for reviewers:** a top-level `gluten-lance` module (like `gluten-iceberg`) makes sense once there is engine-agnostic code to host — e.g. a write path. The read-only offload has none today, so this PR keeps it Velox-local. Happy to restructure if you'd prefer the module up front.

## How was this patch tested?

`VeloxLanceSuite` (under the `lance-test` profile, run with `-Plance -Plance-test`) asserts:

1. a columnar Lance scan offloads to `LanceScanTransformer`,
2. projection + a pushed filter stay offloaded and return correct results,
3. a pushed-down aggregation falls back to a vanilla `BatchScanExec`.

The offload / fallback behavior these assertions encode was also exercised end-to-end against a Lance table on an amd64 runner. lance-spark publishes its native library for `linux-x86-64` only, so the suite runs in that environment.

> **Draft status / CI:** this depends on a published lance-spark release that carries lance-spark#778. The latest release (`0.8.0-beta.1`) predates it, so the `lance` profile currently points at a not-yet-published `0.8.0-beta.2` placeholder; the version property will be bumped to the real release, at which point the profile resolves and the suite runs. The shared CI test jobs are intentionally **not** wired to `-Plance`, so they are unaffected by the pending dependency. Kept as a draft until the release lands.

Relates to #12263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
