### PR TITLE
[GLUTEN][VL] Re-enable the ignored "Velox Parquet Write" test in ORC suite

### DIFF
--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxOrcDataTypeValidationSuite.scala
@@ -465,16 +465,25 @@ class VeloxOrcDataTypeValidationSuite extends VeloxWholeStageTransformerSuite {
     }
   }
 
-  ignore("Velox Parquet Write") {
+  test("Velox Parquet Write") {
     withSQLConf((GlutenConfig.NATIVE_WRITER_ENABLED.key, "true")) {
       withTempDir {
         dir =>
-          val write_path = dir.toURI.getPath
-          val data_path = getClass.getResource("/").getPath + "/data-type-validation-data/type1"
-          val df = spark.read.format("parquet").load(data_path)
-          df.write.mode("append").format("parquet").save(write_path)
+          val writePath = dir.toURI.getPath
+          val dataPath = getClass.getResource("/").getPath + "/data-type-validation-data/type1"
+          // Velox native write doesn't support Complex type.
+          val df = spark.read
+            .format("parquet")
+            .load(dataPath)
+            .drop("array")
+            .drop("struct")
+            .drop("map")
+          df.write.mode("append").format("parquet").save(writePath)
+          val parquetDf = spark.read
+            .format("parquet")
+            .load(writePath)
+          checkAnswer(parquetDf, df)
       }
     }
-
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some tips:

1. For first-time contributors, please read our contributing guide:
   https://github.com/apache/gluten/blob/main/CONTRIBUTING.md
2. If necessary, create a GitHub issue for discussion beforehand to avoid duplicate work.
3. If the PR is specific to a single backend, include [VL] or [CH] in the PR title to indicate the
   Velox or ClickHouse backend, respectively.
4. If the PR is not ready for review, please mark it as a draft.
-->

## What changes are proposed in this pull request?

<!--
Provide a clear and concise description of the changes introduced in this PR.
Ensure the PR description aligns with the code changes, especially after updates.
If applicable, include "Fixes #<GitHub_Issue_ID>" to automatically close the corresponding issue
when the PR is merged.
-->
The "Velox Parquet Write" test in VeloxOrcDataTypeValidationSuite has been ignored since the Spark 3.4 test framework was introduced. 

The identical test in VeloxParquetDataTypeValidationSuite is enabled and passing, the only reason the ORC-suite copy failed was that it did not drop the complex-type columns that Velox native write does not support.

## How was this patch tested?

<!--
Describe how the changes were tested, if applicable.
Include new tests to validate the functionality, if necessary.
For UI-related changes, attach screenshots to demonstrate the updates.
-->
re-enable test.
## Was this patch authored or co-authored using generative AI tooling?

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes, Generated-by: Claude claude-opus-4-8