### PR TITLE
[DOC] Fix Bolt quick-start migration link

### DIFF
--- a/docs/bolt-quick-start.md
+++ b/docs/bolt-quick-start.md
@@ -24,7 +24,7 @@ Before you begin, ensure you have the following:
 > **Note**:
 > This guide does not restate the full build process. If you need to build from scratch, please refer to the Gluten repository's migration and build documents:
 > - [Bolt Backend (Prerequisites & Build)](gluten/README.md#bolt-backend)
-> - [Guide to Migrating from Velox to Bolt Backend in Gluten](gluten/docs/migrate-velox-to-bolt.md)
+> - [Guide to Migrating from Velox to Bolt Backend in Gluten](velox-to-bolt-migration-guide.md)
 
 ---
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update the Bolt quick-start guide to link to the migration document at its current location. The previous relative path pointed to a file that does not exist.

## How was this patch tested?

Confirmed that `docs/velox-to-bolt-migration-guide.md` exists, the old target is absent, and ran `preflight-format.sh` successfully.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI 1.0.84-4.