### PR TITLE
[MINOR][DOC] Fix Bolt quick start build link

### DIFF
--- a/docs/bolt-quick-start.md
+++ b/docs/bolt-quick-start.md
@@ -23,7 +23,7 @@ Before you begin, ensure you have the following:
 
 > **Note**:
 > This guide does not restate the full build process. If you need to build from scratch, please refer to the Gluten repository's migration and build documents:
-> - [Bolt Backend (Prerequisites & Build)](gluten/README.md#bolt-backend)
+> - [Bolt Backend (Prerequisites & Build)](../README.md#bolt-backend)
 > - [Guide to Migrating from Velox to Bolt Backend in Gluten](gluten/docs/migrate-velox-to-bolt.md)
 
 ---


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix the Bolt quick-start guide link so it resolves to the repository README from the docs directory.

## How was this patch tested?

Ran the repository formatting preflight.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Copilot CLI v1.0.84-3