### PR TITLE
[MINOR][CORE] Make ColumnarInputAdapter inherit from GlutenPlan

### DIFF
--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCDSMetricsSuite.scala
@@ -21,7 +21,7 @@ import org.apache.gluten.execution.GlutenPlan
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.execution.InputIteratorTransformer
+import org.apache.spark.sql.execution.{ColumnarInputAdapter, InputIteratorTransformer}
 import org.apache.spark.task.TaskResources
 
 import scala.collection.JavaConverters._
@@ -87,7 +87,10 @@ class GlutenClickHouseTPCDSMetricsSuite extends GlutenClickHouseTPCDSAbstractSui
     ) {
       () =>
         val allGlutenPlans = wholeStageTransformer.collect {
-          case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
+          case g: GlutenPlan
+              if !g.isInstanceOf[InputIteratorTransformer] &&
+                !g.isInstanceOf[ColumnarInputAdapter] =>
+            g
         }
 
         assert(allGlutenPlans.size == 30)

--- a/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
+++ b/backends-clickhouse/src/test/scala/org/apache/gluten/execution/metrics/GlutenClickHouseTPCHMetricsSuite.scala
@@ -246,7 +246,10 @@ class GlutenClickHouseTPCHMetricsSuite extends ParquetTPCHSuite {
         ) {
           () =>
             val allGlutenPlans = wholeStageTransformer1.collect {
-              case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
+              case g: GlutenPlan
+                  if !g.isInstanceOf[InputIteratorTransformer] &&
+                    !g.isInstanceOf[ColumnarInputAdapter] =>
+                g
             }
 
             val scanPlan = allGlutenPlans(9)
@@ -283,7 +286,10 @@ class GlutenClickHouseTPCHMetricsSuite extends ParquetTPCHSuite {
         ) {
           () =>
             val allGlutenPlans = wholeStageTransformer2.collect {
-              case g: GlutenPlan if !g.isInstanceOf[InputIteratorTransformer] => g
+              case g: GlutenPlan
+                  if !g.isInstanceOf[InputIteratorTransformer] &&
+                    !g.isInstanceOf[ColumnarInputAdapter] =>
+                g
             }
 
             assert(allGlutenPlans.size == 58)

--- a/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
+++ b/gluten-substrait/src/main/scala/org/apache/spark/sql/execution/ColumnarCollapseTransformStages.scala
@@ -20,7 +20,7 @@ import org.apache.gluten.backendsapi.BackendsApiManager
 import org.apache.gluten.config.GlutenConfig
 import org.apache.gluten.execution._
 import org.apache.gluten.extension.ApplyStageInputStatsRule
-import org.apache.gluten.extension.columnar.transition.{Convention, ConventionReq}
+import org.apache.gluten.extension.columnar.transition.Convention
 import org.apache.gluten.metrics.MetricsUpdater
 import org.apache.gluten.substrait.SubstraitContext
 import org.apache.gluten.substrait.rel.{InputIteratorRelNode, RelBuilder}
@@ -215,21 +215,16 @@ case class ColumnarCollapseTransformStages(glutenConf: GlutenConfig) extends Rul
   }
 }
 
-// TODO: Make this inherit from GlutenPlan.
 case class ColumnarInputAdapter(child: SparkPlan)
-  extends InputAdapterGenerateTreeStringShim
-  with Convention.KnownBatchType
-  with Convention.KnownRowType
-  with ConventionReq.KnownChildConvention {
+  extends GlutenPlan
+  with InputAdapterGenerateTreeStringShim {
   override def output: Seq[Attribute] = child.output
-  final override val supportsColumnar: Boolean = true
-  final override val supportsRowBased: Boolean = false
+  // Row output is unsupported, so GlutenPlan derives supportsRowBased = false.
   override def rowType(): Convention.RowType = Convention.RowType.None
+  // Columnar output only, so GlutenPlan derives supportsColumnar = true. GlutenPlan's default
+  // requiredChildConvention then requires the same batch type from the child.
   override def batchType(): Convention.BatchType =
     BackendsApiManager.getSettings.primaryBatchType
-  override def requiredChildConvention(): Seq[ConventionReq] = Seq(
-    ConventionReq.ofBatch(
-      ConventionReq.BatchType.Is(BackendsApiManager.getSettings.primaryBatchType)))
   override protected def doExecute(): RDD[InternalRow] = throw new UnsupportedOperationException()
   override protected def doExecuteColumnar(): RDD[ColumnarBatch] = child.executeColumnar()
   override def outputPartitioning: Partitioning = child.outputPartitioning


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->
ColumnarInputAdapter previously mixed in Convention.KnownBatchType, Convention.KnownRowType and ConventionReq.KnownChildConvention directly.

`GlutenPlan` already bundles those three traits and derives `supportsColumnar` / `supportsRowBased` from `batchType()` / `rowType()`. This PR makes `ColumnarInputAdapter` inherit from `GlutenPlan` and removes the now-redundant overrides.

## How was this patch tested?
Exists UTs.
<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->

## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes.