### PR TITLE
[GLUTEN-12538][VL] Support cast between DATE and TIMESTAMP_NTZ

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -621,6 +621,11 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
           checkGlutenPlan[ProjectExecTransformer]
         }
 
+        // cast(timestamp_ntz as date)
+        runQueryAndCompare("select cast(ts as date) from view") {
+          checkGlutenPlan[ProjectExecTransformer]
+        }
+
         // cast(timestamp_ntz as string)
         runQueryAndCompare("select cast(ts as string) from view") {
           checkGlutenPlan[ProjectExecTransformer]
@@ -680,6 +685,26 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
         // cast(varchar as timestamp_ntz)
         runQueryAndCompare("select cast(str as timestamp_ntz) from str_view") {
           checkGlutenPlan[ProjectExecTransformer]
+        }
+
+        val datePath = dir.getAbsolutePath + "/date_view"
+        Seq(
+          java.sql.Date.valueOf("1969-12-31"),
+          java.sql.Date.valueOf("1970-01-01"),
+          java.sql.Date.valueOf("2000-01-01")
+        ).toDF("d").coalesce(1).write.mode("overwrite").parquet(datePath)
+        spark.read.parquet(datePath).createOrReplaceTempView("date_view")
+
+        // cast(date as timestamp_ntz)
+        runQueryAndCompare("select cast(d as timestamp_ntz) from date_view") {
+          checkGlutenPlan[ProjectExecTransformer]
+        }
+
+        // The conversion is independent of the session timezone.
+        withSQLConf("spark.sql.session.timeZone" -> "America/Los_Angeles") {
+          runQueryAndCompare("select cast(d as timestamp_ntz) from date_view") {
+            checkGlutenPlan[ProjectExecTransformer]
+          }
         }
     }
   }

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -700,7 +700,7 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
           checkGlutenPlan[ProjectExecTransformer]
         }
 
-        // The conversion is independent of the session timezone.
+        // Ensure native execution works under a non-UTC session timezone.
         withSQLConf("spark.sql.session.timeZone" -> "America/Los_Angeles") {
           runQueryAndCompare("select cast(d as timestamp_ntz) from date_view") {
             checkGlutenPlan[ProjectExecTransformer]

--- a/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
+++ b/cpp/velox/substrait/SubstraitToVeloxPlanValidator.cc
@@ -305,13 +305,13 @@ bool SubstraitToVeloxPlanValidator::isAllowedCast(const TypePtr& fromType, const
   // Limited support for TimestampNTZ from/to X
   // Casts between Timestamp and TimestampNTZ are handled in from/to timestamp.
   if (fromType->equivalent(*TIMESTAMP_UTC())) {
-    if (toType->isVarchar() || toType->isVarbinary()) {
+    if (toType->isDate() || toType->isVarchar() || toType->isVarbinary()) {
       return true;
     }
     return false;
   }
   if (toType->equivalent(*TIMESTAMP_UTC())) {
-    if (fromType->isVarchar()) {
+    if (fromType->isDate() || fromType->isVarchar()) {
       return true;
     }
     return false;


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allow casts between `DATE` and `TIMESTAMP_NTZ` to pass Gluten's Substrait-to-Velox validation now that native support is available in facebookincubator/velox#17961 and included by #12961.

Add native execution coverage for both cast directions, including `DATE` to `TIMESTAMP_NTZ` under a non-UTC session timezone.

This addresses the DATE/TIMESTAMP_NTZ case discussed in #12538 and is related to #11622.

## How was this patch tested?

- Rebuilt the pinned Velox dependency and Gluten native backend with tests enabled.
- `cpp/build/velox/tests/velox_plan_conversion_test --gtest_filter='Substrait2VeloxPlanValidatorTest.*'`
- `./build/mvn test -Pspark-ut -Pbackends-velox -Pspark-3.5 -Pjava-17 -DargLine="-Dspark.test.home=/opt/shims/spark35/spark_home/" -DwildcardSuites=org.apache.gluten.functions.DateFunctionsValidateSuite`

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI 1.0.82
