### PR TITLE
[GLUTEN-13003][TEST] Replace constant-true testWithMinSparkVersion calls with test

### DIFF
--- a/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltAggregateFunctionsSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltAggregateFunctionsSuite.scala
@@ -389,7 +389,7 @@ abstract class BoltAggregateFunctionsSuite extends BoltWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion("regr_r2", "3.3") {
+  test("regr_r2") {
     runQueryAndCompare("""
                          |select regr_r2(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
@@ -408,7 +408,7 @@ abstract class BoltAggregateFunctionsSuite extends BoltWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion("regr_slope", "3.4") {
+  test("regr_slope") {
     runQueryAndCompare("""
                          |select regr_slope(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
@@ -427,7 +427,7 @@ abstract class BoltAggregateFunctionsSuite extends BoltWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion("regr_intercept", "3.4") {
+  test("regr_intercept") {
     runQueryAndCompare("""
                          |select regr_intercept(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
@@ -446,7 +446,7 @@ abstract class BoltAggregateFunctionsSuite extends BoltWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion("regr_sxy regr_sxx regr_syy", "3.4") {
+  test("regr_sxy regr_sxx regr_syy") {
     runQueryAndCompare("""
                          |select regr_sxy(l_quantity, l_tax) from lineitem;
                          |""".stripMargin) {

--- a/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltColumnarCacheSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltColumnarCacheSuite.scala
@@ -87,7 +87,7 @@ class BoltColumnarCacheSuite extends BoltWholeStageTransformerSuite with Adaptiv
     }
   }
 
-  testWithMinSparkVersion("input row", "3.2") {
+  test("input row") {
     withTable("t") {
       sql("CREATE TABLE t USING json AS SELECT * FROM values(1, 'a', (2, 'b'), (3, 'c'))")
       runQueryAndCompare("SELECT * FROM t", cache = true) {
@@ -110,7 +110,7 @@ class BoltColumnarCacheSuite extends BoltWholeStageTransformerSuite with Adaptiv
   }
 
   // See issue https://github.com/apache/incubator-gluten/issues/8497.
-  testWithMinSparkVersion("Input fallen back vanilla Spark columnar scan", "3.3") {
+  test("Input fallen back vanilla Spark columnar scan") {
     def withId(id: Int): Metadata =
       new MetadataBuilder().putLong("parquet.field.id", id).build()
 

--- a/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltHashJoinSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltHashJoinSuite.scala
@@ -92,9 +92,7 @@ class BoltHashJoinSuite extends BoltWholeStageTransformerSuite {
 
       // The computing is combined into one single whole stage transformer.
       val wholeStages = plan.collect { case wst: WholeStageTransformer => wst }
-      if (SparkShimLoader.getSparkVersion.startsWith("3.2.")) {
-        assert(wholeStages.length == 1)
-      } else if (SparkShimLoader.getSparkVersion.startsWith("3.5.")) {
+      if (SparkShimLoader.getSparkVersion.startsWith("3.5.")) {
         assert(wholeStages.length == 5)
       } else {
         assert(wholeStages.length == 3)
@@ -107,11 +105,7 @@ class BoltHashJoinSuite extends BoltWholeStageTransformerSuite {
           case _: ShuffledHashJoinExecTransformer => 1
         }.getOrElse(0)
       }.sum
-      if (SparkShimLoader.getSparkVersion.startsWith("3.2.")) {
-        assert(countSHJ == 1)
-      } else {
-        assert(countSHJ == 2)
-      }
+      assert(countSHJ == 2)
     }
   }
 

--- a/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltHashJoinSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltHashJoinSuite.scala
@@ -74,7 +74,7 @@ class BoltHashJoinSuite extends BoltWholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("generate hash join plan - v2", "3.2") {
+  test("generate hash join plan - v2") {
     withSQLConf(
       ("spark.sql.autoBroadcastJoinThreshold", "-1"),
       ("spark.sql.adaptive.enabled", "false"),

--- a/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltStringFunctionsSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/execution/BoltStringFunctionsSuite.scala
@@ -418,7 +418,7 @@ class BoltStringFunctionsSuite extends BoltWholeStageTransformerSuite {
         s"from $LINEITEM_TABLE where l_comment rlike '%$$##@@#&&' limit $LENGTH") { _ => }
   }
 
-  testWithMinSparkVersion("ilike", "3.3") {
+  test("ilike") {
     runQueryAndCompare(
       s"select l_orderkey, l_comment, ilike(l_comment, 'a*') " +
         s"from $LINEITEM_TABLE limit $LENGTH")(checkGlutenPlan[ProjectExecTransformer])
@@ -544,7 +544,7 @@ class BoltStringFunctionsSuite extends BoltWholeStageTransformerSuite {
         s"from $LINEITEM_TABLE limit 5") { _ => }
   }
 
-  testWithMinSparkVersion("split", "3.4") {
+  test("split") {
     runQueryAndCompare(
       s"select l_orderkey, l_comment, split(l_comment, '') " +
         s"from $LINEITEM_TABLE limit 5") {

--- a/backends-bolt/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -315,7 +315,7 @@ class MiscOperatorSuite extends BoltWholeStageTransformerSuite with AdaptiveSpar
     checkLengthAndPlan(df, 5)
   }
 
-  testWithMinSparkVersion("coalesce validation", "3.4") {
+  test("coalesce validation") {
     withTempPath {
       path =>
         val data = "2019-09-09 01:02:03.456789"

--- a/backends-bolt/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -262,7 +262,7 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("timestampadd", "3.3") {
+  test("timestampadd") {
     withTempPath {
       path =>
         val ts = Timestamp.valueOf("2020-02-29 00:00:00.500")
@@ -276,7 +276,7 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("timestampdiff", "3.3") {
+  test("timestampdiff") {
     withTempPath {
       path =>
         val t1 = Timestamp.valueOf("2020-03-01 00:00:00.500")

--- a/backends-bolt/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
@@ -81,7 +81,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function bool", "3.4") {
+  test("from_json function bool") {
     withTempPath {
       path =>
         Seq[String](
@@ -103,7 +103,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function small int", "3.4") {
+  test("from_json function small int") {
     withTempPath {
       path =>
         Seq[String](
@@ -125,7 +125,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function int", "3.4") {
+  test("from_json function int") {
     withTempPath {
       path =>
         Seq[String](
@@ -147,7 +147,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function big int", "3.4") {
+  test("from_json function big int") {
     withTempPath {
       path =>
         Seq[String](
@@ -169,7 +169,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function float", "3.4") {
+  test("from_json function float") {
     withTempPath {
       path =>
         Seq[String](
@@ -193,7 +193,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function double", "3.4") {
+  test("from_json function double") {
     withTempPath {
       path =>
         Seq[String](
@@ -217,7 +217,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function string", "3.4") {
+  test("from_json function string") {
     withTempPath {
       path =>
         Seq[String](
@@ -239,7 +239,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function array", "3.4") {
+  test("from_json function array") {
     withTempPath {
       path =>
         Seq[String](
@@ -259,7 +259,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function map", "3.4") {
+  test("from_json function map") {
     withTempPath {
       path =>
         Seq[String](
@@ -281,7 +281,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function row", "3.4") {
+  test("from_json function row") {
     withTempPath {
       path =>
         Seq[String](
@@ -321,7 +321,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function duplicate key", "3.4") {
+  test("from_json function duplicate key") {
     withTempPath {
       path =>
         Seq[String](

--- a/backends-bolt/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
@@ -49,7 +49,7 @@ class MathFunctionsValidateSuiteAnsiOn extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("try_multiply", "3.3") {
+  test("try_multiply") {
     runQueryAndCompare(
       "select try_multiply(2147483647, cast(l_orderkey as int)), " +
         "try_multiply(-2147483648, cast(l_orderkey as int)) from lineitem") {
@@ -57,7 +57,7 @@ class MathFunctionsValidateSuiteAnsiOn extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("try_subtract", "3.3") {
+  test("try_subtract") {
     runQueryAndCompare(
       "select try_subtract(2147483647, cast(l_orderkey as int)), " +
         "try_subtract(-2147483648, cast(l_orderkey as int)) from lineitem") {
@@ -363,7 +363,7 @@ class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("width_bucket", "3.4") {
+  test("width_bucket") {
     withTempPath {
       path =>
         Seq[(Integer, Integer, Integer, Integer)](

--- a/backends-bolt/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-bolt/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -51,7 +51,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_append - INT", "3.4") {
+  test("array_append - INT") {
     withTempPath {
       path =>
         Seq[(Array[Int], Int)](
@@ -76,7 +76,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_append - STRING", "3.4") {
+  test("array_append - STRING") {
     withTempPath {
       path =>
         Seq[(Array[String], String)](
@@ -124,7 +124,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_compact", "3.4") {
+  test("array_compact") {
     withTempPath {
       path =>
         Seq[Array[String]](
@@ -145,7 +145,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("null input for array_size", "3.3") {
+  test("null input for array_size") {
     withTempPath {
       path =>
         Seq[Array[Int]](
@@ -321,7 +321,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("map_contains_key", "3.3") {
+  test("map_contains_key") {
     withTempPath {
       path =>
         Seq(
@@ -629,7 +629,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("url_decode", "3.4") {
+  test("url_decode") {
     withTempPath {
       path =>
         Seq("https%3A%2F%2Fspark.apache.org")
@@ -643,7 +643,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("url_encode", "3.4") {
+  test("url_encode") {
     withTempPath {
       path =>
         Seq("https://spark.apache.org")
@@ -680,7 +680,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("mask", "3.4") {
+  test("mask") {
     runQueryAndCompare("SELECT mask(c_comment) FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]
     }
@@ -883,7 +883,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("get", "3.4") {
+  test("get") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -1044,7 +1044,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array insert", "3.4") {
+  test("array insert") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -1091,7 +1091,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("try_cast", "3.4") {
+  test("try_cast") {
     withTempView("try_cast_table") {
       withTempPath {
         path =>
@@ -1475,7 +1475,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("equal_null", "3.4") {
+  test("equal_null") {
     Seq[(Integer, Integer)]().toDF("a", "b")
     withTempPath {
       path =>

--- a/backends-clickhouse/src-iceberg/test/scala/org/apache/gluten/execution/iceberg/ClickHouseIcebergSuite.scala
+++ b/backends-clickhouse/src-iceberg/test/scala/org/apache/gluten/execution/iceberg/ClickHouseIcebergSuite.scala
@@ -292,9 +292,7 @@ class ClickHouseIcebergSuite extends GlutenClickHouseWholeStageTransformerSuite 
     }
   }
 
-  testWithMinSparkVersion(
-    "iceberg bucketed join partition value not exists partial cluster",
-    "3.4") {
+  test("iceberg bucketed join partition value not exists partial cluster") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {

--- a/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
+++ b/backends-velox/src-iceberg/test/scala/org/apache/gluten/execution/VeloxIcebergSuite.scala
@@ -53,7 +53,7 @@ class VeloxIcebergSuite extends IcebergSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg v3 initial default for an added column", "3.4") {
+  test("iceberg v3 initial default for an added column") {
     withTable("iceberg_v3_initial_default") {
       withSQLConf(GlutenConfig.GLUTEN_ENABLED.key -> "false") {
         spark.sql("""

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/FallbackSuite.scala
@@ -310,7 +310,7 @@ class FallbackSuite extends VeloxWholeStageTransformerSuite with AdaptiveSparkPl
     }
   }
 
-  testWithMinSparkVersion("fallback with index based schema evolution", "3.4") {
+  test("fallback with index based schema evolution") {
     val query = "SELECT c2 FROM test"
     Seq("parquet", "orc").foreach {
       format =>

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/MiscOperatorSuite.scala
@@ -315,7 +315,7 @@ class MiscOperatorSuite extends VeloxWholeStageTransformerSuite with AdaptiveSpa
     checkLengthAndPlan(df, 5)
   }
 
-  testWithMinSparkVersion("coalesce validation", "3.4") {
+  test("coalesce validation") {
     withTempPath {
       path =>
         val data = "2019-09-09 01:02:03.456789"

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxAggregateFunctionsSuite.scala
@@ -417,7 +417,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     }
   }
 
-  testWithMinSparkVersion("regr_slope", "3.4") {
+  test("regr_slope") {
     runQueryAndCompare("""
                          |select regr_slope(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
@@ -436,7 +436,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     }
   }
 
-  testWithMinSparkVersion("regr_intercept", "3.4") {
+  test("regr_intercept") {
     runQueryAndCompare("""
                          |select regr_intercept(l_partkey, l_suppkey) from lineitem;
                          |""".stripMargin) {
@@ -455,7 +455,7 @@ abstract class VeloxAggregateFunctionsSuite extends VeloxWholeStageTransformerSu
     }
   }
 
-  testWithMinSparkVersion("regr_sxy regr_sxx regr_syy", "3.4") {
+  test("regr_sxy regr_sxx regr_syy") {
     runQueryAndCompare("""
                          |select regr_sxy(l_quantity, l_tax) from lineitem;
                          |""".stripMargin) {

--- a/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/execution/VeloxParquetDataTypeValidationSuite.scala
@@ -461,7 +461,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion("TimestampNTZ type scan", "3.4") {
+  test("TimestampNTZ type scan") {
     withTempDir {
       dir =>
         val path = new File(dir, "ntz_data").toURI.getPath
@@ -475,9 +475,7 @@ class VeloxParquetDataTypeValidationSuite extends VeloxWholeStageTransformerSuit
     }
   }
 
-  testWithMinSparkVersion(
-    "Schema validation for TimestampNTZ respects enableTimestampNtzValidation",
-    "3.4") {
+  test("Schema validation for TimestampNTZ respects enableTimestampNtzValidation") {
     val ntzType = spark.sql("SELECT TIMESTAMP_NTZ'2024-01-01'").schema.head.dataType
     Seq("true", "false").foreach {
       enabled =>

--- a/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/expression/UDFPartialProjectSuite.scala
@@ -104,7 +104,7 @@ class UDFPartialProjectSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("test plus_one in nested project lists", "3.4") {
+  test("test plus_one in nested project lists") {
     val sql = """
                 |select plus_one(col1) as col2, l_partkey from (
                 | select plus_one(l_orderkey) as col1, l_partkey from lineitem

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/DateFunctionsValidateSuite.scala
@@ -569,7 +569,7 @@ class DateFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("read as timestamp_ntz", "3.4") {
+  test("read as timestamp_ntz") {
     val inputs: Seq[String] = Seq(
       "1970-01-01",
       "1970-01-01 00:00:00-02:00",

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/JsonFunctionsValidateSuite.scala
@@ -81,7 +81,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function bool", "3.4") {
+  test("from_json function bool") {
     withTempPath {
       path =>
         Seq[String](
@@ -103,7 +103,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function small int", "3.4") {
+  test("from_json function small int") {
     withTempPath {
       path =>
         Seq[String](
@@ -125,7 +125,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function int", "3.4") {
+  test("from_json function int") {
     withTempPath {
       path =>
         Seq[String](
@@ -147,7 +147,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function big int", "3.4") {
+  test("from_json function big int") {
     withTempPath {
       path =>
         Seq[String](
@@ -169,7 +169,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function float", "3.4") {
+  test("from_json function float") {
     withTempPath {
       path =>
         Seq[String](
@@ -193,7 +193,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function double", "3.4") {
+  test("from_json function double") {
     withTempPath {
       path =>
         Seq[String](
@@ -217,7 +217,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function string", "3.4") {
+  test("from_json function string") {
     withTempPath {
       path =>
         Seq[String](
@@ -239,7 +239,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function array", "3.4") {
+  test("from_json function array") {
     withTempPath {
       path =>
         Seq[String](
@@ -259,7 +259,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function map", "3.4") {
+  test("from_json function map") {
     withTempPath {
       path =>
         Seq[String](
@@ -281,7 +281,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function row", "3.4") {
+  test("from_json function row") {
     withTempPath {
       path =>
         Seq[String](
@@ -321,7 +321,7 @@ class JsonFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("from_json function duplicate key", "3.4") {
+  test("from_json function duplicate key") {
     withTempPath {
       path =>
         Seq[String](

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/MathFunctionsValidateSuite.scala
@@ -415,7 +415,7 @@ class MathFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("width_bucket", "3.4") {
+  test("width_bucket") {
     withTempPath {
       path =>
         Seq[(Integer, Integer, Integer, Integer)](

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -52,7 +52,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_append - INT", "3.4") {
+  test("array_append - INT") {
     withTempPath {
       path =>
         Seq[(Array[Int], Int)](
@@ -77,7 +77,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_append - STRING", "3.4") {
+  test("array_append - STRING") {
     withTempPath {
       path =>
         Seq[(Array[String], String)](
@@ -125,7 +125,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array_compact", "3.4") {
+  test("array_compact") {
     withTempPath {
       path =>
         Seq[Array[String]](
@@ -622,7 +622,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("url_decode", "3.4") {
+  test("url_decode") {
     withTempPath {
       path =>
         Seq("https%3A%2F%2Fspark.apache.org")
@@ -636,7 +636,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("url_encode", "3.4") {
+  test("url_encode") {
     withTempPath {
       path =>
         Seq("https://spark.apache.org")
@@ -653,7 +653,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
   // Add test suite for CharVarcharCodegenUtils functions.
   // A ProjectExecTransformer is expected to be constructed after expr support.
   // We currently test below functions with Spark v3.4
-  testWithMinSparkVersion("charTypeWriteSideCheck", "3.4") {
+  test("charTypeWriteSideCheck") {
     withTable("src", "dest") {
 
       sql("create table src(id string) USING PARQUET")
@@ -666,7 +666,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("varcharTypeWriteSideCheck", "3.4") {
+  test("varcharTypeWriteSideCheck") {
     withTable("src", "dest") {
 
       sql("create table src(id string) USING PARQUET")
@@ -679,7 +679,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("readSidePadding", "3.4") {
+  test("readSidePadding") {
     withTable("src", "dest") {
 
       sql("create table tgt(id char(3)) USING PARQUET")
@@ -714,7 +714,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("regexp_instr", "3.4") {
+  test("regexp_instr") {
     // Two-argument form.
     runQueryAndCompare("SELECT regexp_instr(c_comment, '\\w+') FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]
@@ -779,7 +779,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("mask", "3.4") {
+  test("mask") {
     runQueryAndCompare("SELECT mask(c_comment) FROM customer limit 50") {
       checkGlutenPlan[ProjectExecTransformer]
     }
@@ -982,7 +982,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("get", "3.4") {
+  test("get") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -1187,7 +1187,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("array insert", "3.4") {
+  test("array insert") {
     withTempPath {
       path =>
         Seq[Seq[Integer]](Seq(1, null, 5, 4), Seq(5, -1, 8, 9, -7, 2), Seq.empty, null)
@@ -1234,7 +1234,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("try_cast", "3.4") {
+  test("try_cast") {
     withTempView("try_cast_table") {
       withTempPath {
         path =>
@@ -1618,7 +1618,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("equal_null", "3.4") {
+  test("equal_null") {
     Seq[(Integer, Integer)]().toDF("a", "b")
     withTempPath {
       path =>
@@ -1679,7 +1679,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("localtimestamp with validation enabled", "3.4") {
+  test("localtimestamp with validation enabled") {
     // localtimestamp() is folded to a TimestampNTZType literal by ComputeCurrentTime. With
     // validation enabled, any Project whose output contains TimestampNTZ falls back to JVM.
     // The Project falls back at the top of the plan (above the one VeloxColumnarToRow), so
@@ -1693,7 +1693,7 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
     }
   }
 
-  testWithMinSparkVersion("localtimestamp with validation disabled", "3.4") {
+  test("localtimestamp with validation disabled") {
     // With validation disabled, scans on TimestampNTZ columns are allowed natively. For
     // localtimestamp(), the expression constant-folds to a TimestampNTZType literal in the
     // Project; Gluten only permits native Projects when NTZ appears in Hour(ntz_col), so

--- a/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
+++ b/backends-velox/src/test/scala/org/apache/gluten/functions/ScalarFunctionsValidateSuite.scala
@@ -652,7 +652,6 @@ class ScalarFunctionsValidateSuite extends FunctionsValidateSuite {
 
   // Add test suite for CharVarcharCodegenUtils functions.
   // A ProjectExecTransformer is expected to be constructed after expr support.
-  // We currently test below functions with Spark v3.4
   test("charTypeWriteSideCheck") {
     withTable("src", "dest") {
 

--- a/gluten-delta/src/test/scala/org/apache/gluten/execution/DeltaSuite.scala
+++ b/gluten-delta/src/test/scala/org/apache/gluten/execution/DeltaSuite.scala
@@ -461,7 +461,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("delta: change data feed read with deletion vectors", "3.4") {
+  test("delta: change data feed read with deletion vectors") {
     withTable("delta_cdf_dv") {
       spark.sql(s"""
                    |create table delta_cdf_dv (id int, name string) using delta
@@ -605,7 +605,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("deletion vector", "3.4") {
+  test("deletion vector") {
     withTempPath {
       p =>
         import testImplicits._
@@ -632,7 +632,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("deletion vector on partitioned table", "3.4") {
+  test("deletion vector on partitioned table") {
     withTempPath {
       p =>
         import testImplicits._
@@ -671,7 +671,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("deletion vector on shallow-cloned table", "3.4") {
+  test("deletion vector on shallow-cloned table") {
     withTable("dv_clone_source", "dv_clone_target") {
       import testImplicits._
       // Shallow clone is the case the old data-file walk-up got wrong. The clone's AddFile paths
@@ -841,9 +841,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
   }
 
   // TIMESTAMP_NTZ was introduced in Spark 3.4 / Delta 2.4
-  testWithMinSparkVersion(
-    "delta: create table with TIMESTAMP_NTZ and return correct results",
-    "3.4") {
+  test("delta: create table with TIMESTAMP_NTZ and return correct results") {
     withTable("delta_ntz") {
       spark.sql("CREATE TABLE delta_ntz(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ) USING DELTA")
       spark.sql("""INSERT INTO delta_ntz VALUES
@@ -858,9 +856,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "delta: TIMESTAMP_NTZ as partition column should fallback and return correct results",
-    "3.4") {
+  test("delta: TIMESTAMP_NTZ as partition column should fallback and return correct results") {
     withTable("delta_ntz_part") {
       spark.sql("""CREATE TABLE delta_ntz_part(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ)
                   |USING DELTA PARTITIONED BY (c3)""".stripMargin)
@@ -886,9 +882,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "delta: filter on TIMESTAMP_NTZ column should fallback and return correct results",
-    "3.4") {
+  test("delta: filter on TIMESTAMP_NTZ column should fallback and return correct results") {
     withTable("delta_ntz_filter") {
       spark.sql("CREATE TABLE delta_ntz_filter(id INT, ts TIMESTAMP_NTZ) USING DELTA")
       spark.sql("""INSERT INTO delta_ntz_filter VALUES
@@ -902,9 +896,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles struct field metadata correctly") {
     withTable("merge_struct_source", "merge_struct_target") {
       spark.sql("""
                   |CREATE TABLE merge_struct_target(
@@ -941,9 +933,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles array-of-struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles array-of-struct field metadata correctly") {
     withTable("merge_arraystruct_source", "merge_arraystruct_target") {
       spark.sql("""
                   |CREATE TABLE merge_arraystruct_target(
@@ -976,9 +966,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles map-of-struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles map-of-struct field metadata correctly") {
     withTable("merge_mapstruct_source", "merge_mapstruct_target") {
       spark.sql("""
                   |CREATE TABLE merge_mapstruct_target(
@@ -1011,9 +999,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles nested struct-within-struct field metadata correctly",
-    "3.4") {
+  test("merge with column mapping handles nested struct-within-struct field metadata correctly") {
     withTable("merge_nestedstruct_source", "merge_nestedstruct_target") {
       spark.sql("""
                   |CREATE TABLE merge_nestedstruct_target(
@@ -1044,9 +1030,7 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "merge with column mapping handles array with null struct elements correctly",
-    "3.4") {
+  test("merge with column mapping handles array with null struct elements correctly") {
     withTable("merge_arraynull_source", "merge_arraynull_target") {
       spark.sql("""
                   |CREATE TABLE merge_arraynull_target(

--- a/gluten-delta/src/test/scala/org/apache/gluten/execution/DeltaSuite.scala
+++ b/gluten-delta/src/test/scala/org/apache/gluten/execution/DeltaSuite.scala
@@ -840,7 +840,6 @@ abstract class DeltaSuite extends WholeStageTransformerSuite {
     }
   }
 
-  // TIMESTAMP_NTZ was introduced in Spark 3.4 / Delta 2.4
   test("delta: create table with TIMESTAMP_NTZ and return correct results") {
     withTable("delta_ntz") {
       spark.sql("CREATE TABLE delta_ntz(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ) USING DELTA")

--- a/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
+++ b/gluten-iceberg/src/test/scala/org/apache/gluten/execution/IcebergSuite.scala
@@ -85,7 +85,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join", "3.4") {
+  test("iceberg bucketed join") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -159,7 +159,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join with partition", "3.4") {
+  test("iceberg bucketed join with partition") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -233,7 +233,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join partition value not exists", "3.4") {
+  test("iceberg bucketed join partition value not exists") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -308,9 +308,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion(
-    "iceberg bucketed join partition value not exists partial cluster",
-    "3.4") {
+  test("iceberg bucketed join partition value not exists partial cluster") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {
@@ -385,7 +383,7 @@ abstract class IcebergSuite extends WholeStageTransformerSuite {
     }
   }
 
-  testWithMinSparkVersion("iceberg bucketed join with partition filter", "3.4") {
+  test("iceberg bucketed join with partition filter") {
     val leftTable = "p_str_tb"
     val rightTable = "p_int_tb"
     withTable(leftTable, rightTable) {

--- a/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
+++ b/gluten-ut/test/src/test/scala/org/apache/gluten/expressions/GlutenExpressionMappingSuite.scala
@@ -94,9 +94,7 @@ class GlutenExpressionMappingSuite
     }
   }
 
-  testWithMinSparkVersion(
-    "GLUTEN-7213: Check fallback reason with CheckOverflowInTableInsert",
-    "3.4") {
+  test("GLUTEN-7213: Check fallback reason with CheckOverflowInTableInsert") {
     withTable("t1", "t2") {
       sql("create table t1 (a float) using parquet")
       sql("insert into t1 values(1.1)")


### PR DESCRIPTION
## What changes are proposed in this pull request?

`testWithMinSparkVersion(name, floor)` registers a case only when the running Spark is at least `floor` (`GlutenQueryTest.scala:132`). Since #12902 the supported set is {3.4, 3.5, 4.0, 4.1}, so any floor of 3.4 or below is always satisfied and the call is a plain `test(...)` wearing a version check. This rewrites all 95 of them across 23 files: 84 with floor `"3.4"`, 9 with `"3.3"`, 2 with `"3.2"`.

#12981 left the 3.4 group out of scope deliberately. The 3.3 and 3.2 groups are newer than that cleanup rather than older: #12454 branched before #12954 and merged between #12954 and #12981, so it brought the pattern back into `backends-bolt` after the first sweep and before the second one, which touched no bolt file.

The helper stays. Ten call sites still pass `"3.5"`, and that floor does separate 3.4 from the rest.

Three things came off with the floors rather than being left dangling. `BoltHashJoinSuite.scala` had a `"3.2"` floor whose body still branched on `startsWith("3.2.")` in two places, so the floor and the assertions were one thing and removing only the floor would have been half a job; both `3.2.` arms are gone and the surviving expectations are the ones the supported versions already take. Two comments existed only to justify a floor and now say something untrue or pointless: `ScalarFunctionsValidateSuite.scala:655` claimed `We currently test below functions with Spark v3.4` above a group that registers on all four, and `DeltaSuite.scala:843` noted that TIMESTAMP_NTZ arrived in Spark 3.4, which constrains nothing once 3.4 is the minimum.

Otherwise no test body changed. The rewrite was done by script and then run through `spotless:apply`, so the remaining edits are the call itself and whatever reflowing scalafmt wanted afterwards; the collapsed multi-line calls are where the line counts move.

## How was this patch tested?

`clean test-compile` on Spark 3.4, 3.5, 4.0 and 4.1 with `-Pbackends-velox -Pspark-ut -Piceberg -Pdelta`, Scala 2.13, which covers the velox, gluten-delta, gluten-iceberg and gluten-ut files. The 3.5 run adds `-Pbackends-clickhouse` for `src-iceberg/test`, that being the only profile clickhouse builds on.

The nine `backends-bolt` files needed a detour, since bolt does not compile on main at all right now. I stacked #12999 on top of this branch, ran `test-compile -Pbackends-bolt -Pspark-ut` on 3.4 and 3.5, then dropped it again, so what is pushed here is the rewrite alone.

No suite was run. For the 95 rewritten calls the change cannot alter what a case does, only whether it is registered, and every one of them was already registered on all four supported versions; a script checked that the set of case names each of the 23 files registers is identical before and after. The `BoltHashJoinSuite` assertion change is the one place that needed judgement rather than mechanics, and it cannot be run here: bolt's native library needs Linux plus GCC 10-12 or Clang 16 per `docs/bolt-quick-start.md`.

## Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude claude-opus-5

Related issue: #13003
