### PR TITLE
[GLUTEN-12992][CORE] Drop the now-constant ">= 3.4" test gates

### DIFF
--- a/backends-clickhouse/src-iceberg/test/scala/org/apache/gluten/execution/iceberg/ClickHouseIcebergSuite.scala
+++ b/backends-clickhouse/src-iceberg/test/scala/org/apache/gluten/execution/iceberg/ClickHouseIcebergSuite.scala
@@ -292,9 +292,7 @@ class ClickHouseIcebergSuite extends GlutenClickHouseWholeStageTransformerSuite 
     }
   }
 
-  testWithMinSparkVersion(
-    "iceberg bucketed join partition value not exists partial cluster",
-    "3.4") {
+  test("iceberg bucketed join partition value not exists partial cluster") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -53,7 +53,7 @@ class VeloxIcebergSuite extends IcebergSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg v3 initial default for an added column", "3.4") {
+  test("iceberg v3 initial default for an added column") {
     withTable("iceberg_v3_initial_default") {
       withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
         spark.sql("""

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -310,7 +310,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
     }
   }
 
-  testWithMinSparkVersion("fallback with index based schema evolution", "3.4") {
+  test("fallback with index based schema evolution") {
     val query = "SELECT c2 FROM test"
     Seq("parquet", "orc").foreach {
       format =>

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -315,7 +315,7 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     checkLengthAndPlan(df, 5)
   }
 
-  testWithMinSparkVersion("coalesce validation", "3.4") {
+  test("coalesce validation") {
     withTempPath {
       path =>
         val data = "2019-09-09 01:02:03.456789"

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
@@ -417,7 +417,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     }
   }
 
-  testWithMinSparkVersion("regr_slope", "3.4") {
+  test("regr_slope") {
     runQueryAndCompare("""
                          |select regr_slope(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
@@ -436,7 +436,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     }
   }
 
-  testWithMinSparkVersion("regr_intercept", "3.4") {
+  test("regr_intercept") {
     runQueryAndCompare("""
                          |select regr_intercept(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
@@ -455,7 +455,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     }
   }
 
-  testWithMinSparkVersion("regr_sxy regr_sxx regr_syy", "3.4") {
+  test("regr_sxy regr_sxx regr_syy") {
     runQueryAndCompare("""
                          |select regr_sxy(l_quantity, l_tax) from lineitem;
                          |""".stripMargin) {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -461,7 +461,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion("TimestampNTZ type scan", "3.4") {
+  test("TimestampNTZ type scan") {
     withTempDir {
       dir =>
         val path = new File(dir, "ntz_data").toURI.getPath
@@ -475,9 +475,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion(
-    "Schema validation for TimestampNTZ respects enableTimestampNtzValidation",
-    "3.4") {
+  test("Schema validation for TimestampNTZ respects enableTimestampNtzValidation") {
     val ntzType = spark.sql("SELECT TIMESTAMP_NTZ'2024-01-01'").schema.head.dataType
     Seq("true", "false").foreach {
       enabled =>

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -104,7 +104,7 @@ class UDFPartialProjectSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("test plus_one in nested project lists", "3.4") {
+  test("test plus_one in nested project lists") {
     val sql = """
                 |select plus_one(col1) as col2, l_partkey from (
                 | select plus_one(l_orderkey) as col1, l_partkey from lineitem

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -569,7 +569,7 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("read as timestamp_ntz", "3.4") {
+  test("read as timestamp_ntz") {
     val inputs: Seq[String] = Seq(
       "1970-01-01",
       "1970-01-01 00:00:00-02:00",

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
@@ -81,7 +81,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function bool", "3.4") {
+  test("from_json function bool") {
     withTempPath {
       path =>
         Seq[String](
@@ -103,7 +103,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function small int", "3.4") {
+  test("from_json function small int") {
     withTempPath {
       path =>
         Seq[String](
@@ -125,7 +125,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function int", "3.4") {
+  test("from_json function int") {
     withTempPath {
       path =>
         Seq[String](
@@ -147,7 +147,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function big int", "3.4") {
+  test("from_json function big int") {
     withTempPath {
       path =>
         Seq[String](
@@ -169,7 +169,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function float", "3.4") {
+  test("from_json function float") {
     withTempPath {
       path =>
         Seq[String](
@@ -193,7 +193,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function double", "3.4") {
+  test("from_json function double") {
     withTempPath {
       path =>
         Seq[String](
@@ -217,7 +217,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function string", "3.4") {
+  test("from_json function string") {
     withTempPath {
       path =>
         Seq[String](
@@ -239,7 +239,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function array", "3.4") {
+  test("from_json function array") {
     withTempPath {
       path =>
         Seq[String](
@@ -259,7 +259,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function map", "3.4") {
+  test("from_json function map") {
     withTempPath {
       path =>
         Seq[String](
@@ -281,7 +281,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function row", "3.4") {
+  test("from_json function row") {
     withTempPath {
       path =>
         Seq[String](
@@ -321,7 +321,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function duplicate key", "3.4") {
+  test("from_json function duplicate key") {
     withTempPath {
       path =>
         Seq[String](

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
@@ -415,7 +415,7 @@ class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("width_bucket", "3.4") {
+  test("width_bucket") {
     withTempPath {
       path =>
         Seq[(Integer, Integer, Integer, Integer)](

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -652,7 +652,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
 
   // Add test suite for CharVarcharCodegenUtils functions.
   // A ProjectExecTransformer is expected to be constructed after expr support.
-  // We currently test below functions with Spark v3.4
+  // These functions are tested across all supported Spark profiles.
   test("charTypeWriteSideCheck") {
     withTable("src", "dest") {
 

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -52,7 +52,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_append - INT", "3.4") {
+  test("array_append - INT") {
     withTempPath {
       path =>
         Seq[(Array[Int], Int)](
@@ -77,7 +77,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_append - STRING", "3.4") {
+  test("array_append - STRING") {
     withTempPath {
       path =>
         Seq[(Array[String], String)](
@@ -125,7 +125,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_compact", "3.4") {
+  test("array_compact") {
     withTempPath {
       path =>
         Seq[Array[String]](
@@ -622,7 +622,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("url_decode", "3.4") {
+  test("url_decode") {
     withTempPath {
       path =>
         Seq("https%3A%2F%2Fspark.apache.org")
@@ -636,7 +636,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("url_encode", "3.4") {
+  test("url_encode") {
     withTempPath {
       path =>
         Seq("https://spark.apache.org")
@@ -653,7 +653,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
   // Add test suite for CharVarcharCodegenUtils functions.
   // A ProjectExecTransformer is expected to be constructed after expr support.
   // We currently test below functions with Spark v3.4
-  testWithMinSparkVersion("charTypeWriteSideCheck", "3.4") {
+  test("charTypeWriteSideCheck") {
     withTable("src", "dest") {
 
       sql("create table src(id string) USING PARQUET")
@@ -666,7 +666,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("varcharTypeWriteSideCheck", "3.4") {
+  test("varcharTypeWriteSideCheck") {
     withTable("src", "dest") {
 
       sql("create table src(id string) USING PARQUET")
@@ -679,7 +679,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("readSidePadding", "3.4") {
+  test("readSidePadding") {
     withTable("src", "dest") {
 
       sql("create table tgt(id char(3)) USING PARQUET")
@@ -714,7 +714,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("regexp_instr", "3.4") {
+  test("regexp_instr") {
     // Two-argument form.
     runQueryAndCompare("SELECT regexp_instr(c_comment, '\\w+') FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]
@@ -779,7 +779,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("mask", "3.4") {
+  test("mask") {
     runQueryAndCompare("SELECT mask(c_comment) FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]
     }
@@ -982,7 +982,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("get", "3.4") {
+  test("get") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -1187,7 +1187,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array insert", "3.4") {
+  test("array insert") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -1234,7 +1234,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("try_cast", "3.4") {
+  test("try_cast") {
     withTempView("try_cast_table") {
       withTempPath {
         path =>
@@ -1618,7 +1618,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("equal_null", "3.4") {
+  test("equal_null") {
     Seq[(Integer, Integer)]().toDF("a", "b")
     withTempPath {
       path =>
@@ -1679,7 +1679,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("localtimestamp with validation enabled", "3.4") {
+  test("localtimestamp with validation enabled") {
     // localtimestamp() is folded to a TimestampNTZType literal by ComputeCurrentTime. With
     // validation enabled, any Project whose output contains TimestampNTZ falls back to JVM.
     // The Project falls back at the top of the plan (above the one VeloxColumnarToRow), so
@@ -1693,7 +1693,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("localtimestamp with validation disabled", "3.4") {
+  test("localtimestamp with validation disabled") {
     // With validation disabled, scans on TimestampNTZ columns are allowed natively. For
     // localtimestamp(), the expression constant-folds to a TimestampNTZType literal in the
     // Project; Gluten only permits native Projects when NTZ appears in Hour(ntz_col), so

--- a/gluten-delta/src/test/scala/org/apache/gluten/execution/DeltaSuite.scala
+++ b/gluten-delta/src/test/scala/org/apache/gluten/execution/DeltaSuite.scala
@@ -461,7 +461,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("delta: change data feed read with deletion vectors", "3.4") {
+  test("delta: change data feed read with deletion vectors") {
     withTable("delta_cdf_dv") {
       spark.sql(s"""
                    |create table delta_cdf_dv (id int, name string) using delta
@@ -605,7 +605,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("deletion vector", "3.4") {
+  test("deletion vector") {
     withTempPath {
       p =>
         import testImplicits._
@@ -632,7 +632,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("deletion vector on partitioned table", "3.4") {
+  test("deletion vector on partitioned table") {
     withTempPath {
       p =>
         import testImplicits._
@@ -671,7 +671,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("deletion vector on shallow-cloned table", "3.4") {
+  test("deletion vector on shallow-cloned table") {
     withTable("dv_clone_source", "dv_clone_target") {
       import testImplicits._
       // Shallow clone is the case the old data-file walk-up got wrong. The clone's AddFile paths
@@ -841,9 +841,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
   }
 
   // TIMESTAMP_NTZ was introduced in Spark 3.4 / Delta 2.4
-  testWithMinSparkVersion(
-    "delta: create table with TIMESTAMP_NTZ and return correct results",
-    "3.4") {
+  test("delta: create table with TIMESTAMP_NTZ and return correct results") {
     withTable("delta_ntz") {
       spark.sql("CREATE TABLE delta_ntz(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ) USING DELTA")
       spark.sql("""INSERT INTO delta_ntz VALUES
@@ -858,9 +856,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "delta: TIMESTAMP_NTZ as partition column should fallback and return correct results",
-    "3.4") {
+  test("delta: TIMESTAMP_NTZ as partition column should fallback and return correct results") {
     withTable("delta_ntz_part") {
       spark.sql("""CREATE TABLE delta_ntz_part(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ)
                   |USING DELTA PARTITIONED BY (c3)""".stripMargin)
@@ -886,9 +882,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "delta: filter on TIMESTAMP_NTZ column should fallback and return correct results",
-    "3.4") {
+  test("delta: filter on TIMESTAMP_NTZ column should fallback and return correct results") {
     withTable("delta_ntz_filter") {
       spark.sql("CREATE TABLE delta_ntz_filter(id INT, ts TIMESTAMP_NTZ) USING DELTA")
       spark.sql("""INSERT INTO delta_ntz_filter VALUES
@@ -902,9 +896,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles struct field metadata correctly") {
     withTable("merge_struct_source", "merge_struct_target") {
       spark.sql("""
                   |CREATE TABLE merge_struct_target(
@@ -941,9 +933,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles array-of-struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles array-of-struct field metadata correctly") {
     withTable("merge_arraystruct_source", "merge_arraystruct_target") {
       spark.sql("""
                   |CREATE TABLE merge_arraystruct_target(
@@ -976,9 +966,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles map-of-struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles map-of-struct field metadata correctly") {
     withTable("merge_mapstruct_source", "merge_mapstruct_target") {
       spark.sql("""
                   |CREATE TABLE merge_mapstruct_target(
@@ -1011,9 +999,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles nested struct-within-struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles nested struct-within-struct field metadata correctly") {
     withTable("merge_nestedstruct_source", "merge_nestedstruct_target") {
       spark.sql("""
                   |CREATE TABLE merge_nestedstruct_target(
@@ -1044,9 +1030,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles array with null struct elements correctly",
-    "3.4") {
+  test("merge with column mapping handles array with null struct elements correctly") {
     withTable("merge_arraynull_source", "merge_arraynull_target") {
       spark.sql("""
                   |CREATE TABLE merge_arraynull_target(

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
@@ -85,7 +85,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join", "3.4") {
+  test("iceberg bucketed join") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -159,7 +159,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join with partition", "3.4") {
+  test("iceberg bucketed join with partition") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -233,7 +233,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join partition value not exists", "3.4") {
+  test("iceberg bucketed join partition value not exists") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -308,9 +308,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "iceberg bucketed join partition value not exists partial cluster",
-    "3.4") {
+  test("iceberg bucketed join partition value not exists partial cluster") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -385,7 +383,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join with partition filter", "3.4") {
+  test("iceberg bucketed join with partition filter") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {

--- a/gluten-substrait/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
+++ b/gluten-substrait/src/test/scala/org/apache/spark/sql/GlutenQueryTest.scala
@@ -97,27 +97,6 @@ abstract class GlutenQueryTest extends PlanTest with AdaptiveSparkPlanHelper {
     shouldRun
   }
 
-  /** Ignore the test if the current spark version is between the minVersion and maxVersion */
-  def ignoreWithSpecifiedSparkVersion(
-      testName: String,
-      minSparkVersion: Option[String] = None,
-      maxSparkVersion: Option[String] = None)(testFun: => Any): Unit = {
-    if (matchSparkVersion(minSparkVersion, maxSparkVersion)) {
-      ignore(testName) {
-        testFun
-      }
-    }
-  }
-
-  /** Run the test if the current spark version is between the minVersion and maxVersion */
-  def testWithRangeSparkVersion(testName: String, minSparkVersion: String, maxSparkVersion: String)(
-      testFun: => Any): Unit = {
-    if (matchSparkVersion(Some(minSparkVersion), Some(maxSparkVersion))) {
-      test(testName) {
-        testFun
-      }
-    }
-  }
 
   /** Run the test if the current spark version less than the maxVersion */
   def testWithMaxSparkVersion(testName: String, maxVersion: String)(testFun: => Any): Unit = {

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
@@ -94,9 +94,7 @@ class GlutenExpressionMappingSuite
     }
   }
 
-  testWithMinSparkVersion(
-    "GLUTEN-7213: Check fallback reason with CheckOverflowInTableInsert",
-    "3.4") {
+  test("GLUTEN-7213: Check fallback reason with CheckOverflowInTableInsert") {
     withTable("t1", "t2") {
       sql("create table t1 (a float) using parquet")
       sql("insert into t1 values(1.1)")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Following the removal of Spark 3.2 and Spark 3.3 support (#12902, #12981), Spark 3.4 is the lowest supported profile. Therefore, `testWithMinSparkVersion(name, "3.4")` is constant-true across all supported Spark profiles (3.4, 3.5, 4.0, 4.1).

This PR:
1. Replaces all 57 occurrences of `testWithMinSparkVersion(..., "3.4")` across 14 test suite files with direct `test(...)` calls.
2. Removes uncalled helper methods `testWithRangeSparkVersion` and `ignoreWithSpecifiedSparkVersion` in `GlutenQueryTest`.
3. Keeps all live version gates on 3.5, 4.0, and 4.1 unchanged.

Fixes #12992.

## How was this patch tested?

- Verified all 57 call sites across the 14 suites were replaced with direct `test(...)` calls.
- Verified live gates on 3.5, 4.0, and 4.1 remain intact.
- Verified 0 remaining callers or declarations of `testWithRangeSparkVersion` and `ignoreWithSpecifiedSparkVersion`.
- Verified `git diff --check` and confirmed line lengths comply with Scalafmt/Scalastyle 100-character limit.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Antigravity
