### PR TITLE
[GLUTEN-12998][BOLT] Fix backends-bolt compilation after the Spark shims cleanup

### DIFF
--- a/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltBackend.scala
+++ b/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltBackend.scala
@@ -25,7 +25,6 @@ import org.apache.gluten.execution.WriteFilesExecTransformer
 import org.apache.gluten.expression.WindowFunctionsBuilder
 import org.apache.gluten.extension.columnar.cost.{LegacyCoster, LongCoster, RoughCoster}
 import org.apache.gluten.extension.columnar.transition.{Convention, ConventionFunc}
-import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.rel.LocalFilesNode
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat.{DwrfReadFormat, OrcReadFormat, ParquetReadFormat}
@@ -40,8 +39,7 @@ import org.apache.spark.sql.connector.read.Scan
 import org.apache.spark.sql.execution.{ColumnarCachedBatchSerializer, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
-import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand
-import org.apache.spark.sql.execution.datasources.{FileFormat, InsertIntoHadoopFsRelationCommand}
+import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetOptions}
 import org.apache.spark.sql.hive.execution.HiveFileFormat
 import org.apache.spark.sql.internal.SQLConf
@@ -537,12 +535,6 @@ object BoltBackendSettings extends BackendSettingsApi {
 
   override def insertPostProjectForGenerate(): Boolean = true
 
-  override def skipNativeCtas(ctas: CreateDataSourceTableAsSelectCommand): Boolean = true
-
-  override def skipNativeInsertInto(insertInto: InsertIntoHadoopFsRelationCommand): Boolean = {
-    insertInto.bucketSpec.nonEmpty
-  }
-
   override def alwaysFailOnMapExpression(): Boolean = true
 
   override def requiredChildOrderingForWindowGroupLimit(): Boolean = false
@@ -550,9 +542,7 @@ object BoltBackendSettings extends BackendSettingsApi {
   override def staticPartitionWriteOnly(): Boolean = true
 
   override def enableNativeWriteFiles(): Boolean = {
-    GlutenConfig.get.enableNativeWriter.getOrElse(
-      SparkShimLoader.getSparkShims.enableNativeWriteFilesByDefault()
-    )
+    GlutenConfig.get.enableNativeWriter.getOrElse(true)
   }
 
   override def shouldRewriteCount(): Boolean = {

--- a/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltIteratorApi.scala
+++ b/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltIteratorApi.scala
@@ -26,6 +26,7 @@ import org.apache.gluten.sql.shims.SparkShimLoader
 import org.apache.gluten.substrait.plan.PlanNode
 import org.apache.gluten.substrait.rel.{LocalFilesBuilder, LocalFilesNode, SplitInfo}
 import org.apache.gluten.substrait.rel.LocalFilesNode.ReadFileFormat
+import org.apache.gluten.utils.FileMetadataUtil
 import org.apache.gluten.vectorized._
 
 import org.apache.spark.{Partition, SparkConf, TaskContext}
@@ -114,8 +115,7 @@ class BoltIteratorApi extends IteratorApi with Logging {
     val (fileSizes, modificationTimes) = getFileInfo(partitionFiles).unzip
     val partitionColumns = getPartitionColumns(partitionSchema, partitionFiles)
     val metadataColumns = partitionFiles
-      .map(
-        f => SparkShimLoader.getSparkShims.generateMetadataColumns(f, metadataColumnNames).asJava)
+      .map(f => FileMetadataUtil.generateMetadataColumns(f, metadataColumnNames).asJava)
     val otherMetadataColumns = partitionFiles
       .map(f => SparkShimLoader.getSparkShims.getOtherConstantMetadataColumnValues(f))
     setFileSchemaForLocalFiles(

--- a/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltListenerApi.scala
+++ b/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltListenerApi.scala
@@ -39,7 +39,6 @@ import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.shuffle.{ColumnarShuffleDependency, LookupKey, ShuffleManagerRegistry}
 import org.apache.spark.shuffle.sort.ColumnarShuffleManager
 import org.apache.spark.sql.execution.ColumnarCachedBatchSerializer
-import org.apache.spark.sql.execution.datasources.GlutenWriterColumnarRules
 import org.apache.spark.sql.execution.datasources.bolt.{BoltParquetWriterInjects, BoltRowSplitter}
 import org.apache.spark.sql.expression.UDFResolver
 import org.apache.spark.sql.internal.{GlutenConfigUtil, StaticSQLConf}
@@ -231,8 +230,6 @@ class BoltListenerApi extends ListenerApi with Logging {
 
     // Inject backend-specific implementations to override spark classes.
     GlutenFormatFactory.register(new BoltParquetWriterInjects)
-    GlutenFormatFactory.injectPostRuleFactory(
-      session => GlutenWriterColumnarRules.NativeWritePostRule(session))
     GlutenFormatFactory.register(new BoltRowSplitter())
   }
 

--- a/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltRuleApi.scala
+++ b/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltRuleApi.scala
@@ -126,9 +126,6 @@ object BoltRuleApi {
 
     // Gluten columnar: Post rules.
     injector.injectPost(c => RemoveTopmostColumnarToRow(c.session, c.caller.isAqe()))
-    SparkShimLoader.getSparkShims
-      .getExtendedColumnarPostRules()
-      .foreach(each => injector.injectPost(c => each(c.session)))
     injector.injectPost(c => ColumnarCollapseTransformStages(new GlutenConfig(c.sqlConf)))
     injector.injectPost(c => CudfNodeValidationRule(new GlutenConfig(c.sqlConf)))
 

--- a/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltSparkPlanExecApi.scala
+++ b/backends-bolt/src/main/scala/org/apache/gluten/backendsapi/bolt/BoltSparkPlanExecApi.scala
@@ -144,7 +144,7 @@ class BoltSparkPlanExecApi extends SparkPlanExecApi {
       right: ExpressionTransformer,
       original: Expression,
       checkArithmeticExprName: String): ExpressionTransformer = {
-    if (SparkShimLoader.getSparkShims.withTryEvalMode(original)) {
+    if (ExpressionUtils.withTryEvalMode(original)) {
       original.dataType match {
         case LongType | IntegerType | ShortType | ByteType =>
         case _ =>
@@ -155,7 +155,7 @@ class BoltSparkPlanExecApi extends SparkPlanExecApi {
         ExpressionMappings.expressionsMap(classOf[TryEval]),
         Seq(GenericExpressionTransformer(checkArithmeticExprName, Seq(left, right), original)),
         original)
-    } else if (SparkShimLoader.getSparkShims.withAnsiEvalMode(original)) {
+    } else if (ExpressionUtils.withAnsiEvalMode(original)) {
       GenericExpressionTransformer(checkArithmeticExprName, Seq(left, right), original)
     } else {
       GenericExpressionTransformer(substraitExprName, Seq(left, right), original)
@@ -920,7 +920,7 @@ class BoltSparkPlanExecApi extends SparkPlanExecApi {
       substraitExprName: String,
       child: ExpressionTransformer,
       expr: UnBase64): ExpressionTransformer = {
-    if (SparkShimLoader.getSparkShims.unBase64FunctionFailsOnError(expr)) {
+    if (expr.failOnError) {
       GlutenExceptionUtil
         .throwsNotFullySupported(
           ExpressionNames.UNBASE64,
@@ -1135,7 +1135,6 @@ class BoltSparkPlanExecApi extends SparkPlanExecApi {
       left: ExpressionTransformer,
       right: ExpressionTransformer,
       original: Expression): ExpressionTransformer = {
-    // Since spark 3.3.0
     val extract =
       SparkShimLoader.getSparkShims.extractExpressionTimestampAddUnit(original)
     if (extract.isEmpty) {
@@ -1149,13 +1148,12 @@ class BoltSparkPlanExecApi extends SparkPlanExecApi {
       left: ExpressionTransformer,
       right: ExpressionTransformer,
       original: Expression): ExpressionTransformer = {
-    // Since spark 3.3.0
-    val extract =
-      SparkShimLoader.getSparkShims.extractExpressionTimestampDiffUnit(original)
-    if (extract.isEmpty) {
-      throw new UnsupportedOperationException(s"Not support expression TimestampDiff.")
+    val unit = original match {
+      case timestampDiff: TimestampDiff => timestampDiff.unit
+      case _ =>
+        throw new UnsupportedOperationException("Not support expression TimestampDiff.")
     }
-    TimestampDiffTransformer(substraitExprName, extract.get, left, right, original)
+    TimestampDiffTransformer(substraitExprName, unit, left, right, original)
   }
 
   override def genToUnixTimestampTransformer(

--- a/backends-bolt/src/main/scala/org/apache/spark/sql/execution/datasources/bolt/BoltBlockStripes.java
+++ b/backends-bolt/src/main/scala/org/apache/spark/sql/execution/datasources/bolt/BoltBlockStripes.java
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.execution.datasources.BlockStripe;
 import org.apache.spark.sql.execution.datasources.BlockStripes;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
 
@@ -34,7 +33,7 @@ public class BoltBlockStripes extends BlockStripes {
   }
 
   @Override
-  public @NotNull Iterator<BlockStripe> iterator() {
+  public Iterator<BlockStripe> iterator() {
     return new Iterator<BlockStripe>() {
       private int index = 0;
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

`backends-bolt` does not compile on main. #12454 was merged without rebasing onto #12954, which removed 19 methods from the `SparkShims` trait, and #12981 then landed on top of it, removing the Spark-3.3-only native-write post-rule pipeline. No CI job builds the `backends-bolt` profile, so nobody noticed: `mvn test-compile -Pbackends-bolt` fails with twelve errors. This restores the build. The wider drift the failure exposed is filed separately as #12998.

Six call sites move off deleted shim methods, each to what Velox already does: `enableNativeWriteFilesByDefault()` becomes the literal `true`, `generateMetadataColumns` becomes `FileMetadataUtil.generateMetadataColumns`, `withTryEvalMode` and `withAnsiEvalMode` become `ExpressionUtils.withTryEvalMode` / `withAnsiEvalMode`, `unBase64FunctionFailsOnError(expr)` becomes `expr.failOnError`, and `extractExpressionTimestampDiffUnit` becomes an inline match on `TimestampDiff`. The two that turn into a literal or a field read were checked against the four per-version shim bodies as they stood before #12954: every one of them returned `true` and `unBase64.failOnError` respectively, so the values are the ones the shim produced on 3.4, 3.5, 4.0 and 4.1. The trait defaults they replaced (`false` in both cases) were reachable only on 3.3.

Five deletions, none of which loses behaviour. `skipNativeCtas` and `skipNativeInsertInto` no longer exist on `BackendSettingsApi` and nothing in the repo reads them, so the overrides cannot compile; the bucket restriction the second one expressed still holds on the live path, through `validateBucketSpec()` in `supportWriteFilesExec`. The `NativeWritePostRule` injection goes because that pipeline stopped being reachable when 3.3 left: since 3.4 a write is a real `WriteFilesExec` node, the only surviving user of the fake-row adaptor is the noop format's `GlutenNoopWriterRule`, and Velox has shipped native write without ever injecting the rule. The `getExtendedColumnarPostRules()` loop goes because all four shims returned an empty list, so it never iterated. `@NotNull` goes from `BoltBlockStripes.iterator()` because `org.jetbrains.annotations` is not on the main compile classpath under `-Pspark-4.1`, and the base method plus `VeloxBlockStripes.iterator()` carry no annotation either. Finally one `// Since spark 3.3.0` comment next to the changed `genTimestampDiffTransformer` is dropped, since its sibling lost the same comment here.

`extractExpressionTimestampAddUnit` deliberately stays on the shim. Unlike the Diff variant, its 4.0 and 4.1 overrides carry an extra guard that rejects a quantity above `Int.MaxValue`, and inlining would silently drop it.

Out of scope, and listed in #12998: `-Pbackends-bolt -Pdelta` still does not compile, because `BoltDeltaComponent` calls `OffloadDeltaScan()` while the case class has taken a parameter since it grew deletion-vector support. That one needs a decision about bolt rather than a mechanical copy, so it is not in this PR.

## How was this patch tested?

Compile only. Scala 2.13 throughout, since Spark 4.x publishes no 2.12 artifacts.

| profile | built |
|-|-|
| 3.4, 3.5 | `-Pbackends-bolt -Pspark-ut`, including bolt's own test sources |
| 4.0, 4.1 | `-Pbackends-bolt` |

`spotless:check` is clean. 4.0 and 4.1 leave `-Pspark-ut` off because `gluten-ut/spark40` and `gluten-ut/spark41` have no `src/test/backends-bolt` directory, which is a pre-existing gap in how bolt is wired into gluten-ut rather than anything this PR changes.

No suite ran. Bolt's native library needs Linux with GCC 10-12 or Clang 16 per `docs/bolt-quick-start.md`, so no bolt test can execute on the machine this was written on. Someone with a Linux build, or a CI job of the kind #12998 asks for, is what would exercise these paths.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-5


Related issue: #12998
