### PR TITLE
[GLUTEN-12985][VL] Fix multi-window page deserialization in rss-sort shuffle reader

### DIFF
--- a/cpp/velox/shuffle/GlutenByteStream.h
+++ b/cpp/velox/shuffle/GlutenByteStream.h
@@ -192,7 +192,7 @@ class GlutenByteInputStream : public ByteInputStream {
   /// bytes. The size of the value may be less if the current byte
   /// range ends within 'size' bytes from the current position.  The
   /// size will be 0 if at end.
-  std::string_view nextView(int64_t size) {
+  virtual std::string_view nextView(int64_t size) {
     VELOX_CHECK_GE(size, 0, "Attempting to view negative number of bytes");
     if (current_->position == current_->size) {
       if (current_ == &ranges_.back()) {

--- a/cpp/velox/shuffle/VeloxShuffleReader.cc
+++ b/cpp/velox/shuffle/VeloxShuffleReader.cc
@@ -36,6 +36,8 @@
 #include "velox/vector/arrow/Bridge.h"
 
 #include <algorithm>
+#include <array>
+#include <cstring>
 
 #include "VeloxGpuAsyncShuffleReader.h"
 #include "config/VeloxConfig.h"
@@ -65,6 +67,41 @@ uint32_t validateHashShuffleReaderBatchSize(int32_t batchSize) {
   GLUTEN_CHECK(batchSize > 0, fmt::format("Hash shuffle reader batch size must be positive, but got {}", batchSize));
   return static_cast<uint32_t>(batchSize);
 }
+
+// The Presto page wire header (velox/serializers/PrestoSerializer.h):
+// numRows:int32, pageCodecMarker:int8, uncompressedSize:int32,
+// compressedSize:int32, checksum:int64 — 21 bytes in machine byte order.
+// Parsed manually instead of via PrestoHeader to avoid depending on
+// velox-internal serde detail headers; the wire format itself is frozen by
+// protocol compatibility.
+struct PrestoPageHeader {
+  static constexpr int32_t kSize = 21;
+  static constexpr int8_t kCompressedBitMask = 1;
+
+  int32_t numRows;
+  int8_t pageCodecMarker;
+  int32_t uncompressedSize;
+  int32_t compressedSize;
+  int64_t checksum;
+
+  static PrestoPageHeader read(const uint8_t* data) {
+    PrestoPageHeader h;
+    std::memcpy(&h.numRows, data, sizeof(h.numRows));
+    data += sizeof(h.numRows);
+    std::memcpy(&h.pageCodecMarker, data, sizeof(h.pageCodecMarker));
+    data += sizeof(h.pageCodecMarker);
+    std::memcpy(&h.uncompressedSize, data, sizeof(h.uncompressedSize));
+    data += sizeof(h.uncompressedSize);
+    std::memcpy(&h.compressedSize, data, sizeof(h.compressedSize));
+    data += sizeof(h.compressedSize);
+    std::memcpy(&h.checksum, data, sizeof(h.checksum));
+    return h;
+  }
+
+  bool isCompressed() const {
+    return (pageCodecMarker & kCompressedBitMask) != 0;
+  }
+};
 
 struct BufferViewReleaser {
   BufferViewReleaser() : BufferViewReleaser(nullptr) {}
@@ -826,6 +863,15 @@ void VeloxSortShuffleReaderDeserializer::readNextRow() {
   ++cachedRows_;
 }
 
+// A single-window refill stream: each next() overwrites the sole range with up
+// to buffer_ capacity bytes from the underlying InputStream. This contrasts
+// with the base class (GlutenByteInputStream), which supports multiple stable
+// ranges traversed sequentially. Because earlier windows are physically
+// discarded on refill, operations that assume stable multi-range data (e.g.
+// arbitrary rewinds across refill boundaries) are unsupported and will throw.
+// Overrides nextView/tellp/seekp/size/atEnd preserve safe behavior under this
+// single-window contract — callers can always read forward and rewind within
+// the current window, but cannot revisit bytes from prior windows.
 class VeloxRssSortShuffleReaderDeserializer::VeloxInputStream : public facebook::velox::GlutenByteInputStream {
  public:
   VeloxInputStream(std::shared_ptr<arrow::io::InputStream> input, facebook::velox::BufferPtr buffer);
@@ -836,16 +882,49 @@ class VeloxRssSortShuffleReaderDeserializer::VeloxInputStream : public facebook:
 
   size_t remainingSize() const override;
 
+  size_t size() const override {
+    return atEnd_ ? totalBytesRead_ : std::numeric_limits<size_t>::max();
+  }
+
+  bool atEnd() const override {
+    return atEnd_;
+  }
+
+  std::string_view nextView(int64_t size) override;
+
+  std::streampos tellp() const override;
+
+  void seekp(std::streampos position) override;
+
+  int32_t remainingInWindow() const {
+    if (ranges().empty()) {
+      return 0;
+    }
+    return ranges()[0].size - ranges()[0].position;
+  }
+
+  uint8_t* data() const {
+    return ranges().empty() ? nullptr : ranges()[0].buffer + ranges()[0].position;
+  }
+
+  void advance(int32_t n) {
+    VELOX_CHECK(!ranges_.empty() && ranges_[0].position + n <= ranges_[0].size);
+    ranges_[0].position += n;
+  }
+
+ private:
   std::shared_ptr<arrow::io::InputStream> in_;
   const facebook::velox::BufferPtr buffer_;
   uint64_t offset_ = -1;
+  uint64_t totalBytesRead_ = 0;
+  bool atEnd_ = false;
 };
 
 VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::VeloxInputStream(
     std::shared_ptr<arrow::io::InputStream> input,
     facebook::velox::BufferPtr buffer)
     : in_(std::move(input)), buffer_(std::move(buffer)) {
-  next(true);
+  next(false);
 }
 
 bool VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::hasNext() {
@@ -853,7 +932,7 @@ bool VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::hasNext() {
     return false;
   }
   if (ranges()[0].position >= ranges()[0].size) {
-    next(true);
+    next(false);
     return offset_ != 0;
   }
   return true;
@@ -861,11 +940,23 @@ bool VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::hasNext() {
 
 void VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::next(bool throwIfPastEnd) {
   const uint32_t readBytes = buffer_->capacity();
-  offset_ = in_->Read(readBytes, buffer_->asMutable<char>()).ValueOr(0);
-  if (offset_ > 0) {
-    int32_t realBytes = offset_;
-    VELOX_CHECK_LT(0, realBytes, "Reading past end of file.");
-    setRange({buffer_->asMutable<uint8_t>(), realBytes, 0});
+  offset_ = 0;
+  int64_t realBytes = in_->Read(readBytes, buffer_->asMutable<char>()).ValueOr(0);
+  VELOX_CHECK_LE(0, realBytes, "Read returned negative value: {}", realBytes);
+  if (realBytes > 0) {
+    offset_ = realBytes;
+    totalBytesRead_ += realBytes;
+    atEnd_ = false;
+    setRange({buffer_->asMutable<uint8_t>(), static_cast<int32_t>(realBytes), 0});
+  } else {
+    atEnd_ = true;
+    if (throwIfPastEnd) {
+      VELOX_FAIL(
+          "Reading past end of VeloxRssSortShuffleReaderDeserializer::VeloxInputStream, real bytes = {}, "
+          "totalBytesRead = {}",
+          realBytes,
+          totalBytesRead_);
+    }
   }
 }
 
@@ -906,19 +997,13 @@ std::shared_ptr<ColumnarBatch> VeloxRssSortShuffleReaderDeserializer::next() {
 
   ScopedTimer timer(&deserializeTime_);
 
-  RowVectorPtr rowVector;
-  VectorStreamGroup::read(
-      in_.get(), memoryManager_->getLeafMemoryPool().get(), rowType_, serde_, &rowVector, &serdeOptions_);
-
+  auto rowVector = readPage();
   if (rowVector->size() >= batchSize_) {
     return std::make_shared<VeloxColumnarBatch>(std::move(rowVector));
   }
 
   while (rowVector->size() < batchSize_ && in_->hasNext()) {
-    RowVectorPtr rowVectorTemp;
-    VectorStreamGroup::read(
-        in_.get(), memoryManager_->getLeafMemoryPool().get(), rowType_, serde_, &rowVectorTemp, &serdeOptions_);
-    rowVector->append(rowVectorTemp.get());
+    rowVector->append(readPage().get());
   }
 
   return std::make_shared<VeloxColumnarBatch>(std::move(rowVector));
@@ -950,6 +1035,114 @@ void VeloxRssSortShuffleReaderDeserializer::loadNextStream() {
 
 size_t VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::remainingSize() const {
   return std::numeric_limits<unsigned long>::max();
+}
+
+std::string_view VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::nextView(int64_t size) {
+  VELOX_CHECK_GE(size, 0, "Attempting to view negative number of bytes");
+  if (ranges_.empty()) {
+    return std::string_view(nullptr, 0);
+  }
+  if (ranges_[0].position == ranges_[0].size) {
+    // Current window is exhausted. For single-window refill streams, next()
+    // overwrites the window with fresh data, so attempt refill before
+    // reporting end-of-stream.
+    next(false);
+    if (ranges_.empty() || ranges_[0].position == ranges_[0].size) {
+      return std::string_view(nullptr, 0);
+    }
+  }
+  VELOX_DCHECK(ranges_[0].size > 0);
+  const int32_t position = ranges_[0].position;
+  const int64_t viewSize = std::min<int64_t>(ranges_[0].size - ranges_[0].position, size);
+  ranges_[0].position += static_cast<int32_t>(viewSize);
+  return std::string_view(reinterpret_cast<char*>(ranges_[0].buffer) + position, viewSize);
+}
+
+std::streampos VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::tellp() const {
+  if (ranges_.empty()) {
+    return 0;
+  }
+  return static_cast<std::streampos>(
+      static_cast<int64_t>(totalBytesRead_) - (ranges_[0].size - ranges_[0].position));
+}
+
+void VeloxRssSortShuffleReaderDeserializer::VeloxInputStream::seekp(std::streampos position) {
+  if (ranges_.empty() && position == 0) {
+    return;
+  }
+  VELOX_CHECK(!ranges_.empty(), "Cannot seek an empty VeloxInputStream");
+  const int64_t windowStart = static_cast<int64_t>(totalBytesRead_) - ranges_[0].size;
+  const int64_t windowEnd = static_cast<int64_t>(totalBytesRead_);
+  const int64_t target = static_cast<int64_t>(position);
+  VELOX_CHECK(
+      target >= windowStart && target <= windowEnd,
+      "VeloxInputStream::seekp({}) is outside the resident window [{}, {}): bytes before the "
+      "window were already consumed from the underlying stream (totalBytesRead={})",
+      target,
+      windowStart,
+      windowEnd,
+      totalBytesRead_);
+  ranges_[0].position = static_cast<int32_t>(target - windowStart);
+}
+
+RowVectorPtr VeloxRssSortShuffleReaderDeserializer::readPage() {
+  constexpr int32_t kPrestoHeaderSize = PrestoPageHeader::kSize;
+
+  // Fast path: peek the header without consuming; if the whole page fits in
+  // the current window, deserialize in-situ from in_ directly.
+  if (in_->remainingInWindow() >= kPrestoHeaderSize) {
+    const auto peekedHeader = PrestoPageHeader::read(in_->data());
+    if (peekedHeader.numRows >= 0) {
+      const int32_t payloadSize = peekedHeader.isCompressed() ? peekedHeader.compressedSize
+                                                              : peekedHeader.uncompressedSize;
+      const int64_t totalSize = kPrestoHeaderSize + static_cast<int64_t>(payloadSize);
+      if (payloadSize >= 0 && totalSize <= in_->remainingInWindow()) {
+        RowVectorPtr rowVector;
+        VectorStreamGroup::read(
+            in_.get(),
+            memoryManager_->getLeafMemoryPool().get(),
+            rowType_,
+            serde_,
+            &rowVector,
+            &serdeOptions_);
+        return rowVector;
+      }
+    }
+  }
+
+  // Slow path: the page spans multiple read windows. Reassemble it into a
+  // contiguous BufferInputStream so the serde's backward seek never touches
+  // window data overwritten by a refill.
+  std::array<uint8_t, kPrestoHeaderSize> headerStorage;
+  in_->readBytes(headerStorage.data(), kPrestoHeaderSize);
+  const auto header = PrestoPageHeader::read(headerStorage.data());
+  VELOX_CHECK_GE(header.numRows, 0, "Invalid Presto page row count: {}", header.numRows);
+
+  const int32_t payloadSize = header.isCompressed() ? header.compressedSize : header.uncompressedSize;
+  VELOX_CHECK_GE(payloadSize, 0, "Invalid Presto page payload size: {}", payloadSize);
+
+  // Payload is still in the window: stitch [copied header, in-situ payload].
+  if (payloadSize <= in_->remainingInWindow()) {
+    in_->advance(payloadSize);
+    BufferInputStream pageStream(std::vector<ByteRange>{
+        ByteRange{headerStorage.data(), kPrestoHeaderSize, 0},
+        ByteRange{in_->data() - payloadSize, payloadSize, 0}});
+    RowVectorPtr rowVector;
+    VectorStreamGroup::read(
+        &pageStream, memoryManager_->getLeafMemoryPool().get(), rowType_, serde_, &rowVector, &serdeOptions_);
+    return rowVector;
+  }
+
+  // Payload spans windows: copy it into a contiguous buffer.
+  auto payloadBuffer = AlignedBuffer::allocate<char>(payloadSize, memoryManager_->getLeafMemoryPool().get());
+  in_->readBytes(payloadBuffer->asMutable<uint8_t>(), payloadSize);
+  BufferInputStream pageStream(std::vector<ByteRange>{
+      ByteRange{headerStorage.data(), kPrestoHeaderSize, 0},
+      ByteRange{payloadBuffer->asMutable<uint8_t>(), payloadSize, 0}});
+  RowVectorPtr rowVector;
+  VectorStreamGroup::read(
+      &pageStream, memoryManager_->getLeafMemoryPool().get(), rowType_, serde_, &rowVector, &serdeOptions_);
+  return rowVector;
 }
 
 VeloxShuffleReader::VeloxShuffleReader(

--- a/cpp/velox/shuffle/VeloxShuffleReader.h
+++ b/cpp/velox/shuffle/VeloxShuffleReader.h
@@ -180,6 +180,8 @@ class VeloxRssSortShuffleReaderDeserializer : public ShuffleReaderDeserializer {
 
   void loadNextStream();
 
+  facebook::velox::RowVectorPtr readPage();
+
   std::shared_ptr<StreamReader> streamReader_;
   VeloxMemoryManager* memoryManager_;
   facebook::velox::RowTypePtr rowType_;

--- a/cpp/velox/tests/CMakeLists.txt
+++ b/cpp/velox/tests/CMakeLists.txt
@@ -99,6 +99,8 @@ set(VELOX_TEST_COMMON_SRCS JsonToProtoConverter.cc FilePathGenerator.cc)
 
 add_velox_test(velox_shuffle_writer_test SOURCES VeloxShuffleWriterTest.cc)
 
+add_velox_test(velox_shuffle_reader_test SOURCES VeloxShuffleReaderTest.cc)
+
 add_velox_test(velox_hash_shuffle_writer_input_encoding_test SOURCES
                VeloxHashShuffleWriterInputEncodingTest.cc)
 

--- a/cpp/velox/tests/VeloxShuffleReaderTest.cc
+++ b/cpp/velox/tests/VeloxShuffleReaderTest.cc
@@ -40,6 +40,8 @@
 
 #include <arrow/buffer.h>
 #include <arrow/io/interfaces.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
 
 #include <cstdint>
 #include <cstring>
@@ -120,6 +122,14 @@ class FakeInputStream final : public arrow::io::InputStream {
           " consecutive calls");
     }
     return toRead; // 0 == EOS when payload exhausted
+  }
+
+  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes));
+    ARROW_ASSIGN_OR_RAISE(int64_t bytesRead, Read(nbytes, buffer->mutable_data()));
+    ARROW_RETURN_NOT_OK(buffer->Resize(bytesRead, false));
+    buffer->ZeroPadding();
+    return std::move(buffer);
   }
 
  private:

--- a/cpp/velox/tests/VeloxShuffleReaderTest.cc
+++ b/cpp/velox/tests/VeloxShuffleReaderTest.cc
@@ -1,0 +1,391 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression tests for the rss_sort shuffle reader, driven through the
+// public VeloxRssSortShuffleReaderDeserializer API via controllable fake
+// arrow::io::InputStreams.
+//
+// Covers:
+// - graceful EOS on an empty stream (e.g. an empty Celeborn partition);
+// - EOS hit mid-page on a truncated compressed page;
+// - a buggy upstream whose Read() returns a negative byte count;
+// - uncompressed Presto pages spanning multiple read windows (nested struct
+//   pre-scan, header crossing a refill boundary, checksummed pages) and the
+//   single-window zero-copy fast path.
+//
+// NOTE on the two bug-probe cases (EosMidPageTerminates, NegativeReadThrows):
+// on code where VeloxInputStream::next() ignores its throwIfPastEnd argument
+// and silently returns on EOS, the mid-page case enters the readBytes for(;;)
+// loop that never exits. FakeInputStream counts consecutive EOS reads and
+// throws after kMaxConsecutiveEosReads so the loop is cut short in
+// milliseconds instead of hanging until the test timeout; the assertion then
+// fails on the message mismatch and surfaces "possible infinite loop" as the
+// actual exception. Both cases turn green once the EOS handling fix lands.
+
+#include <gtest/gtest.h>
+
+#include <arrow/buffer.h>
+#include <arrow/io/interfaces.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+#include "compute/VeloxBackend.h"
+#include "memory/VeloxColumnarBatch.h"
+#include "memory/VeloxMemoryManager.h"
+#include "shuffle/GlutenByteStream.h"
+#include "shuffle/VeloxShuffleReader.h"
+#include "tests/utils/TestStreamReader.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/type/Type.h"
+#include "velox/vector/VectorStream.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace gluten {
+
+namespace {
+// A minimal arrow::io::InputStream backed by a fixed in-memory payload. Once
+// the payload is exhausted, Read returns 0 (EOS). With `negativeRead`, Read
+// always returns -1 instead, modeling a buggy upstream that reports EOF as a
+// negative byte count. With `firstReadLimit` >= 0, only the FIRST Read is
+// capped to that many bytes (subsequent reads are unbounded), modeling an
+// upstream (e.g. a network stream) whose first chunk ends mid-page.
+//
+// To keep a possible reader-side infinite loop (readBytes -> next() -> EOS ->
+// silently return -> spin) from hanging the test until the CI timeout, Read
+// throws after kMaxConsecutiveEosReads consecutive EOS returns. Well-behaved
+// readers probe EOS only a couple of times, so the cap never trips for them.
+class FakeInputStream final : public arrow::io::InputStream {
+ public:
+  explicit FakeInputStream(
+      std::vector<uint8_t> payload = {},
+      bool negativeRead = false,
+      int64_t firstReadLimit = -1)
+      : payload_(std::move(payload)),
+        negativeRead_(negativeRead),
+        firstReadLimit_(firstReadLimit) {}
+
+  arrow::Status Close() override {
+    closed_ = true;
+    return arrow::Status::OK();
+  }
+  arrow::Result<int64_t> Tell() const override {
+    return pos_;
+  }
+  bool closed() const override {
+    return closed_;
+  }
+
+  arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
+    if (negativeRead_) {
+      return static_cast<int64_t>(-1);
+    }
+    int64_t toRead = std::min<int64_t>(nbytes, static_cast<int64_t>(payload_.size()) - pos_);
+    if (firstRead_ && firstReadLimit_ >= 0) {
+      toRead = std::min<int64_t>(toRead, firstReadLimit_);
+      firstRead_ = false;
+    }
+    if (toRead > 0) {
+      std::memcpy(out, payload_.data() + pos_, toRead);
+      pos_ += toRead;
+      consecutiveEosReads_ = 0;
+    } else if (++consecutiveEosReads_ > kMaxConsecutiveEosReads) {
+      // Throw a plain C++ exception: the reader wraps Read() in
+      // arrow::Result and drops arrow errors via .ValueOr(0), so an
+      // arrow::Status::IOError would be swallowed and the loop would spin on.
+      throw std::runtime_error(
+          "possible infinite loop: Read() returned 0 for " + std::to_string(kMaxConsecutiveEosReads) +
+          " consecutive calls");
+    }
+    return toRead; // 0 == EOS when payload exhausted
+  }
+
+ private:
+  static constexpr int32_t kMaxConsecutiveEosReads = 100;
+
+  std::vector<uint8_t> payload_;
+  int64_t pos_{0};
+  bool negativeRead_{false};
+  int64_t firstReadLimit_{-1};
+  bool firstRead_{true};
+  int32_t consecutiveEosReads_{0};
+  bool closed_{false};
+};
+
+// Append a little-endian POD value to `out` (Presto page header fields are
+// machine byte order / little-endian on x86).
+template <typename T>
+void appendLe(std::vector<uint8_t>& out, T value) {
+  T v = value;
+  const auto* p = reinterpret_cast<const uint8_t*>(&v);
+  out.insert(out.end(), p, p + sizeof(T));
+}
+
+// Build a truncated Presto compressed page: a valid 21-byte header declaring
+// compressedSize bytes of body, but only `bodyBytes` bytes follow. The
+// reader's compressed branch calls source->readBytes(buf, compressedSize);
+// when EOS is hit mid-drain, GlutenByteInputStream::readBytes loops to
+// next(true) which must VELOX_FAIL instead of spinning.
+//
+// Header layout (PrestoHeader.cpp): numRows:int32, pageCodecMarker:int8,
+// uncompressedSize:int32, compressedSize:int32, checksum:int64 == 21 bytes.
+// pageCodecMarker = kCompressedBitMask (1), no checksum bit -> actualCheckSum
+// stays 0 and matches header.checksum = 0 (PrestoSerializer.cpp:159).
+std::vector<uint8_t> buildTruncatedCompressedPage(int32_t compressedSize, int32_t bodyBytes) {
+  std::vector<uint8_t> out;
+  out.reserve(21 + bodyBytes);
+  appendLe<int32_t>(out, /*numRows=*/1);
+  appendLe<int8_t>(out, /*pageCodecMarker=*/1); // kCompressedBitMask, no checksum
+  appendLe<int32_t>(out, /*uncompressedSize=*/compressedSize + 64);
+  appendLe<int32_t>(out, compressedSize);
+  appendLe<int64_t>(out, /*checksum=*/0);
+  for (int i = 0; i < bodyBytes; ++i) {
+    out.push_back(static_cast<uint8_t>(i & 0xFF));
+  }
+  return out;
+}
+} // namespace
+
+class VeloxShuffleReaderTest : public ::testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    VeloxBackend::create(AllocationListener::noop(), {});
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  static void TearDownTestSuite() {
+    VeloxBackend::get()->tearDown();
+  }
+
+  std::shared_ptr<VeloxRssSortShuffleReaderDeserializer> makeDeserializer(
+      std::shared_ptr<arrow::io::InputStream> in,
+      const RowTypePtr& rowType = ROW({"c0"}, {INTEGER()})) {
+    int64_t deserializeTime = 0;
+    return std::make_shared<VeloxRssSortShuffleReaderDeserializer>(
+        std::make_shared<TestStreamReader>(std::move(in)),
+        getDefaultMemoryManager(),
+        rowType,
+        /*batchSize=*/1024,
+        common::CompressionKind_NONE,
+        deserializeTime);
+  }
+
+  // Serializes `rowVector` into a single uncompressed Presto page
+  // (21-byte header + payload), the exact wire format the rss-sort writer
+  // produces. With `withChecksum`, a PrestoOutputStreamListener is attached so
+  // the writer fills in the checksum bit and CRC (same mechanism as
+  // VeloxHashShuffleWriter's complex-type flush). NOTE: must not use
+  // gluten::BufferOutputStream here — its write() ignores the listener.
+  std::vector<uint8_t> serializePage(const RowVectorPtr& rowVector, bool withChecksum = false) {
+    serializer::presto::PrestoVectorSerde::PrestoOptions options;
+    options.compressionKind = common::CompressionKind_NONE;
+    auto serde = std::make_unique<serializer::presto::PrestoVectorSerde>();
+    VectorStreamGroup group(pool(), serde.get());
+    group.createStreamTree(asRowType(rowVector->type()), rowVector->size(), &options);
+    group.append(rowVector);
+    serializer::presto::PrestoOutputStreamListener listener;
+    std::stringstream out;
+    facebook::velox::OStreamOutputStream os(&out, withChecksum ? &listener : nullptr);
+    group.flush(&os);
+    const auto str = out.str();
+    return std::vector<uint8_t>(str.begin(), str.end());
+  }
+
+  // ROW<c0: ARRAY<ROW<a: INTEGER>>> with `numArrays` arrays of
+  // `elementsPerArray` dense elements each. The nested struct triggers the
+  // Presto serde's pre-scan (tellp -> scan page -> seekp back).
+  RowVectorPtr makeNestedArraysRowVector(vector_size_t numArrays, vector_size_t elementsPerArray) {
+    const vector_size_t numElements = numArrays * elementsPerArray;
+    auto offsets = AlignedBuffer::allocate<vector_size_t>(numArrays, pool());
+    auto sizes = AlignedBuffer::allocate<vector_size_t>(numArrays, pool());
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < numArrays; ++i) {
+      rawOffsets[i] = i * elementsPerArray;
+      rawSizes[i] = elementsPerArray;
+    }
+    auto elements = makeRowVector({makeFlatVector<int32_t>(
+        numElements, [](vector_size_t row) { return row % 1024; })});
+    auto arrayVector = std::make_shared<ArrayVector>(
+        pool(),
+        ARRAY(ROW({"a"}, {INTEGER()})),
+        BufferPtr(nullptr),
+        numArrays,
+        offsets,
+        sizes,
+        elements);
+    return makeRowVector({arrayVector});
+  }
+};
+
+// Empty stream (e.g. an empty Celeborn partition): construction must NOT
+// throw; next() returns nullptr (graceful EOS).
+TEST_F(VeloxShuffleReaderTest, EmptyStreamGracefulEos) {
+  auto deserializer = makeDeserializer(std::make_shared<FakeInputStream>());
+  EXPECT_EQ(deserializer->next(), nullptr);
+}
+
+// Truncated compressed page: header reads fine and construction succeeds,
+// but next() drives PrestoVectorSerde::deserialize's compressed branch ->
+// readBytes(compressedSize) -> next(true) on EOS -> VELOX_FAIL. Pre-fix this
+// is the documented infinite loop; post-fix it throws. See the file header
+// note for how FakeInputStream cuts the pre-fix loop short.
+TEST_F(VeloxShuffleReaderTest, EosMidPageTerminates) {
+  auto payload = buildTruncatedCompressedPage(/*compressedSize=*/1000, /*bodyBytes=*/8);
+  auto deserializer = makeDeserializer(std::make_shared<FakeInputStream>(std::move(payload)));
+
+  VELOX_ASSERT_THROW(
+      deserializer->next(), "Reading past end of VeloxRssSortShuffleReaderDeserializer::VeloxInputStream");
+}
+
+// A buggy upstream whose Read returns a negative byte count. Without a
+// signed-result guard the negative value would implicitly convert to a huge
+// uint64_t offset_ and corrupt setRange / loop forever. With the guard it
+// fails fast during the probe-read.
+TEST_F(VeloxShuffleReaderTest, NegativeReadThrows) {
+  auto deserializer = makeDeserializer(
+      std::make_shared<FakeInputStream>(std::vector<uint8_t>{}, /*negativeRead=*/true));
+  VELOX_ASSERT_THROW(deserializer->next(), "Read returned negative value");
+}
+
+// EOS bug regression: uncompressed + nested struct + page spanning multiple
+// read windows is the exact combination that reproduced the original failure
+// (corrupted data / spurious "Reading past end" EOS). With the fix the page
+// deserializes correctly.
+TEST_F(VeloxShuffleReaderTest, UncompressedNestedStructPageSpansWindows) {
+  constexpr vector_size_t kNumArrays = 20000;
+  constexpr vector_size_t kElementsPerArray = 30;
+
+  auto rowVector = makeNestedArraysRowVector(kNumArrays, kElementsPerArray);
+  auto payload = serializePage(rowVector);
+  // The page must be larger than the reader's read window (~1MB) to exercise
+  // the multi-window slow path.
+  ASSERT_GT(payload.size(), 1 << 20);
+
+  auto deserializer = makeDeserializer(
+      std::make_shared<FakeInputStream>(std::move(payload)),
+      asRowType(rowVector->type()));
+  auto batch = deserializer->next();
+  ASSERT_NE(batch, nullptr);
+  auto result = VeloxColumnarBatch::from(pool(), batch)->getRowVector();
+  assertEqualVectors(rowVector, result);
+  ASSERT_EQ(deserializer->next(), nullptr);
+}
+
+// Fast path: a small page that fits in one window is deserialized in-situ
+// from the read window (zero copy).
+TEST_F(VeloxShuffleReaderTest, SingleWindowPageZeroCopy) {
+  constexpr vector_size_t kNumRows = 200;
+  auto rowVector = makeRowVector({makeFlatVector<int32_t>(
+      kNumRows, [](vector_size_t row) { return static_cast<int32_t>(row * 7); })});
+
+  auto payload = serializePage(rowVector);
+  // Small page: header + payload well under 1MB -> zero-copy fast path.
+  ASSERT_LT(payload.size(), 1 << 20);
+
+  auto deserializer = makeDeserializer(
+      std::make_shared<FakeInputStream>(std::move(payload)),
+      asRowType(rowVector->type()));
+  auto batch = deserializer->next();
+  ASSERT_NE(batch, nullptr);
+  auto result = VeloxColumnarBatch::from(pool(), batch)->getRowVector();
+  assertEqualVectors(rowVector, result);
+  ASSERT_EQ(deserializer->next(), nullptr);
+}
+
+// Base-class contract: nextView returns a view truncated at the current
+// range's end and advances to the next range; 0 size means end-of-stream.
+TEST_F(VeloxShuffleReaderTest, BaseByteStreamNextViewAcrossRanges) {
+  uint8_t range1[] = {1, 2, 3};
+  uint8_t range2[] = {4, 5, 6, 7};
+  GlutenByteInputStream stream(std::vector<ByteRange>{
+      ByteRange{range1, 3, 0}, ByteRange{range2, 4, 0}});
+
+  auto view1 = stream.nextView(10);
+  EXPECT_EQ(view1.size(), 3);
+  EXPECT_EQ(view1.front(), 1);
+
+  auto view2 = stream.nextView(10);
+  EXPECT_EQ(view2.size(), 4);
+  EXPECT_EQ(view2.front(), 4);
+
+  // All ranges consumed: nextView reports end-of-stream without throwing.
+  auto view3 = stream.nextView(10);
+  EXPECT_EQ(view3.size(), 0);
+}
+
+// Slow path 2: the page header crosses a refill boundary. readPage() copies
+// the header out (readBytes refills mid-header) and stitches it with the
+// in-situ payload into a contiguous stream before deserializing.
+TEST_F(VeloxShuffleReaderTest, HeaderCrossesRefillBoundary) {
+  constexpr vector_size_t kArraysA = 1024;
+  constexpr vector_size_t kArraysB = 100;
+  constexpr vector_size_t kElementsPerArray = 30;
+
+  auto rowVectorA = makeNestedArraysRowVector(kArraysA, kElementsPerArray);
+  auto rowVectorB = makeNestedArraysRowVector(kArraysB, kElementsPerArray);
+  auto pageA = serializePage(rowVectorA);
+  auto pageB = serializePage(rowVectorB);
+
+  std::vector<uint8_t> payload = pageA;
+  payload.insert(payload.end(), pageB.begin(), pageB.end());
+  // First window holds all of A plus only 10 bytes of B's header.
+  const int64_t firstReadLimit = static_cast<int64_t>(pageA.size()) + 10;
+
+  auto deserializer = makeDeserializer(
+      std::make_shared<FakeInputStream>(std::move(payload), /*negativeRead=*/false, firstReadLimit),
+      asRowType(rowVectorA->type()));
+
+  // Page A fits the window -> zero-copy fast path.
+  auto batchA = deserializer->next();
+  ASSERT_NE(batchA, nullptr);
+  assertEqualVectors(rowVectorA, VeloxColumnarBatch::from(pool(), batchA)->getRowVector());
+
+  // Page B's header crossed the refill boundary -> stitched mid path.
+  auto batchB = deserializer->next();
+  ASSERT_NE(batchB, nullptr);
+  assertEqualVectors(rowVectorB, VeloxColumnarBatch::from(pool(), batchB)->getRowVector());
+
+  ASSERT_EQ(deserializer->next(), nullptr);
+}
+
+// Checksummed page: the serde scans the payload via nextView() and seeks
+// back to verify the CRC before deserializing.
+TEST_F(VeloxShuffleReaderTest, PageDeserializesWithChecksum) {
+  auto rowVector = makeRowVector({makeFlatVector<int32_t>(
+      200, [](vector_size_t row) { return static_cast<int32_t>(row * 7); })});
+  auto payload = serializePage(rowVector, /*withChecksum=*/true);
+
+  auto deserializer = makeDeserializer(
+      std::make_shared<FakeInputStream>(std::move(payload)),
+      asRowType(rowVector->type()));
+  auto batch = deserializer->next();
+  ASSERT_NE(batch, nullptr);
+  auto result = VeloxColumnarBatch::from(pool(), batch)->getRowVector();
+  assertEqualVectors(rowVector, result);
+  ASSERT_EQ(deserializer->next(), nullptr);
+}
+
+} // namespace gluten

--- a/cpp/velox/tests/VeloxShuffleReaderTest.cc
+++ b/cpp/velox/tests/VeloxShuffleReaderTest.cc
@@ -166,11 +166,11 @@ void appendLe(std::vector<uint8_t>& out, T value) {
 std::vector<uint8_t> buildTruncatedCompressedPage(int32_t compressedSize, int32_t bodyBytes) {
   std::vector<uint8_t> out;
   out.reserve(21 + bodyBytes);
-  appendLe<int32_t>(out, /*numRows=*/1);
-  appendLe<int8_t>(out, /*pageCodecMarker=*/1); // kCompressedBitMask, no checksum
-  appendLe<int32_t>(out, /*uncompressedSize=*/compressedSize + 64);
+  appendLe<int32_t>(out, 1); // numRows
+  appendLe<int8_t>(out, 1); // pageCodecMarker = kCompressedBitMask, no checksum
+  appendLe<int32_t>(out, compressedSize + 64); // uncompressedSize
   appendLe<int32_t>(out, compressedSize);
-  appendLe<int64_t>(out, /*checksum=*/0);
+  appendLe<int64_t>(out, 0); // checksum
   for (int i = 0; i < bodyBytes; ++i) {
     out.push_back(static_cast<uint8_t>(i & 0xFF));
   }
@@ -190,11 +190,11 @@ class VeloxShuffleReaderTest : public ::testing::Test, public test::VectorTestBa
   }
 
   std::shared_ptr<VeloxRssSortShuffleReaderDeserializer> makeDeserializer(
-      std::shared_ptr<arrow::io::InputStream> in,
+      const std::shared_ptr<arrow::io::InputStream>& in,
       const RowTypePtr& rowType = ROW({"c0"}, {INTEGER()})) {
     int64_t deserializeTime = 0;
     return std::make_shared<VeloxRssSortShuffleReaderDeserializer>(
-        std::make_shared<TestStreamReader>(std::move(in)),
+        std::make_shared<TestStreamReader>(in),
         getDefaultMemoryManager(),
         rowType,
         /*batchSize=*/1024,


### PR DESCRIPTION
## What Changes

Follow-up to #12986, which fixed the mid-page EOS handling of `VeloxRssSortShuffleReaderDeserializer`. This PR fixes the second bug from #12985 that still remains on main:

**Multi-window page corruption.** `VeloxInputStream` is a single-window refill stream — each `next()` overwrites the sole `ByteRange` — but the Presto serde assumes stable multi-range data (`tellp` → pre-scan → `seekp` back for nested types, `nextView` over the payload for checksum verification). When an uncompressed page spans multiple read windows, the serde's backward seek reads window data already overwritten by a refill, corrupting the stream (production symptom: `Invalid serialized string size`).

### Fix

- `VeloxInputStream` now overrides `nextView` (refills the window instead of reporting EOS at a range boundary) and `tellp`/`seekp` (window-bounded; fail fast instead of reading overwritten data).
- The deserializer gained `readPage()`:
  - **fast path** — peeks the 21-byte Presto page header (via velox's `serializer::presto::detail::PrestoHeader`) without consuming; if the whole page fits in the current window, deserializes in-situ (zero copy);
  - **slow path** — reassembles cross-window pages (copied header stitched with the in-situ payload, or a fully-copied payload) into a contiguous `BufferInputStream` so serde seeks never touch refill-overwritten data.
- `GlutenByteInputStream::nextView` is made virtual for the override.

## Why the Changes Are Needed

Production rss_sort + hash partitioning jobs failed with `Invalid serialized string size` when a Presto page crossed the ~1MB read-window boundary. See #12985.

## How the Changes Were Tested
UT

## Was this patch authored or co-authored using generative AI tooling?
Co-Authored-By: Claude