### PR TITLE
[GLUTEN-12959][VL] Keep the final stage of a grouping-only aggregate non-flushable

### DIFF
--- a/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
@@ -71,11 +71,31 @@ case class FlushableHashAggregateRule(session: SparkSession) extends Rule[SparkP
   }
 
   /**
+   * Returns true if the aggregate applies no aggregate functions and is the final (or complete)
+   * stage, e.g. the last step of `SELECT DISTINCT`, or of a `GROUP BY` without aggregate functions.
+   *
+   * Such an aggregate must fully aggregate. Flushing lets Velox abandon aggregation and emit
+   * duplicate grouping keys, and since no further aggregate follows, the duplicates reach the
+   * consumer. When the consumer is a join, they turn into extra join output rows.
+   *
+   * The mode check used by the other guards cannot detect this case: `aggregateExpressions` is
+   * empty here, so `forall(_.mode == Partial | PartialMerge)` is vacuously true and says nothing
+   * about which stage this is. Spark distinguishes the stages with
+   * `requiredChildDistributionExpressions`, which is `None` for a partial aggregate and
+   * `Some(groupingAttributes)` for the final one -- see `AggUtils.planAggregateWithoutDistinct`.
+   * Spark makes the same check in its own guard for the equivalent runtime bypass, see
+   * `HashAggregateExec.adaptivePartialAggEnabled`.
+   */
+  private def isGroupingOnlyFinalAgg(agg: HashAggregateExecTransformer): Boolean = {
+    agg.aggregateExpressions.isEmpty && agg.requiredChildDistributionExpressions.isDefined
+  }
+
+  /**
    * Walks the plan downward, applying func to each RegularHashAggregateExecTransformer or
    * SortHashAggregateExecTransformer that is eligible for flushable conversion. An aggregate is
-   * eligible when all expressions are Partial/PartialMerge, it is not the protected PartialMerge
-   * aggregate directly below a distinct-partial aggregate, and no aggregate function disallows
-   * flushing.
+   * eligible when all expressions are Partial/PartialMerge, it is not the final stage of a
+   * grouping-only aggregate, it is not the protected PartialMerge aggregate directly below a
+   * distinct-partial aggregate, and no aggregate function disallows flushing.
    */
   private def replaceEligibleAggregates(
       plan: SparkPlan,
@@ -93,6 +113,9 @@ case class FlushableHashAggregateRule(session: SparkSession) extends Rule[SparkP
     }
 
     def transformDown: SparkPlan => SparkPlan = {
+      case agg: RegularHashAggregateExecTransformer if isGroupingOnlyFinalAgg(agg) =>
+        // Final stage of a grouping-only aggregate. It must fully aggregate. Skip.
+        agg
       case agg: RegularHashAggregateExecTransformer
           if !agg.aggregateExpressions.forall(p => p.mode == Partial || p.mode == PartialMerge) =>
         // Not an intermediate agg. Skip.
@@ -110,6 +133,9 @@ case class FlushableHashAggregateRule(session: SparkSession) extends Rule[SparkP
       case agg: RegularHashAggregateExecTransformer =>
         // All guards passed; replace with the flushable variant.
         toFlushableAgg(agg)
+      case agg: SortHashAggregateExecTransformer if isGroupingOnlyFinalAgg(agg) =>
+        // See the RegularHashAggregateExecTransformer branch above.
+        agg
       case agg: SortHashAggregateExecTransformer
           if !agg.aggregateExpressions.forall(p => p.mode == Partial || p.mode == PartialMerge) =>
         // Not an intermediate agg. Skip.

--- a/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
+++ b/backends-velox/src/main/scala/org/apache/gluten/extension/FlushableHashAggregateRule.scala
@@ -73,18 +73,6 @@ case class FlushableHashAggregateRule(session: SparkSession) extends Rule[SparkP
   /**
    * Returns true if the aggregate applies no aggregate functions and is the final (or complete)
    * stage, e.g. the last step of `SELECT DISTINCT`, or of a `GROUP BY` without aggregate functions.
-   *
-   * Such an aggregate must fully aggregate. Flushing lets Velox abandon aggregation and emit
-   * duplicate grouping keys, and since no further aggregate follows, the duplicates reach the
-   * consumer. When the consumer is a join, they turn into extra join output rows.
-   *
-   * The mode check used by the other guards cannot detect this case: `aggregateExpressions` is
-   * empty here, so `forall(_.mode == Partial | PartialMerge)` is vacuously true and says nothing
-   * about which stage this is. Spark distinguishes the stages with
-   * `requiredChildDistributionExpressions`, which is `None` for a partial aggregate and
-   * `Some(groupingAttributes)` for the final one -- see `AggUtils.planAggregateWithoutDistinct`.
-   * Spark makes the same check in its own guard for the equivalent runtime bypass, see
-   * `HashAggregateExec.adaptivePartialAggEnabled`.
    */
   private def isGroupingOnlyFinalAgg(agg: HashAggregateExecTransformer): Boolean = {
     agg.aggregateExpressions.isEmpty && agg.requiredChildDistributionExpressions.isDefined

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
@@ -1281,6 +1281,39 @@ class VeloxAggregateFunctionsFlushSuite extends VeloxAggregateFunctionsSuite {
     }
   }
 
+  test("flushable aggregate rule - distinct feeding a join keeps final agg regular") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "-1",
+      SQLConf.FILES_MAX_PARTITION_BYTES.key -> "1k") {
+      // The join key is a strict subset of the distinct keys, so the distinct's final aggregate
+      // is repartitioned by a following exchange and thus visited by FlushableHashAggregateRule.
+      // Flushing it would emit duplicate distinct keys and inflate the join output.
+      runQueryAndCompare("""
+                           |select count(*) from orders
+                           |left join (select distinct l_orderkey, l_partkey from lineitem) d
+                           |  on o_orderkey = d.l_orderkey
+                           |""".stripMargin) {
+        df =>
+          val executedPlan = getExecutedPlan(df)
+          val groupingOnlyFinalAggs = executedPlan.collect {
+            case agg: HashAggregateExecTransformer
+                if agg.aggregateExpressions.isEmpty &&
+                  agg.requiredChildDistributionExpressions.isDefined =>
+              agg
+          }
+          assert(
+            groupingOnlyFinalAggs.nonEmpty,
+            "expected the distinct's final aggregate in the plan")
+          assert(
+            groupingOnlyFinalAggs.forall(
+              agg => !agg.isInstanceOf[FlushableHashAggregateExecTransformer]),
+            "the final aggregate of a grouping-only aggregation must not be flushable"
+          )
+      }
+    }
+  }
+
   test("flushable aggregate decimal sum") {
     withSQLConf(
       SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/explain.txt
@@ -39,7 +39,7 @@ VeloxColumnarToRow (187)
                                  :                             :     :                       :  +- ColumnarExchange (58)
                                  :                             :     :                       :     +- VeloxResizeBatches (57)
                                  :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-                                 :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+                                 :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
                                  :                             :     :                       :              +- ^ InputIteratorTransformer (53)
                                  :                             :     :                       :                 +- ColumnarExchange (51)
                                  :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -370,7 +370,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/simplified.txt
@@ -95,7 +95,7 @@ VeloxColumnarToRow
                                                                                             VeloxResizeBatches
                                                                                               WholeStageCodegenTransformer (22)
                                                                                                 ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                                                  FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                                                  RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                                                     InputIteratorTransformer
                                                                                                       InputAdapter
                                                                                                         ColumnarExchange [brand_id,class_id,category_id] #7

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/explain.txt
@@ -30,7 +30,7 @@ VeloxColumnarToRow (150)
       :                             :     :                       :  +- ColumnarExchange (58)
       :                             :     :                       :     +- VeloxResizeBatches (57)
       :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-      :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+      :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
       :                             :     :                       :              +- ^ InputIteratorTransformer (53)
       :                             :     :                       :                 +- ColumnarExchange (51)
       :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -342,7 +342,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/simplified.txt
@@ -90,7 +90,7 @@ VeloxColumnarToRow
                                                                   VeloxResizeBatches
                                                                     WholeStageCodegenTransformer (24)
                                                                       ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                        FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                        RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                           InputIteratorTransformer
                                                                             InputAdapter
                                                                               ColumnarExchange [brand_id,class_id,category_id] #6

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/explain.txt
@@ -8,7 +8,7 @@ VeloxColumnarToRow (104)
          :  :  +- ColumnarExchange (34)
          :  :     +- VeloxResizeBatches (33)
          :  :        +- ^ ProjectExecTransformer (31)
-         :  :           +- ^ FlushableHashAggregateExecTransformer (30)
+         :  :           +- ^ RegularHashAggregateExecTransformer (30)
          :  :              +- ^ InputIteratorTransformer (29)
          :  :                 +- ColumnarExchange (27)
          :  :                    +- VeloxResizeBatches (26)
@@ -35,7 +35,7 @@ VeloxColumnarToRow (104)
          :     +- ColumnarExchange (65)
          :        +- VeloxResizeBatches (64)
          :           +- ^ ProjectExecTransformer (62)
-         :              +- ^ FlushableHashAggregateExecTransformer (61)
+         :              +- ^ RegularHashAggregateExecTransformer (61)
          :                 +- ^ InputIteratorTransformer (60)
          :                    +- ColumnarExchange (58)
          :                       +- VeloxResizeBatches (57)
@@ -58,7 +58,7 @@ VeloxColumnarToRow (104)
             +- ColumnarExchange (97)
                +- VeloxResizeBatches (96)
                   +- ^ ProjectExecTransformer (94)
-                     +- ^ FlushableHashAggregateExecTransformer (93)
+                     +- ^ RegularHashAggregateExecTransformer (93)
                         +- ^ InputIteratorTransformer (92)
                            +- ColumnarExchange (90)
                               +- VeloxResizeBatches (89)
@@ -197,7 +197,7 @@ Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 (29) InputIteratorTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
-(30) FlushableHashAggregateExecTransformer
+(30) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Functions: []
@@ -320,7 +320,7 @@ Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 (60) InputIteratorTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 
-(61) FlushableHashAggregateExecTransformer
+(61) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Functions: []
@@ -449,7 +449,7 @@ Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 (92) InputIteratorTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/simplified.txt
@@ -10,7 +10,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (6)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #2
@@ -52,7 +52,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (12)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #7
@@ -84,7 +84,7 @@ VeloxColumnarToRow
                 VeloxResizeBatches
                   WholeStageCodegenTransformer (18)
                     ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                      FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                      RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                         InputIteratorTransformer
                           InputAdapter
                             ColumnarExchange [c_last_name,c_first_name,d_date] #10

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/explain.txt
@@ -29,7 +29,7 @@ VeloxColumnarToRow (85)
                                  +- ColumnarExchange (69)
                                     +- VeloxResizeBatches (68)
                                        +- ^ ProjectExecTransformer (66)
-                                          +- ^ FlushableHashAggregateExecTransformer (65)
+                                          +- ^ RegularHashAggregateExecTransformer (65)
                                              +- ^ InputIteratorTransformer (64)
                                                 +- ColumnarExchange (62)
                                                    +- VeloxResizeBatches (61)
@@ -332,7 +332,7 @@ Input [1]: [ca_zip#11]
 (64) InputIteratorTransformer
 Input [1]: [ca_zip#11]
 
-(65) FlushableHashAggregateExecTransformer
+(65) RegularHashAggregateExecTransformer
 Input [1]: [ca_zip#11]
 Keys [1]: [ca_zip#11]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/simplified.txt
@@ -44,7 +44,7 @@ VeloxColumnarToRow
                                   VeloxResizeBatches
                                     WholeStageCodegenTransformer (10)
                                       ProjectExecTransformer [ca_zip]
-                                        FlushableHashAggregateExecTransformer [ca_zip]
+                                        RegularHashAggregateExecTransformer [ca_zip]
                                           InputIteratorTransformer
                                             InputAdapter
                                               ColumnarExchange [ca_zip] #6

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/explain.txt
@@ -8,7 +8,7 @@ VeloxColumnarToRow (104)
          :  :  +- ColumnarExchange (34)
          :  :     +- VeloxResizeBatches (33)
          :  :        +- ^ ProjectExecTransformer (31)
-         :  :           +- ^ FlushableHashAggregateExecTransformer (30)
+         :  :           +- ^ RegularHashAggregateExecTransformer (30)
          :  :              +- ^ InputIteratorTransformer (29)
          :  :                 +- ColumnarExchange (27)
          :  :                    +- VeloxResizeBatches (26)
@@ -35,7 +35,7 @@ VeloxColumnarToRow (104)
          :     +- ColumnarExchange (65)
          :        +- VeloxResizeBatches (64)
          :           +- ^ ProjectExecTransformer (62)
-         :              +- ^ FlushableHashAggregateExecTransformer (61)
+         :              +- ^ RegularHashAggregateExecTransformer (61)
          :                 +- ^ InputIteratorTransformer (60)
          :                    +- ColumnarExchange (58)
          :                       +- VeloxResizeBatches (57)
@@ -58,7 +58,7 @@ VeloxColumnarToRow (104)
             +- ColumnarExchange (97)
                +- VeloxResizeBatches (96)
                   +- ^ ProjectExecTransformer (94)
-                     +- ^ FlushableHashAggregateExecTransformer (93)
+                     +- ^ RegularHashAggregateExecTransformer (93)
                         +- ^ InputIteratorTransformer (92)
                            +- ColumnarExchange (90)
                               +- VeloxResizeBatches (89)
@@ -197,7 +197,7 @@ Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 (29) InputIteratorTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
-(30) FlushableHashAggregateExecTransformer
+(30) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Functions: []
@@ -320,7 +320,7 @@ Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 (60) InputIteratorTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 
-(61) FlushableHashAggregateExecTransformer
+(61) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Functions: []
@@ -449,7 +449,7 @@ Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 (92) InputIteratorTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/simplified.txt
@@ -10,7 +10,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (6)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #2
@@ -52,7 +52,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (12)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #7
@@ -84,7 +84,7 @@ VeloxColumnarToRow
                 VeloxResizeBatches
                   WholeStageCodegenTransformer (18)
                     ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                      FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                      RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                         InputIteratorTransformer
                           InputAdapter
                             ColumnarExchange [c_last_name,c_first_name,d_date] #10

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/explain.txt
@@ -30,7 +30,7 @@ VeloxColumnarToRow (150)
       :                             :     :                       :  +- ColumnarExchange (58)
       :                             :     :                       :     +- VeloxResizeBatches (57)
       :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-      :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+      :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
       :                             :     :                       :              +- ^ InputIteratorTransformer (53)
       :                             :     :                       :                 +- ColumnarExchange (51)
       :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -342,7 +342,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/simplified.txt
@@ -90,7 +90,7 @@ VeloxColumnarToRow
                                                                   VeloxResizeBatches
                                                                     WholeStageCodegenTransformer (24)
                                                                       ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                        FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                        RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                           InputIteratorTransformer
                                                                             InputAdapter
                                                                               ColumnarExchange [brand_id,class_id,category_id] #6

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/explain.txt
@@ -45,7 +45,7 @@ VeloxColumnarToRow (250)
                            :                       :                             :     :                       :  +- ColumnarExchange (58)
                            :                       :                             :     :                       :     +- VeloxResizeBatches (57)
                            :                       :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-                           :                       :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+                           :                       :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
                            :                       :                             :     :                       :              +- ^ InputIteratorTransformer (53)
                            :                       :                             :     :                       :                 +- ColumnarExchange (51)
                            :                       :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -415,7 +415,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/simplified.txt
@@ -110,7 +110,7 @@ VeloxColumnarToRow
                                                                                                                 VeloxResizeBatches
                                                                                                                   WholeStageCodegenTransformer (22)
                                                                                                                     ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                                                                      FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                                                                      RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                                                                         InputIteratorTransformer
                                                                                                                           InputAdapter
                                                                                                                             ColumnarExchange [brand_id,class_id,category_id] #8

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (81)
                   +- VeloxResizeBatches (72)
                      +- ^ ProjectExecTransformer (70)
                         +- ^ ProjectExecTransformer (69)
-                           +- ^ FlushableHashAggregateExecTransformer (68)
+                           +- ^ RegularHashAggregateExecTransformer (68)
                               +- ^ InputIteratorTransformer (67)
                                  +- ColumnarExchange (65)
                                     +- VeloxResizeBatches (64)
@@ -345,7 +345,7 @@ Input [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#2
 (67) InputIteratorTransformer
 Input [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#24, lochierarchy#25]
 
-(68) FlushableHashAggregateExecTransformer
+(68) RegularHashAggregateExecTransformer
 Input [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#24, lochierarchy#25]
 Keys [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#24, lochierarchy#25]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (21)
                       ProjectExecTransformer [lochierarchy,_w0,gross_margin,i_category,i_class]
                         ProjectExecTransformer [gross_margin,i_category,i_class,lochierarchy,t_class]
-                          FlushableHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (81)
                   +- VeloxResizeBatches (72)
                      +- ^ ProjectExecTransformer (70)
                         +- ^ ProjectExecTransformer (69)
-                           +- ^ FlushableHashAggregateExecTransformer (68)
+                           +- ^ RegularHashAggregateExecTransformer (68)
                               +- ^ InputIteratorTransformer (67)
                                  +- ColumnarExchange (65)
                                     +- VeloxResizeBatches (64)
@@ -345,7 +345,7 @@ Input [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24
 (67) InputIteratorTransformer
 Input [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24, lochierarchy#25]
 
-(68) FlushableHashAggregateExecTransformer
+(68) RegularHashAggregateExecTransformer
 Input [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24, lochierarchy#25]
 Keys [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24, lochierarchy#25]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (21)
                       ProjectExecTransformer [lochierarchy,_w0,gross_margin,i_category,i_class]
                         ProjectExecTransformer [gross_margin,i_category,i_class,lochierarchy,t_class]
-                          FlushableHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (106)
                   +- VeloxResizeBatches (97)
                      +- ^ ProjectExecTransformer (95)
                         +- ^ ProjectExecTransformer (94)
-                           +- ^ FlushableHashAggregateExecTransformer (93)
+                           +- ^ RegularHashAggregateExecTransformer (93)
                               +- ^ InputIteratorTransformer (92)
                                  +- ColumnarExchange (90)
                                     +- VeloxResizeBatches (89)
@@ -471,7 +471,7 @@ Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochie
 (92) InputIteratorTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Keys [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (33)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,s_state,s_county]
                         ProjectExecTransformer [total_sum,s_state,s_county,lochierarchy,g_county]
-                          FlushableHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (106)
                   +- VeloxResizeBatches (97)
                      +- ^ ProjectExecTransformer (95)
                         +- ^ ProjectExecTransformer (94)
-                           +- ^ FlushableHashAggregateExecTransformer (93)
+                           +- ^ RegularHashAggregateExecTransformer (93)
                               +- ^ InputIteratorTransformer (92)
                                  +- ColumnarExchange (90)
                                     +- VeloxResizeBatches (89)
@@ -471,7 +471,7 @@ Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochie
 (92) InputIteratorTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Keys [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (33)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,s_state,s_county]
                         ProjectExecTransformer [total_sum,s_state,s_county,lochierarchy,g_county]
-                          FlushableHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (72)
                   +- VeloxResizeBatches (63)
                      +- ^ ProjectExecTransformer (61)
                         +- ^ ProjectExecTransformer (60)
-                           +- ^ FlushableHashAggregateExecTransformer (59)
+                           +- ^ RegularHashAggregateExecTransformer (59)
                               +- ^ InputIteratorTransformer (58)
                                  +- ColumnarExchange (56)
                                     +- VeloxResizeBatches (55)
@@ -299,7 +299,7 @@ Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lo
 (58) InputIteratorTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 
-(59) FlushableHashAggregateExecTransformer
+(59) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Keys [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (18)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,i_category,i_class]
                         ProjectExecTransformer [total_sum,i_category,i_class,lochierarchy,g_class]
-                          FlushableHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/explain.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (72)
                   +- VeloxResizeBatches (63)
                      +- ^ ProjectExecTransformer (61)
                         +- ^ ProjectExecTransformer (60)
-                           +- ^ FlushableHashAggregateExecTransformer (59)
+                           +- ^ RegularHashAggregateExecTransformer (59)
                               +- ^ InputIteratorTransformer (58)
                                  +- ColumnarExchange (56)
                                     +- VeloxResizeBatches (55)
@@ -299,7 +299,7 @@ Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lo
 (58) InputIteratorTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 
-(59) FlushableHashAggregateExecTransformer
+(59) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Keys [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Functions: []

--- a/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/simplified.txt
+++ b/gluten-ut/spark40/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (18)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,i_category,i_class]
                         ProjectExecTransformer [total_sum,i_category,i_class,lochierarchy,g_class]
-                          FlushableHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/explain.txt
@@ -39,7 +39,7 @@ VeloxColumnarToRow (187)
                                  :                             :     :                       :  +- ColumnarExchange (58)
                                  :                             :     :                       :     +- VeloxResizeBatches (57)
                                  :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-                                 :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+                                 :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
                                  :                             :     :                       :              +- ^ InputIteratorTransformer (53)
                                  :                             :     :                       :                 +- ColumnarExchange (51)
                                  :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -370,7 +370,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14a.sf100/simplified.txt
@@ -95,7 +95,7 @@ VeloxColumnarToRow
                                                                                             VeloxResizeBatches
                                                                                               WholeStageCodegenTransformer (22)
                                                                                                 ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                                                  FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                                                  RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                                                     InputIteratorTransformer
                                                                                                       InputAdapter
                                                                                                         ColumnarExchange [brand_id,class_id,category_id] #7

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/explain.txt
@@ -30,7 +30,7 @@ VeloxColumnarToRow (150)
       :                             :     :                       :  +- ColumnarExchange (58)
       :                             :     :                       :     +- VeloxResizeBatches (57)
       :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-      :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+      :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
       :                             :     :                       :              +- ^ InputIteratorTransformer (53)
       :                             :     :                       :                 +- ColumnarExchange (51)
       :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -342,7 +342,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q14b.sf100/simplified.txt
@@ -90,7 +90,7 @@ VeloxColumnarToRow
                                                                   VeloxResizeBatches
                                                                     WholeStageCodegenTransformer (24)
                                                                       ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                        FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                        RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                           InputIteratorTransformer
                                                                             InputAdapter
                                                                               ColumnarExchange [brand_id,class_id,category_id] #6

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/explain.txt
@@ -8,7 +8,7 @@ VeloxColumnarToRow (104)
          :  :  +- ColumnarExchange (34)
          :  :     +- VeloxResizeBatches (33)
          :  :        +- ^ ProjectExecTransformer (31)
-         :  :           +- ^ FlushableHashAggregateExecTransformer (30)
+         :  :           +- ^ RegularHashAggregateExecTransformer (30)
          :  :              +- ^ InputIteratorTransformer (29)
          :  :                 +- ColumnarExchange (27)
          :  :                    +- VeloxResizeBatches (26)
@@ -35,7 +35,7 @@ VeloxColumnarToRow (104)
          :     +- ColumnarExchange (65)
          :        +- VeloxResizeBatches (64)
          :           +- ^ ProjectExecTransformer (62)
-         :              +- ^ FlushableHashAggregateExecTransformer (61)
+         :              +- ^ RegularHashAggregateExecTransformer (61)
          :                 +- ^ InputIteratorTransformer (60)
          :                    +- ColumnarExchange (58)
          :                       +- VeloxResizeBatches (57)
@@ -58,7 +58,7 @@ VeloxColumnarToRow (104)
             +- ColumnarExchange (97)
                +- VeloxResizeBatches (96)
                   +- ^ ProjectExecTransformer (94)
-                     +- ^ FlushableHashAggregateExecTransformer (93)
+                     +- ^ RegularHashAggregateExecTransformer (93)
                         +- ^ InputIteratorTransformer (92)
                            +- ColumnarExchange (90)
                               +- VeloxResizeBatches (89)
@@ -197,7 +197,7 @@ Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 (29) InputIteratorTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
-(30) FlushableHashAggregateExecTransformer
+(30) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Functions: []
@@ -320,7 +320,7 @@ Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 (60) InputIteratorTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 
-(61) FlushableHashAggregateExecTransformer
+(61) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Functions: []
@@ -449,7 +449,7 @@ Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 (92) InputIteratorTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q38.sf100/simplified.txt
@@ -10,7 +10,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (6)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #2
@@ -52,7 +52,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (12)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #7
@@ -84,7 +84,7 @@ VeloxColumnarToRow
                 VeloxResizeBatches
                   WholeStageCodegenTransformer (18)
                     ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                      FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                      RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                         InputIteratorTransformer
                           InputAdapter
                             ColumnarExchange [c_last_name,c_first_name,d_date] #10

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/explain.txt
@@ -29,7 +29,7 @@ VeloxColumnarToRow (85)
                                  +- ColumnarExchange (69)
                                     +- VeloxResizeBatches (68)
                                        +- ^ ProjectExecTransformer (66)
-                                          +- ^ FlushableHashAggregateExecTransformer (65)
+                                          +- ^ RegularHashAggregateExecTransformer (65)
                                              +- ^ InputIteratorTransformer (64)
                                                 +- ColumnarExchange (62)
                                                    +- VeloxResizeBatches (61)
@@ -332,7 +332,7 @@ Input [1]: [ca_zip#11]
 (64) InputIteratorTransformer
 Input [1]: [ca_zip#11]
 
-(65) FlushableHashAggregateExecTransformer
+(65) RegularHashAggregateExecTransformer
 Input [1]: [ca_zip#11]
 Keys [1]: [ca_zip#11]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q8.sf100/simplified.txt
@@ -44,7 +44,7 @@ VeloxColumnarToRow
                                   VeloxResizeBatches
                                     WholeStageCodegenTransformer (10)
                                       ProjectExecTransformer [ca_zip]
-                                        FlushableHashAggregateExecTransformer [ca_zip]
+                                        RegularHashAggregateExecTransformer [ca_zip]
                                           InputIteratorTransformer
                                             InputAdapter
                                               ColumnarExchange [ca_zip] #6

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/explain.txt
@@ -8,7 +8,7 @@ VeloxColumnarToRow (104)
          :  :  +- ColumnarExchange (34)
          :  :     +- VeloxResizeBatches (33)
          :  :        +- ^ ProjectExecTransformer (31)
-         :  :           +- ^ FlushableHashAggregateExecTransformer (30)
+         :  :           +- ^ RegularHashAggregateExecTransformer (30)
          :  :              +- ^ InputIteratorTransformer (29)
          :  :                 +- ColumnarExchange (27)
          :  :                    +- VeloxResizeBatches (26)
@@ -35,7 +35,7 @@ VeloxColumnarToRow (104)
          :     +- ColumnarExchange (65)
          :        +- VeloxResizeBatches (64)
          :           +- ^ ProjectExecTransformer (62)
-         :              +- ^ FlushableHashAggregateExecTransformer (61)
+         :              +- ^ RegularHashAggregateExecTransformer (61)
          :                 +- ^ InputIteratorTransformer (60)
          :                    +- ColumnarExchange (58)
          :                       +- VeloxResizeBatches (57)
@@ -58,7 +58,7 @@ VeloxColumnarToRow (104)
             +- ColumnarExchange (97)
                +- VeloxResizeBatches (96)
                   +- ^ ProjectExecTransformer (94)
-                     +- ^ FlushableHashAggregateExecTransformer (93)
+                     +- ^ RegularHashAggregateExecTransformer (93)
                         +- ^ InputIteratorTransformer (92)
                            +- ColumnarExchange (90)
                               +- VeloxResizeBatches (89)
@@ -197,7 +197,7 @@ Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 (29) InputIteratorTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 
-(30) FlushableHashAggregateExecTransformer
+(30) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Keys [3]: [c_last_name#9, c_first_name#8, d_date#5]
 Functions: []
@@ -320,7 +320,7 @@ Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 (60) InputIteratorTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 
-(61) FlushableHashAggregateExecTransformer
+(61) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Keys [3]: [c_last_name#20, c_first_name#19, d_date#16]
 Functions: []
@@ -449,7 +449,7 @@ Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 (92) InputIteratorTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Keys [3]: [c_last_name#30, c_first_name#29, d_date#26]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v1_4/q87.sf100/simplified.txt
@@ -10,7 +10,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (6)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #2
@@ -52,7 +52,7 @@ VeloxColumnarToRow
                   VeloxResizeBatches
                     WholeStageCodegenTransformer (12)
                       ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                        FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                        RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                           InputIteratorTransformer
                             InputAdapter
                               ColumnarExchange [c_last_name,c_first_name,d_date] #7
@@ -84,7 +84,7 @@ VeloxColumnarToRow
                 VeloxResizeBatches
                   WholeStageCodegenTransformer (18)
                     ProjectExecTransformer [c_last_name,c_first_name,d_date]
-                      FlushableHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
+                      RegularHashAggregateExecTransformer [c_last_name,c_first_name,d_date]
                         InputIteratorTransformer
                           InputAdapter
                             ColumnarExchange [c_last_name,c_first_name,d_date] #10

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/explain.txt
@@ -30,7 +30,7 @@ VeloxColumnarToRow (150)
       :                             :     :                       :  +- ColumnarExchange (58)
       :                             :     :                       :     +- VeloxResizeBatches (57)
       :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-      :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+      :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
       :                             :     :                       :              +- ^ InputIteratorTransformer (53)
       :                             :     :                       :                 +- ColumnarExchange (51)
       :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -342,7 +342,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14.sf100/simplified.txt
@@ -90,7 +90,7 @@ VeloxColumnarToRow
                                                                   VeloxResizeBatches
                                                                     WholeStageCodegenTransformer (24)
                                                                       ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                        FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                        RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                           InputIteratorTransformer
                                                                             InputAdapter
                                                                               ColumnarExchange [brand_id,class_id,category_id] #6

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/explain.txt
@@ -40,7 +40,7 @@ VeloxColumnarToRow (327)
                            :        :                             :     :                       :  +- ColumnarExchange (58)
                            :        :                             :     :                       :     +- VeloxResizeBatches (57)
                            :        :                             :     :                       :        +- ^ ProjectExecTransformer (55)
-                           :        :                             :     :                       :           +- ^ FlushableHashAggregateExecTransformer (54)
+                           :        :                             :     :                       :           +- ^ RegularHashAggregateExecTransformer (54)
                            :        :                             :     :                       :              +- ^ InputIteratorTransformer (53)
                            :        :                             :     :                       :                 +- ColumnarExchange (51)
                            :        :                             :     :                       :                    +- VeloxResizeBatches (50)
@@ -470,7 +470,7 @@ Input [3]: [brand_id#27, class_id#28, category_id#29]
 (53) InputIteratorTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 
-(54) FlushableHashAggregateExecTransformer
+(54) RegularHashAggregateExecTransformer
 Input [3]: [brand_id#27, class_id#28, category_id#29]
 Keys [3]: [brand_id#27, class_id#28, category_id#29]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q14a.sf100/simplified.txt
@@ -103,7 +103,7 @@ VeloxColumnarToRow
                                                                                                   VeloxResizeBatches
                                                                                                     WholeStageCodegenTransformer (22)
                                                                                                       ProjectExecTransformer [brand_id,class_id,category_id]
-                                                                                                        FlushableHashAggregateExecTransformer [brand_id,class_id,category_id]
+                                                                                                        RegularHashAggregateExecTransformer [brand_id,class_id,category_id]
                                                                                                           InputIteratorTransformer
                                                                                                             InputAdapter
                                                                                                               ColumnarExchange [brand_id,class_id,category_id] #7

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (81)
                   +- VeloxResizeBatches (72)
                      +- ^ ProjectExecTransformer (70)
                         +- ^ ProjectExecTransformer (69)
-                           +- ^ FlushableHashAggregateExecTransformer (68)
+                           +- ^ RegularHashAggregateExecTransformer (68)
                               +- ^ InputIteratorTransformer (67)
                                  +- ColumnarExchange (65)
                                     +- VeloxResizeBatches (64)
@@ -345,7 +345,7 @@ Input [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#2
 (67) InputIteratorTransformer
 Input [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#24, lochierarchy#25]
 
-(68) FlushableHashAggregateExecTransformer
+(68) RegularHashAggregateExecTransformer
 Input [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#24, lochierarchy#25]
 Keys [6]: [gross_margin#22, i_category#12, i_class#11, t_category#23, t_class#24, lochierarchy#25]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a.sf100/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (21)
                       ProjectExecTransformer [lochierarchy,_w0,gross_margin,i_category,i_class]
                         ProjectExecTransformer [gross_margin,i_category,i_class,lochierarchy,t_class]
-                          FlushableHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (81)
                   +- VeloxResizeBatches (72)
                      +- ^ ProjectExecTransformer (70)
                         +- ^ ProjectExecTransformer (69)
-                           +- ^ FlushableHashAggregateExecTransformer (68)
+                           +- ^ RegularHashAggregateExecTransformer (68)
                               +- ^ InputIteratorTransformer (67)
                                  +- ColumnarExchange (65)
                                     +- VeloxResizeBatches (64)
@@ -345,7 +345,7 @@ Input [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24
 (67) InputIteratorTransformer
 Input [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24, lochierarchy#25]
 
-(68) FlushableHashAggregateExecTransformer
+(68) RegularHashAggregateExecTransformer
 Input [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24, lochierarchy#25]
 Keys [6]: [gross_margin#22, i_category#10, i_class#9, t_category#23, t_class#24, lochierarchy#25]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q36a/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (21)
                       ProjectExecTransformer [lochierarchy,_w0,gross_margin,i_category,i_class]
                         ProjectExecTransformer [gross_margin,i_category,i_class,lochierarchy,t_class]
-                          FlushableHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [gross_margin,i_category,i_class,t_category,t_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [gross_margin,i_category,i_class,t_category,t_class,lochierarchy] #2

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (106)
                   +- VeloxResizeBatches (97)
                      +- ^ ProjectExecTransformer (95)
                         +- ^ ProjectExecTransformer (94)
-                           +- ^ FlushableHashAggregateExecTransformer (93)
+                           +- ^ RegularHashAggregateExecTransformer (93)
                               +- ^ InputIteratorTransformer (92)
                                  +- ColumnarExchange (90)
                                     +- VeloxResizeBatches (89)
@@ -471,7 +471,7 @@ Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochie
 (92) InputIteratorTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Keys [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a.sf100/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (33)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,s_state,s_county]
                         ProjectExecTransformer [total_sum,s_state,s_county,lochierarchy,g_county]
-                          FlushableHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (106)
                   +- VeloxResizeBatches (97)
                      +- ^ ProjectExecTransformer (95)
                         +- ^ ProjectExecTransformer (94)
-                           +- ^ FlushableHashAggregateExecTransformer (93)
+                           +- ^ RegularHashAggregateExecTransformer (93)
                               +- ^ InputIteratorTransformer (92)
                                  +- ColumnarExchange (90)
                                     +- VeloxResizeBatches (89)
@@ -471,7 +471,7 @@ Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochie
 (92) InputIteratorTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 
-(93) FlushableHashAggregateExecTransformer
+(93) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Keys [6]: [total_sum#27, s_state#8, s_county#7, g_state#28, g_county#29, lochierarchy#30]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q70a/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (33)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,s_state,s_county]
                         ProjectExecTransformer [total_sum,s_state,s_county,lochierarchy,g_county]
-                          FlushableHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,s_state,s_county,g_state,g_county,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,s_state,s_county,g_state,g_county,lochierarchy] #2

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (72)
                   +- VeloxResizeBatches (63)
                      +- ^ ProjectExecTransformer (61)
                         +- ^ ProjectExecTransformer (60)
-                           +- ^ FlushableHashAggregateExecTransformer (59)
+                           +- ^ RegularHashAggregateExecTransformer (59)
                               +- ^ InputIteratorTransformer (58)
                                  +- ColumnarExchange (56)
                                     +- VeloxResizeBatches (55)
@@ -299,7 +299,7 @@ Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lo
 (58) InputIteratorTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 
-(59) FlushableHashAggregateExecTransformer
+(59) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Keys [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a.sf100/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (18)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,i_category,i_class]
                         ProjectExecTransformer [total_sum,i_category,i_class,lochierarchy,g_class]
-                          FlushableHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/explain.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/explain.txt
@@ -9,7 +9,7 @@ VeloxColumnarToRow (72)
                   +- VeloxResizeBatches (63)
                      +- ^ ProjectExecTransformer (61)
                         +- ^ ProjectExecTransformer (60)
-                           +- ^ FlushableHashAggregateExecTransformer (59)
+                           +- ^ RegularHashAggregateExecTransformer (59)
                               +- ^ InputIteratorTransformer (58)
                                  +- ColumnarExchange (56)
                                     +- VeloxResizeBatches (55)
@@ -299,7 +299,7 @@ Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lo
 (58) InputIteratorTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 
-(59) FlushableHashAggregateExecTransformer
+(59) RegularHashAggregateExecTransformer
 Input [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Keys [6]: [total_sum#14, i_category#8, i_class#7, g_category#15, g_class#16, lochierarchy#17]
 Functions: []

--- a/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/simplified.txt
+++ b/gluten-ut/spark41/src/test/resources/backends-velox/tpcds-plan-stability/gluten-approved-plans-v2_7/q86a/simplified.txt
@@ -11,7 +11,7 @@ VeloxColumnarToRow
                     WholeStageCodegenTransformer (18)
                       ProjectExecTransformer [lochierarchy,_w0,total_sum,i_category,i_class]
                         ProjectExecTransformer [total_sum,i_category,i_class,lochierarchy,g_class]
-                          FlushableHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
+                          RegularHashAggregateExecTransformer [total_sum,i_category,i_class,g_category,g_class,lochierarchy]
                             InputIteratorTransformer
                               InputAdapter
                                 ColumnarExchange [total_sum,i_category,i_class,g_category,g_class,lochierarchy] #2


### PR DESCRIPTION
Fixes #12959.

## What changes are proposed in this pull request?

This PR fixes a correctness issue where queries doing a `LEFT JOIN` against a `SELECT DISTINCT` subquery can produce extra duplicate rows and non-deterministic results when Velox triggers early aggregation abandonment.

### The Problem

In `FlushableHashAggregateRule.scala`, the rule determines if an aggregate is an intermediate stage using:
```scala
agg.aggregateExpressions.forall(p => p.mode == Partial || p.mode == PartialMerge)
```
For grouping-only queries (like `SELECT DISTINCT` or a `GROUP BY` without aggregate functions), `aggregateExpressions` is empty. Because `Seq.empty.forall(...)` evaluates vacuously to `true`, the rule fails to distinguish between partial and final stages, and incorrectly transforms the **final** distinct aggregation into a `FlushableHashAggregateExecTransformer`.

When this final distinct output is repartitioned again (e.g. feeding into a `JOIN` on a strict subset of the distinct keys), it falls below an exchange, entering the rule's scope. If Velox later abandons the aggregation under memory pressure, it emits duplicate keys. Because it's already the final aggregation stage, there is no subsequent aggregate to collapse them, resulting in leaked duplicate keys and inflated join outputs.

### History & Context
- This scenario was originally guarded by `isAggInputAlreadyDistributedWithAggKeys`, introduced in #4443.
- That protection was removed in #12098 when the rule was narrowed to target only the `AggUtils.planAggregateWithOneDistinct` pipeline, which left the plain `SELECT DISTINCT` unprotected.

### The Fix

Rather than reverting the performance gains from #12098 by restoring the general distribution check, this PR specifically identifies the final grouping-only aggregate using `requiredChildDistributionExpressions.isDefined`. 

```scala
private def isGroupingOnlyFinalAgg(agg: HashAggregateExecTransformer): Boolean = {
  agg.aggregateExpressions.isEmpty && agg.requiredChildDistributionExpressions.isDefined
}
```

In Spark's `AggUtils.planAggregateWithoutDistinct`, `requiredChildDistributionExpressions` is:
- `None` for the partial aggregate
- `Some(groupingAttributes)` for the final aggregate

This matches the exact logic Spark uses in its own check for the equivalent runtime bypass (`HashAggregateExec.adaptivePartialAggEnabled`, introduced in SPARK-58511).

This ensures the optimization is preserved for valid aggregates with aggregate functions, while safely skipping the final stage for grouping-only aggregations.

## How was this patch tested?

- Added regression test: `flushable aggregate rule - distinct feeding a join keeps final agg regular` to `VeloxAggregateFunctionsFlushSuite`.
- Validated that a `SELECT DISTINCT` repartitioned for a `JOIN` on a subset of its keys leaves the final distinct aggregate as a `RegularHashAggregateExecTransformer`.
- Verified the fix query output matches vanilla Spark exactly.
- Verified style check passed via `./dev/format-scala-code.sh`.
